### PR TITLE
v0.21: Federation Temporal (RFC-0021) + finalize Composition Integrity (RFC-0022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Security — RFC-0022 Composition Integrity (draft, targets v0.21)
+---
+
+## [0.21.0] — 2026-06-13 — Composition Integrity & Federation Temporal
+
+**Spec version:** `"0.21"` | **Prior:** `"0.20"` (v0.20.0, 2026-06-12)
+
+### Federation temporal — RFC-0021 (promoted to SPEC §3.6, §16.5 C18)
+
+- **`manifests[].temporal` block:** an OPTIONAL source-level validity window
+  (`valid_from`, `valid_until`, `superseded_by`) on federation entries. Declares when a
+  sub-manifest is relevant *as a knowledge source*, distinct from unit-level `temporal`
+  (§4.22) which declares when individual knowledge is valid. Hub author controls source
+  relevance; sub-manifest author controls unit validity.
+- **Skip-before-fetch (Level 2):** bridges MUST NOT fetch sub-manifests outside their
+  validity window for the effective date (`as_of` or today) — no HTTP request, no unit
+  loading. `include_all_temporal: true` bypasses. Manifest-level temporal applies before
+  unit-level temporal. Filtering removes sources only; it never elevates trust.
+- **Validation:** `superseded_by` cycles among `manifests[]` entries are a manifest error;
+  dangling/stale/empty-window cases are §7 warnings.
+
+### Security — RFC-0022 Composition Integrity (promoted to SPEC §3.11, §16.5 C17, §4.22)
 
 - **T10 (composition include substitution):** a `trusted`, signed manifest that
   `composition.includes` a source it does not authenticate would have its included
@@ -32,6 +52,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   validity window (`valid_until` earlier than `valid_from`).
 - Regression guards added (`cli/src/consistency.test.ts`) asserting the enforcing
   composition language and the corrected temporal warnings remain in the spec.
+
+### Notes
+
+- `manifests[].temporal` parser exposure (Level 1) and the composition resolver (which C17
+  governs) are not yet implemented in the reference bridges/renderer; the spec promotion lands
+  ahead of implementation, as the composition-integrity correction (RFC-0022) did deliberately.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ The Knowledge Context Protocol (KCP) specification -- a structured metadata stan
 
 ## Architecture
 KCP defines a `knowledge.yaml` manifest format with hierarchical units, each having intent, scope, audience, triggers, and dependency relationships. The spec supports 4 levels of adoption (L1-L4) from basic file listing to full agent orchestration. Includes:
-- **Spec:** `SPEC.md` (core specification, currently v0.20; note: there is no v0.15 — the number was skipped to re-sync with the CLI release train)
+- **Spec:** `SPEC.md` (core specification, currently v0.21; note: there is no v0.15 — the number was skipped to re-sync with the CLI release train)
 - **RFCs:** 22 RFCs (auth, federation, trust, payments, context-window hints, query vocabulary, visibility/authority, discovery provenance, catalog, composition, negative space, content structure, observability, trusted render pipeline, unit content integrity, bi-temporal validity, temporal composition, federation temporal, composition integrity); promoted ones are marked Accepted in their headers
 - **Bridges:** TypeScript, Java, Python parsers that surface KCP metadata via MCP
 - **CLI:** `kcp` developer CLI — init, validate, query, stats, render (§16 trusted render pipeline)

--- a/RFC-0021-Federation-Temporal.md
+++ b/RFC-0021-Federation-Temporal.md
@@ -1,6 +1,6 @@
 # RFC-0021: Federation-Level Temporal Validity
 
-**Status:** Request for Comments
+**Status:** Accepted — promoted to SPEC.md §3.6 (`manifests[].temporal`) and §16.5 C18 (v0.21).
 **Author:** Thor Henning Hetland (eXOReaction AS)
 **Created:** 2026-06-13
 **Target version:** v0.21

--- a/RFC-0022-Composition-Integrity.md
+++ b/RFC-0022-Composition-Integrity.md
@@ -1,6 +1,6 @@
 # RFC-0022: Composition Integrity
 
-**Status:** Draft
+**Status:** Accepted — promoted to SPEC.md §3.11, §16.5 C17, §4.22 correction (v0.21).
 **Author:** Thor Henning Hetland (eXOReaction AS)
 **Created:** 2026-06-13
 **Target version:** v0.21

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knowledge Context Protocol (KCP) Specification
 
-**Version:** 0.20
+**Version:** 0.21
 **Status:** Draft
 **Date:** 2026-06-12
 **Repository:** github.com/cantara/knowledge-context-protocol
@@ -621,6 +621,7 @@ manifests:
 | `local_mirror` | OPTIONAL | string | Relative path (forward slashes, relative to this manifest) to a local copy of the remote manifest. When present and the file exists, parsers MUST load from that path instead of fetching `url`. |
 | `version_pin` | OPTIONAL | string | Semver version to pin this sub-manifest to. When present, validators SHOULD compare against the remote manifest's `version` field. See version pinning below. |
 | `version_policy` | OPTIONAL | string | How to interpret `version_pin`. Values: `exact` (versions must be equal), `minimum` (remote version >= pin), `compatible` (same major version, default). Unknown values MUST be treated as `compatible`. |
+| `temporal` | OPTIONAL | object | Source-level validity window. See `manifests[].temporal` below (v0.21). |
 
 #### `manifests[].relationship` values
 
@@ -633,6 +634,60 @@ manifests:
 | `archive` | Sub-manifest is historical. Agents MAY skip unless specifically requested. |
 
 Unknown `relationship` values MUST be silently ignored.
+
+#### `manifests[].temporal` (v0.21)
+
+Promoted from [RFC-0021](./RFC-0021-Federation-Temporal.md). An OPTIONAL `temporal` block on a
+`manifests[]` entry declares when the sub-manifest is relevant **as a knowledge source** —
+distinct from unit-level `temporal` (§4.22), which declares when individual knowledge is valid
+in the world. The hub author controls source relevance; the sub-manifest author controls unit
+validity. The two compose as independent filter stages.
+
+```yaml
+manifests:
+  - id: gdpr-corpus-2018
+    url: "https://legal.example.com/gdpr-2018/knowledge.yaml"
+    relationship: governs
+    temporal:
+      valid_from: "2018-05-25"
+      valid_until: "2023-09-01"
+      superseded_by: gdpr-corpus-2023   # references another manifests[].id
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `valid_from` | OPTIONAL | ISO 8601 date or datetime | When the sub-manifest became relevant as a source. Absent = relevant from an unbounded past. |
+| `valid_until` | OPTIONAL | ISO 8601 date or datetime | When the sub-manifest ceased to be relevant. Absent = relevant indefinitely. |
+| `superseded_by` | OPTIONAL | string | The `id` of another `manifests[]` entry that replaces this one. Cycles MUST be detected and reported as a manifest error. |
+
+`recorded_at` is intentionally omitted — transaction time is a unit-authoring concept; the hub's
+own root-level `temporal.recorded_at` already covers when the hub recorded its federation list.
+
+**Resolution behaviour (Level 2):**
+- The effective date is `as_of` if set, else today (§15.13).
+- A sub-manifest is *temporally included* iff it has no `temporal` block, OR
+  (`valid_from` is null or `valid_from <= effective_date`) AND
+  (`valid_until` is null or `valid_until >= effective_date`).
+- Sub-manifests that fail this filter MUST NOT be fetched: the bridge skips them entirely — no
+  HTTP request, no unit loading, no unit-level temporal evaluation.
+- `include_all_temporal: true` (§15.13) bypasses manifest-level filtering and traverses all
+  sub-manifests, consistent with its unit-level semantics.
+- Manifest-level temporal applies *before* unit-level temporal. The full federated filter order
+  is: manifest-level temporal filter → fetch sub-manifest → score → `not_for` → unit-level
+  temporal → top-N cut. A skipped sub-manifest simply produces no results — invisible to the
+  caller, identical to a sub-manifest with no matching units.
+- Manifest-level temporal removes sources only; it never elevates trust. Filtering and trust
+  tiering (§16) are orthogonal — a temporally-included edge is still tiered per §16.
+
+**Validation:**
+- `superseded_by` referencing a nonexistent `manifests[].id`: §7 warning.
+- `valid_until` in the past with no `superseded_by`: §7 warning (stale federation link).
+- `valid_until` earlier than `valid_from`: §7 warning (empty window).
+- `superseded_by` cycles among `manifests[]` entries: manifest ERROR (parsers MUST detect),
+  consistent with the unit-level rule (§4.22).
+
+**Conformance:** Parse and expose `manifests[].temporal` and detect `superseded_by` cycles —
+Level 1. Manifest-level temporal filtering at resolution time — Level 2 (C18).
 
 #### Transitive resolution
 
@@ -3235,7 +3290,7 @@ minimum trigger `on_failure: warn` (§3.6). Pinning applies per-edge.
 
 ### 16.5 Renderer conformance
 
-A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18), C15 (RFC-0020, v0.19), C16 (v0.20), and C17 (RFC-0022, v0.21):
+A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18), C15 (RFC-0020, v0.19), C16 (v0.20), C17 (RFC-0022, v0.21), and C18 (RFC-0021, v0.21):
 
 - **C1–C10** (RFC-0018): determinism (C1), fail-closed emission (C2), schema-only output (C3),
   no `load_eligible: true` on executable/service/unknown kinds (C4), no auto-traversal below
@@ -3269,6 +3324,12 @@ A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18)
   MUST emit a §7 warning for every `failed` include recording field, expected, and observed
   values. A signature over the composing file does not authenticate the bytes its includes
   resolve to.
+- **C18** (v0.21): Bridges that implement federated temporal evaluation (§3.6
+  `manifests[].temporal`) MUST: (a) compute the effective date as `as_of` if set, else today;
+  (b) skip — never fetch — sub-manifests outside their validity window; (c) bypass
+  manifest-level filtering when `include_all_temporal: true`; (d) apply manifest-level temporal
+  before unit-level temporal. Parsers MUST detect `superseded_by` cycles among `manifests[]`
+  entries as a manifest error.
 
 The reference implementation is `kcp render` in [`cli/`](./cli/); the validation corpus lives
 in [`experiments/rfc-0018-render/`](./experiments/rfc-0018-render/) (cases A10–A12, B17–B20

--- a/bridge/typescript/src/validator.ts
+++ b/bridge/typescript/src/validator.ts
@@ -98,6 +98,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.18",
   "0.19",
   "0.20",
+  "0.21",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([

--- a/cli/src/validator.ts
+++ b/cli/src/validator.ts
@@ -98,6 +98,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.18",
   "0.19",
   "0.20",
+  "0.21",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -52,7 +52,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -67,7 +67,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "kcp_version": {
       "type": "string",
-      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.20\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.19\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
-      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20"]
+      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.21\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.20\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
+      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21"]
     },
     "project": {
       "type": "string",


### PR DESCRIPTION
## Summary

Cuts the **v0.21** release, bundling the two v0.21-targeted RFCs: **RFC-0022 Composition Integrity** (already on main via #82, finalized here) and **RFC-0021 Federation Temporal** (promoted to spec here).

## Federation temporal — RFC-0021 → SPEC §3.6, §16.5 C18

- **`manifests[].temporal`** — an OPTIONAL source-level validity window (`valid_from`, `valid_until`, `superseded_by`) on federation entries. Declares when a sub-manifest is relevant *as a knowledge source*, distinct from unit-level `temporal` (§4.22) which declares when individual knowledge is valid. Hub author controls source relevance; sub-manifest author controls unit validity — two independent filter stages.
- **Skip-before-fetch (Level 2):** bridges MUST NOT fetch sub-manifests outside their window for the effective date (`as_of` or today); `include_all_temporal` bypasses; manifest-level temporal applies before unit-level. Filtering removes sources only — it never elevates trust, so it's orthogonal to §16 tiering (no new T-class surface, unlike composition).
- `superseded_by` cycles among `manifests[]` → manifest error; stale/dangling/empty-window → §7 warnings.
- Status: RFC → **Accepted**.

## Composition integrity — RFC-0022 finalized

Status Draft → **Accepted**; the §3.11 / §16.5-C17 / §4.22 corrections merged in #82 are now the v0.21 promotion they were annotated for.

## Version bump 0.20 → 0.21

SPEC **Version** header plus `KNOWN_KCP_VERSIONS` in all four validators (CLI + bridge TS byte-identical, Python, Java) and the JSON-schema `kcp_version` enum — the consistency guards require these in lockstep.

## Deliberately not in this PR

`manifests[].temporal` parser exposure (Level 1) and the composition resolver (which C17 governs) are **not yet implemented** in the reference bridges/renderer. The spec promotion lands ahead of implementation — the same sequencing RFC-0022 used. Noted in CHANGELOG. This is the honest state; the implementation parity is the natural follow-on (and overlaps the unit-level temporal validator gap surfaced during analysis).

## Tests

CLI 62, bridge TS 203, Python 144, Java 128 — all green, including the version-sync guards and the composition/temporal spec-invariant guards from #82.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_