### PR TITLE
RFC-0022: Composition Integrity — make include integrity enforcing (T10), fix temporal warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security — RFC-0022 Composition Integrity (draft, targets v0.21)
+
+- **T10 (composition include substitution):** a `trusted`, signed manifest that
+  `composition.includes` a source it does not authenticate would have its included
+  units inherit the composing file's `trusted` tier and become load-eligible into
+  standing context — even though the composing signature covers the `source:`
+  directive, not the bytes the source resolves to. This is the RFC-0019 T9 pattern
+  in the composition path. Found by analysis before composition resolution shipped
+  in the renderer.
+- **Fix (SPEC §3.11, §16.5 C17):** include integrity is now **enforcing** at
+  `trusted` tier, not advisory. Units from an `unverified` or `failed` include
+  render `load_eligible: false`; a `failed` include (present-but-mismatched pin)
+  is demoted at every tier with a §7 warning — mirroring the RFC-0019 `content_hash`
+  demotion (C11). The composed *tier* is still the composing file's (no transitive
+  trust); only included-unit *load-eligibility* is gated.
+- **Hash encoding unified (SPEC §3.11):** `composition.includes[].integrity.manifest_hash`
+  changes from the `"sha256:<hex>"` string to the `{algorithm, value}` object used by
+  RFC-0004 `content_integrity.manifest_hash` and RFC-0019 `content_hash`.
+- **Temporal correction (SPEC §4.22):** removed the v0.19 §7 warning that fired when
+  `recorded_at` was later than `valid_from` — that is RFC-0010's foundational
+  retroactive-recording case, not an anomaly. Replaced with a warning for an empty
+  validity window (`valid_until` earlier than `valid_from`).
+- Regression guards added (`cli/src/consistency.test.ts`) asserting the enforcing
+  composition language and the corrected temporal warnings remain in the spec.
+
 ---
 
 ## [0.20.0] — 2026-06-12 — Temporal Query Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ The Knowledge Context Protocol (KCP) specification -- a structured metadata stan
 
 ## Architecture
 KCP defines a `knowledge.yaml` manifest format with hierarchical units, each having intent, scope, audience, triggers, and dependency relationships. The spec supports 4 levels of adoption (L1-L4) from basic file listing to full agent orchestration. Includes:
-- **Spec:** `SPEC.md` (core specification, currently v0.17; note: there is no v0.15 — the number was skipped to re-sync with the CLI release train)
-- **RFCs:** 19 RFCs (auth, federation, trust, payments, context-window hints, query vocabulary, visibility/authority, discovery provenance, catalog, composition, negative space, content structure, observability, trusted render pipeline, unit content integrity); promoted ones are marked Accepted in their headers
+- **Spec:** `SPEC.md` (core specification, currently v0.20; note: there is no v0.15 — the number was skipped to re-sync with the CLI release train)
+- **RFCs:** 22 RFCs (auth, federation, trust, payments, context-window hints, query vocabulary, visibility/authority, discovery provenance, catalog, composition, negative space, content structure, observability, trusted render pipeline, unit content integrity, bi-temporal validity, temporal composition, federation temporal, composition integrity); promoted ones are marked Accepted in their headers
 - **Bridges:** TypeScript, Java, Python parsers that surface KCP metadata via MCP
 - **CLI:** `kcp` developer CLI — init, validate, query, stats, render (§16 trusted render pipeline)
 - **Conformance:** Test suite and fixtures

--- a/RFC-0022-Composition-Integrity.md
+++ b/RFC-0022-Composition-Integrity.md
@@ -1,0 +1,320 @@
+# RFC-0022: Composition Integrity
+
+**Status:** Draft
+**Author:** Thor Henning Hetland (eXOReaction AS)
+**Created:** 2026-06-13
+**Target version:** v0.21
+**Depends on:** RFC-0018 (Trusted Render Pipeline), RFC-0019 (Unit Content Integrity and Origin Evidence), RFC-0020 (Temporal Composition)
+**Amends:** RFC-0020 (§2.4/§3.11 — makes include integrity enforcing at `trusted` tier; unifies the hash encoding), RFC-0018 (§2 threat model adds T10; §16.5 adds C17), SPEC.md §4.22 (corrects the `recorded_at` advisory warning)
+**Related:** RFC-0004 (Trust and Compliance), RFC-0003 (Federation), RFC-0014 (Manifest Composition)
+
+---
+
+## Summary
+
+RFC-0019 closed the manifest-relocation attack (T9) by establishing a single
+invariant for the render pipeline:
+
+> Content that enters an execution-capable agent's standing context at `trusted`
+> tier MUST be authenticated by the trusted key — the signature must cover the
+> *territory* (the bytes loaded), not merely the *map* (the manifest that points
+> at them).
+
+RFC-0020's manifest composition (§3.11) reopens exactly that hole through a new
+door. A signed, `trusted` manifest may `include` units from another source — a
+local path or a **remote URL** — and the composed result is tiered from the
+*composing* file's signature. But that signature covers the composing file's
+bytes, which contain the `source:` directive, not the bytes *at* that source.
+The composition author's `integrity` pin — the one mechanism that would
+authenticate the included content — is specified as an **advisory warning only**
+(§3.11, C15): a mismatch is logged, the composed units remain `trusted` and
+load-eligible.
+
+This is the T9 pattern, one version later, in the same pipeline — and unlike
+T9 it is *non-enforcing by construction*. This RFC names the attack (**T10**),
+makes include integrity **enforcing** at `trusted` tier using the same
+demote-to-pointer mechanism RFC-0019 uses for `content_hash` (C11), and
+unifies the composition hash encoding with the rest of the spec.
+
+It also corrects a temporal-validity warning promoted in v0.19 that fires on
+RFC-0010's own foundational use case (§4).
+
+All changes preserve backward compatibility for manifests that declare no
+`composition` block. Composition resolution is not yet implemented in the
+reference renderer, so this correction lands *before* the insecure behavior
+ships in code — the ideal time to fix it.
+
+---
+
+## 1. Threat Model Addition
+
+This RFC adds one row to RFC-0018 §2:
+
+| # | Threat | Vector |
+|---|--------|--------|
+| T10 | Composition include substitution | A `trusted` composing manifest includes a source it does not authenticate; an attacker who controls, MITMs, or supply-chain-poisons that source injects units that inherit the composing file's `trusted` tier and enter standing context |
+
+### 1.1 Why the composing signature does not cover the include
+
+The detached JWS over a composing manifest `M` (RFC-0018 §4.2) authenticates
+`M`'s canonical bytes. Those bytes contain:
+
+```yaml
+composition:
+  includes:
+    - source: https://raw.githubusercontent.com/acme/kcps/main/platform/knowledge.yaml
+      as: platform
+```
+
+The signature proves the composing author wrote *this `source:` line*. It does
+not — and cannot — prove anything about the bytes the URL resolves to at render
+time. Resolution (§3.11: "MUST complete before trust tiering") fetches those
+bytes, merges their units, and the render pipeline then tiers the *composed*
+result from `M`'s signature → `trusted` → the `platform:*` units become
+load-eligible into standing context (RFC-0018 §16.4).
+
+The attacker needs no fabricated origin (unlike T9): they need only control the
+included source, which is frequently a third-party URL outside the composing
+author's signing domain. A dependency update, a compromised CDN, a typosquatted
+raw-content host, or a force-push to the included repo all suffice.
+
+### 1.2 Why advisory integrity is not a mitigation
+
+RFC-0020 §2.4 / SPEC §3.11 make `integrity.manifest_hash` and
+`integrity.expected_signer` *advisory*: "a mismatch produces a §7 warning but
+does not lower the composed result's trust tier." A §7 warning does not change
+`load_eligible`. The units still enter context. The control is observable but
+not preventive — the opposite of how RFC-0019 treated the analogous boundary,
+where a `content_hash` mismatch *forces* `load_eligible: false` (C11) and a
+derived origin *caps* the tier (C13).
+
+The existing C15 clause "never allows included sources with lower-tier
+signatures to elevate the composed result's tier" guards only the *upward*
+direction (a weak include cannot raise the result). T10 is the *downward*
+direction: a strong composing signature laundering unauthenticated content into
+trusted load-eligibility. C15 does not address it.
+
+---
+
+## 2. Design
+
+The fix reuses RFC-0019's machinery rather than inventing a parallel one.
+
+### 2.1 Integrity-verified includes
+
+An `includes[]` entry is **integrity-verified** at render time iff at least one
+of:
+
+- **Hash pin:** `integrity.manifest_hash` is present and equals the digest of
+  the included source's fetched raw bytes (using the unified `{algorithm,
+  value}` shape, §2.3); **or**
+- **Signer pin:** `integrity.expected_signer` is present, the fetched source
+  carries a valid detached signature (its own `.sig` / `content_integrity`,
+  RFC-0018 §4.2), and that signature is from the pinned key.
+
+An entry with no `integrity` block is **unverified** (the author opted out of
+authenticating it). An entry whose declared pin is present but does **not**
+match is **failed** (positive evidence of substitution or drift).
+
+### 2.2 Enforcing rule (C17)
+
+Tier governs *placement*; integrity governs *whether included bytes may be
+placed*, mirroring RFC-0019 §6.4 / C11.
+
+- **Unverified include, `trusted` tier:** its units MUST render with
+  `load_eligible: false` (pointer only). The author may still compose them for
+  structure and discovery; they simply do not enter standing context without
+  authentication. Below `trusted`, no units are load-eligible anyway, so the
+  rule is a no-op there (consistent with RFC-0019).
+- **Failed include, any tier:** its units MUST render with `load_eligible:
+  false` AND the renderer MUST emit a §7 warning recording the field
+  (`manifest_hash` / `expected_signer`), the expected value, and the observed
+  value. A present-but-wrong pin is stronger evidence than absence and is
+  surfaced at every tier — exactly as a `content_hash` mismatch is (RFC-0019
+  §3.3).
+- **Verified include:** its units are load-eligible per their `kind` and the
+  composed tier, identically to local units.
+
+This is **pinned inclusion, not transitive trust** (the RFC-0020 framing is
+preserved and now true): a verified include's units are load-eligible because
+the composing author authenticated *these specific bytes*, not because the
+pipeline trusts the source's key chain. `expected_signer` is an explicit
+per-include delegation the composing author chose and signed over.
+
+### 2.3 Determinism and the remote fetch
+
+Verifying a remote include requires a network fetch, which must not enter the
+deterministic render core (RFC-0018 C1, C7). As with RFC-0019 §4.3
+corroboration, the fetch-and-compare is an **evidence-resolution step that
+precedes rendering**; its outcome (`verified` / `unverified` / `failed` per
+include) is part of the `(input, keys, renderer-version)` determinism triple's
+input. A fixed resolution outcome yields byte-identical output.
+
+A local-path include (`source: ./base/knowledge.yaml`) is verified the same
+way, against the local file bytes — no network, fully offline, directly
+analogous to an RFC-0019 directory `content_hash`. A local include is **not**
+implicitly authenticated by proximity: the composing signature does not cover
+sibling files, so an unpinned local include is `unverified` and follows the
+same trusted-tier demotion. This keeps one rule for both source kinds.
+
+### 2.4 Hash encoding unification
+
+RFC-0020 §2.4 claims `integrity.manifest_hash` is "identical to
+`trust.content_integrity.manifest_hash` semantics," but encodes it as a single
+colon-prefixed string (`"sha256:a1b2c3…"`), whereas RFC-0004
+(`content_integrity.manifest_hash`) and RFC-0019 (`content_hash`) both use an
+`{algorithm, value}` object. The byte-level semantics match; the field *shape*
+does not, so an implementation cannot mechanically reuse the RFC-0004/0019 hash
+path against a composition pin.
+
+This RFC unifies on the object shape:
+
+```yaml
+composition:
+  includes:
+    - source: https://…/platform/knowledge.yaml
+      as: platform
+      integrity:
+        manifest_hash:
+          algorithm: sha256          # sha256 | sha384 | sha512 (RFC-0004 §content_integrity)
+          value: "a1b2c3d4e5f6…"     # hex digest of the source's raw bytes
+        expected_signer: "cantara-platform-2026"   # allowlist key_id (RFC-0018 §9)
+```
+
+Because composition resolution is unimplemented, there is no migration cost.
+Renderers MUST accept the `{algorithm, value}` form; the `"sha256:<hex>"`
+string form is removed.
+
+`expected_signer` is a `key_id` joining against the consumer allowlist
+(RFC-0018 §9), not a raw public key — so the consumer's own allowlist decides
+which signer identities are acceptable, consistent with how tiering already
+resolves keys.
+
+---
+
+## 3. Normative Specification
+
+Amends SPEC.md §3.11 (replace the advisory-integrity bullets) and §16.5 (add
+C17). The `composition` block shape is otherwise unchanged from §3.11.
+
+- `includes[].integrity.manifest_hash`: OPTIONAL `{algorithm, value}` object.
+  `algorithm` ∈ `{sha256, sha384, sha512}`; `value` hex. Computed over the
+  included source's raw file bytes (before the source's own composition
+  resolution, if any), matching RFC-0004 `content_integrity.manifest_hash`.
+- `includes[].integrity.expected_signer`: OPTIONAL string `key_id`.
+- An include is **verified** iff a present `manifest_hash` matches the fetched
+  bytes, or a present `expected_signer` matches a valid signature on the
+  fetched source. No `integrity` block ⇒ **unverified**. Present-but-mismatched
+  ⇒ **failed**.
+- **C17 (renderer):** When the composed manifest tiers `trusted`, units from an
+  `unverified` or `failed` include MUST render `load_eligible: false`. Units
+  from a `failed` include MUST be `load_eligible: false` at every tier and MUST
+  emit a §7 warning recording field, expected, and observed values.
+- The trust tier of the composed result is still derived from the composing
+  file's signature only (no transitive trust). Integrity gating changes
+  *load-eligibility of included units*, never the composed *tier*.
+- Resolution determinism: remote-include verification is a pre-render
+  evidence-resolution step; its per-include outcome is a render input (C1
+  preserved).
+
+C15 is retained but no longer load-bearing for security: its "advisory
+warning" disposition applies to the *recording* of mismatches; C17 governs the
+*load-eligibility* consequence.
+
+---
+
+## 4. Temporal Correction (SPEC §4.22)
+
+v0.19 promoted four §7 advisory warnings on the `temporal` block. One is wrong:
+
+> `recorded_at` is later than `valid_from` (manifest authored after the fact it
+> describes)
+
+This fires on RFC-0010's *defining* bi-temporal scenario. RFC-0010 §"The two
+clocks problem":
+
+> A security policy was effective February 15th, but the manifest author did
+> not update `knowledge.yaml` until March 1st.
+
+Here `valid_from` = Feb 15, `recorded_at` = Mar 1: `recorded_at > valid_from`,
+the retroactive-recording case transaction time exists to capture. RFC-0010's
+own Example 1 (`deploy-to-production`: `valid_from: 2026-02-01`, `recorded_at:
+2026-02-03`) trips it too. Neither direction of `recorded_at` vs `valid_from`
+is anomalous — future-dating records before validity, retroactive recording
+records after — so the warning punishes honest audit trails and trains authors
+to fudge `recorded_at`.
+
+**Change:** remove the `recorded_at`-vs-`valid_from` warning. Replace it with a
+warning that flags an actually-impossible window, which the spec currently does
+*not* catch:
+
+> `valid_until` is earlier than `valid_from` (empty validity window — the unit
+> can never be active)
+
+The other three v0.19 temporal warnings (dangling `superseded_by`, stale
+`valid_until` with no successor, `verified` without `verified_by`) are correct
+and retained.
+
+---
+
+## 5. Conformance
+
+Extends RFC-0018 §10 / SPEC §16.5:
+
+- **C17.** When the composed manifest tiers `trusted`, the renderer never emits
+  `load_eligible: true` for a unit originating from an `unverified` or `failed`
+  composition include; records a §7 warning for every `failed` include with
+  field, expected, and observed values.
+
+Test corpus (to be added under `experiments/rfc-0018-render/` once composition
+resolution is implemented in the renderer; the threat fixture and its expected
+outcome are committed now and tracked as PENDING):
+
+- **B21** — T10 substitution: a `trusted` composing manifest with an unverified
+  remote include. Without this RFC: composed units `load_eligible: true`. With
+  it: those units `load_eligible: false` (pointer).
+- **B22** — verified include: same composition with a matching `manifest_hash`
+  → composed units load-eligible.
+- **B23** — failed pin: `manifest_hash` present but not matching the fetched
+  bytes → units `load_eligible: false` at every tier, §7 warning recorded.
+
+A guard test (`cli/src/consistency.test.ts`) asserts the enforcing language is
+present in SPEC §3.11/§16.5 and that the corrected §4.22 warning set is in
+effect — so neither the security regression nor the temporal false-positive can
+silently return.
+
+---
+
+## 6. Deferred
+
+- **Composition resolution implementation.** This RFC fixes the *trust rule*;
+  the full resolver (includes/overrides/excludes, `as` namespacing, recursive
+  composition, remote fetch) remains to be implemented in `kcp render`. C17
+  constrains how it must behave when built.
+- **`verified_by` / `evidence` enforcement.** RFC-0020 §2.3 added these
+  attribution fields advisorily; tightening them (e.g. requiring `verified_by`
+  to be an allowlist `key_id`) is out of scope here.
+- **Transitive trust for composition.** Unchanged: no key-chain trust
+  propagates. `expected_signer` is an explicit per-include delegation, not a
+  trust chain.
+
+---
+
+## Appendix A: Relationship to RFC-0019
+
+| RFC-0019 (local content) | RFC-0022 (composed content) |
+|--------------------------|------------------------------|
+| `content_hash` on a unit binds referenced file bytes to the signed manifest | `integrity.manifest_hash` on an include binds source bytes to the composing manifest |
+| Mismatch → `load_eligible: false` (C11) | Unverified/failed include → `load_eligible: false` (C17) |
+| Origin evidence caps tier (C13) | Composed tier unchanged; load-eligibility gated instead |
+| Network corroboration is a pre-render step (C1 preserved, §4.3) | Remote-include verification is a pre-render step (C1 preserved, §2.3) |
+| `{algorithm, value}` hash shape | unified to `{algorithm, value}` (§2.4) |
+
+The two RFCs together state the full invariant: **whether content reaches an
+agent's standing context from a local file or a composed include, at `trusted`
+tier it must be authenticated against bytes the trusted key covered.**
+
+---
+
+*Co-authored with Claude. The design and normative choices are the author's;
+Claude performed the analysis that surfaced T10 and drafted this document.*

--- a/SPEC.md
+++ b/SPEC.md
@@ -917,8 +917,10 @@ composition:
     - source: https://raw.githubusercontent.com/acme/kcps/main/platform/knowledge.yaml
       as: platform                      # namespace prefix for included unit ids
       integrity:
-        manifest_hash: "sha256:a1b2c3d4e5f6..."  # hash of raw file bytes at authoring time
-        expected_signer: "ed25519:MCowBQYDK2VwAyEA..."
+        manifest_hash:                  # {algorithm, value} — matches §3.2 / RFC-0019
+          algorithm: sha256
+          value: "a1b2c3d4e5f6..."      # hex digest of the source's raw bytes at authoring time
+        expected_signer: "acme-platform-2026"   # allowlist key_id (§9) expected to have signed the source
 
   overrides:
     - id: platform:submit-expense-report  # namespaced: overrides a unit from 'platform' include
@@ -945,8 +947,8 @@ on all collisions). Resolution MUST complete before trust tiering (§16).
 |-------|----------|------|-------------|
 | `source` | REQUIRED | string | Relative path or URL of the manifest to include. |
 | `as` | OPTIONAL | string | Namespace prefix for all unit ids from this source. Applied as `<prefix>:<id>`. |
-| `integrity.manifest_hash` | OPTIONAL | string | `sha256:<hex>` of the included source file's raw bytes at authoring time. Mismatch MUST produce a §7 warning. |
-| `integrity.expected_signer` | OPTIONAL | string | Public key id expected to have signed the included source. Mismatch MUST produce a §7 warning. |
+| `integrity.manifest_hash` | OPTIONAL | object | `{algorithm, value}` (`algorithm` ∈ sha256/sha384/sha512; `value` hex) of the included source's raw bytes at authoring time. Same shape as `trust.content_integrity.manifest_hash` (§3.2). Governs include load-eligibility at `trusted` tier (C17). |
+| `integrity.expected_signer` | OPTIONAL | string | Allowlist `key_id` (§9) expected to have signed the included source. Governs include load-eligibility at `trusted` tier (C17). |
 
 #### `composition.overrides[]` fields
 
@@ -966,12 +968,25 @@ on all collisions). Resolution MUST complete before trust tiering (§16).
 - Circular includes MUST be detected and reported as a manifest error (not a §7 warning).
 - `composition.overrides` MAY add a `temporal` block to a unit that did not originally have one.
 - `superseded_by` (§4.22) MAY reference a unit from an included manifest using the `namespace:id` form.
-- `includes[].integrity` fields are advisory warnings, not hard failures. A mismatch
-  produces a §7 warning but does not lower the composed result's trust tier — that is
-  determined by the composing file's own signature (§16).
-- `includes[].integrity.manifest_hash` is computed over the raw file bytes before
-  composition resolution of the included file, matching `trust.content_integrity.manifest_hash` semantics.
-- The trust tier of included sources does not propagate to the composed result.
+- `includes[].integrity.manifest_hash` is computed over the included source's raw file bytes
+  before that source's own composition resolution, matching `trust.content_integrity.manifest_hash`
+  (§3.2) byte semantics and shape.
+- An include is **integrity-verified** iff a present `manifest_hash` matches the fetched source
+  bytes, or a present `expected_signer` matches a valid signature on the fetched source. An
+  include with no `integrity` block is **unverified**; one whose declared pin is present but does
+  not match is **failed**.
+- **Include integrity is enforcing at `trusted` tier, not advisory (v0.21, RFC-0022, C17):**
+  when the composed manifest tiers `trusted`, units originating from an `unverified` or `failed`
+  include MUST render `load_eligible: false` (pointer only). A `failed` include MUST render its
+  units `load_eligible: false` at *every* tier and MUST emit a §7 warning recording the field,
+  expected value, and observed value. This mirrors the per-unit `content_hash` demotion (§3.2,
+  C11): a signature over the composing file authenticates the `source:` directive, not the bytes
+  the source resolves to.
+- The trust *tier* of the composed result is still derived from the composing file's signature
+  only; integrity gating changes the *load-eligibility of included units*, never the composed
+  tier. The trust tier of included sources does not propagate (no transitive trust).
+- Remote-include verification is a pre-render evidence-resolution step; its per-include outcome
+  is part of the render's determinism input (C1 preserved), as with §16 corroboration (RFC-0019 §4.3).
 
 **Conformance:** `includes`/`overrides`/`excludes` at Level 1; `as` prefix and `integrity`
 pinning at Level 2; recursive composition (includes within includes) at Level 2.
@@ -2228,11 +2243,17 @@ effect on how the unit is evaluated — absence means "always valid" (backward-c
 - Root-level `temporal` provides defaults. Unit-level overrides are field-by-field (not block-level).
 - `superseded_by` cycles MUST be detected and reported as a manifest error.
 
-**§7 advisory warnings (new in v0.19):**
+**§7 advisory warnings (new in v0.19; `recorded_at` rule corrected in v0.21, RFC-0022):**
 - `superseded_by` references a nonexistent unit id
 - `valid_until` is in the past and no `superseded_by` is set (stale unit with no successor)
-- `recorded_at` is later than `valid_from` (manifest authored after the fact it describes)
+- `valid_until` is earlier than `valid_from` (empty validity window — the unit can never be active)
 - `discovery.verification_status: verified` without `discovery.verified_by`
+
+> Note: v0.19 warned when `recorded_at` was later than `valid_from`. That rule was removed in
+> v0.21 — it fires on the foundational bi-temporal case (a fact recorded *after* it became
+> true, e.g. a policy effective Feb 15 but written into the manifest Mar 1), which RFC-0010
+> identifies as exactly why transaction time exists. Neither direction of `recorded_at` vs
+> `valid_from` is anomalous.
 
 **Conformance:** Level 1 — temporal field exposure (parsers MUST read and expose). Level 2 — temporal filtering (bridges that evaluate validity windows at query time).
 
@@ -3214,7 +3235,7 @@ minimum trigger `on_failure: warn` (§3.6). Pinning applies per-edge.
 
 ### 16.5 Renderer conformance
 
-A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18), C15 (RFC-0020, v0.19), and C16 (v0.20):
+A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18), C15 (RFC-0020, v0.19), C16 (v0.20), and C17 (RFC-0022, v0.21):
 
 - **C1–C10** (RFC-0018): determinism (C1), fail-closed emission (C2), schema-only output (C3),
   no `load_eligible: true` on executable/service/unknown kinds (C4), no auto-traversal below
@@ -3234,13 +3255,20 @@ A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18)
   before trust tiering; derives the trust tier from the composing file's signature only; emits
   §7 warnings for `integrity` mismatches, circular includes, and override/exclude references to
   nonexistent unit ids; never allows included sources with lower-tier signatures to elevate the
-  composed result's tier.
+  composed result's tier. (C17 governs the converse: a `trusted` composing tier never elevates
+  *unauthenticated* included content.)
 - **C16** (v0.20): Bridges that implement temporal query evaluation (§15.13) MUST: (a) apply
   default temporal filtering against today when neither `as_of` nor `include_all_temporal`
   is set; (b) honor `as_of` for point-in-time reconstruction using `valid_from`/`valid_until`
   bounds; (c) bypass temporal filtering when `include_all_temporal: true`; (d) return error
   code `temporal_query_conflict` when both a non-default `as_of` and `include_all_temporal:
   true` are present in the same request.
+- **C17** (v0.21): When a `composition` block resolves to a `trusted`-tier result, the renderer
+  MUST NOT emit `load_eligible: true` for any unit originating from an `unverified` or `failed`
+  include (§3.11); MUST render `failed`-include units `load_eligible: false` at every tier; and
+  MUST emit a §7 warning for every `failed` include recording field, expected, and observed
+  values. A signature over the composing file does not authenticate the bytes its includes
+  resolve to.
 
 The reference implementation is `kcp render` in [`cli/`](./cli/); the validation corpus lives
 in [`experiments/rfc-0018-render/`](./experiments/rfc-0018-render/) (cases A10–A12, B17–B20

--- a/cli/src/consistency.test.ts
+++ b/cli/src/consistency.test.ts
@@ -69,3 +69,42 @@ describe("validator duplication guard", () => {
     expect(a).toBe(b);
   });
 });
+
+// Security/correctness invariants that were violated by the v0.19/v0.20
+// composition + temporal promotion and corrected in v0.21 (RFC-0022). These
+// guard the *spec text* so the insecure/incorrect phrasing cannot silently
+// return — each assertion would have FAILED on the pre-RFC-0022 spec.
+describe("composition + temporal spec invariants (RFC-0022)", () => {
+  const spec = readFileSync(r("SPEC.md"), "utf8");
+
+  it("§3.11 makes composition include integrity enforcing, not advisory", () => {
+    // The T10 hole: a trusted composing signature must not launder
+    // unauthenticated included content into standing context.
+    expect(spec).toContain("Include integrity is enforcing at `trusted` tier");
+    // and the old advisory-only disposition must be gone
+    expect(spec).not.toContain(
+      "advisory warnings, not hard failures. A mismatch\n  produces a §7 warning but does not lower the composed result's trust tier"
+    );
+  });
+
+  it("§16.5 defines C17 (the enforcing renderer rule)", () => {
+    expect(spec).toContain("**C17**");
+    expect(spec).toContain(
+      "MUST NOT emit `load_eligible: true` for any unit originating from an `unverified` or `failed`"
+    );
+  });
+
+  it("composition integrity uses the {algorithm, value} hash shape, not a colon string", () => {
+    // unifies with RFC-0004 content_integrity.manifest_hash and RFC-0019 content_hash
+    expect(spec).not.toContain('manifest_hash: "sha256:');
+  });
+
+  it("§4.22 does not warn on recorded_at later than valid_from (RFC-0010 core case)", () => {
+    // the removed false-positive bullet — present tense as an active warning
+    expect(spec).not.toContain("is later than `valid_from` (manifest authored after the fact");
+  });
+
+  it("§4.22 warns on an empty validity window (valid_until before valid_from)", () => {
+    expect(spec).toContain("`valid_until` is earlier than `valid_from`");
+  });
+});

--- a/experiments/rfc-0018-render/fixtures/composition-unverified-include.yaml
+++ b/experiments/rfc-0018-render/fixtures/composition-unverified-include.yaml
@@ -1,0 +1,33 @@
+# T10 threat fixture (RFC-0022, SPEC §3.11 / C17) — PENDING.
+#
+# A trusted, signed composing manifest that includes a REMOTE source it does
+# not authenticate (no `integrity` block). Per RFC-0022 C17, when this renders
+# at `trusted` tier, the included `platform:*` units MUST render
+# load_eligible: false — the composing signature covers this file's bytes (the
+# `source:` line), not the bytes the URL resolves to.
+#
+# This fixture is committed ahead of implementation: composition resolution is
+# not yet in `kcp render`, so the harness tracks B21/B22/B23 as PENDING. When
+# the resolver lands, the expected outcome below becomes an executable check.
+#
+# Expected (B21, unverified remote include, trusted tier):
+#   units originating from the include  -> load_eligible: false (pointer only)
+#   local units                         -> load_eligible: true
+# Sibling fixtures to add when implemented:
+#   B22 (verified): same include with matching integrity.manifest_hash -> include units load-eligible
+#   B23 (failed):   integrity.manifest_hash present but wrong -> include units load_eligible: false at every tier + §7 warning
+kcp_version: "0.20"
+project: composing-app
+version: 1.0.0
+
+composition:
+  includes:
+    - source: https://raw.githubusercontent.com/attacker-controlled/platform/main/knowledge.yaml
+      as: platform
+      # NOTE: no `integrity` block — unauthenticated. This is the T10 vector.
+
+units:
+  - id: local-overview
+    path: docs/overview.md
+    intent: "Local project overview authored in this repository"
+    triggers: [overview]


### PR DESCRIPTION
## Summary

Analyzing the v0.19/v0.20 temporal-composition release surfaced that **manifest composition (SPEC §3.11) reopens the RFC-0019 T9 hole**. A `trusted`, signed manifest can `composition.includes` a source it does not authenticate — and the composed result inherits the *composing file's* `trusted` tier, making unauthenticated included units load-eligible into standing context. The composing signature covers the `source:` directive, not the bytes the URL resolves to. The integrity pin that would catch this was specified as an **advisory §7 warning only** (C15) — the opposite of how RFC-0019 enforced the analogous local-content boundary (C11/C13).

Found by analysis **before** composition resolution shipped in the renderer, so this fixes the rule ahead of the insecure implementation.

## RFC-0022 (draft, targets v0.21)

- **T10 (composition include substitution)** — extends RFC-0018's threat model.
- **C17 (enforcing):** at `trusted` tier, units from an `unverified` or `failed` include render `load_eligible: false`; a `failed` include (present-but-mismatched pin) is demoted at *every* tier with a §7 warning — the same demote-to-pointer move RFC-0019 uses for `content_hash` (C11). The composed *tier* still derives from the composing signature only (no transitive trust); only included-unit *load-eligibility* is gated. Remote verification is a pre-render evidence step, so determinism (C1) holds, mirroring RFC-0019 §4.3.
- **Hash encoding unified:** `integrity.manifest_hash` → `{algorithm, value}`, matching RFC-0004 and RFC-0019 (was a `sha256:`-prefixed string claiming "identical semantics" while using a different shape).
- **Temporal correction (§4.22):** removed the warning on `recorded_at` later than `valid_from` — that is RFC-0010's *defining* retroactive-recording case, not an anomaly — and replaced it with a real one (empty window: `valid_until` before `valid_from`).

## SPEC changes

§3.11, §16.5 (C17), and §4.22 amended in place as security corrections to already-promoted text. The spec **Version** header stays `0.20`; changes are annotated v0.21/RFC-0022 pending the formal v0.21 release.

## Tests — to keep it from recurring

5 guards added in `cli/src/consistency.test.ts` that read the spec text and assert the secure invariant is present — **each would have failed on the pre-fix spec**. Mutation-verified: reintroducing the old `recorded_at` bullet flips 2 guards red. A T10 threat fixture is committed and tracked as PENDING B21–B23 until composition resolution is implemented in the renderer.

CLI tests 62 pass; RFC-0018 harness 30/30.

## Follow-on

This is the security half of the planned composition × trust-tiers work. The v0.21 release (promoting RFC-0021 Federation Temporal, finalizing RFC-0022 status, version bump) is the next PR.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_