### PR TITLE
Implement temporal validation across all four reference implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Implementation — temporal validation backlog (closes spec-vs-code gap)
+
+Promoted-but-unimplemented normative rules from v0.19/v0.21 are now enforced in
+all four reference implementations (TypeScript CLI + bridge, Python, Java):
+
+- **Parsing parity (Level 1):** the CLI parser now reads unit- and root-level
+  `temporal` (it silently dropped them before); all four parsers now expose
+  `manifests[].temporal` (RFC-0021) and `discovery.verified_by` / `discovery.evidence`
+  (RFC-0020 §2.3 / §4.18).
+- **Unit-level temporal validation (§4.22):** `superseded_by` cycle detection
+  (manifest **error**); §7 warnings for dangling `superseded_by`, stale `valid_until`
+  (past with no successor), empty window (`valid_until` before `valid_from`), and
+  `verification_status: verified` without `verified_by`. Root-level `temporal`
+  defaults apply field-by-field.
+- **Federation temporal validation (§3.6):** the same window/dangling warnings and
+  `superseded_by` cycle error for `manifests[].temporal` entries.
+- Cross-language test parity: matched temporal-validation suites added to CLI,
+  Python, and Java (15 cases each). An outdated Java parser test fixture (a
+  `verified` discovery with no `verified_by`) was made spec-compliant.
+
+Still deferred (genuinely larger features, not validation): composition resolution
++ C17 enforcement in the renderer, and bridge skip-before-fetch federation temporal
+filtering (Level 2).
+
 ---
 
 ## [0.21.0] — 2026-06-13 — Composition Integrity & Federation Temporal

--- a/bridge/typescript/src/model.ts
+++ b/bridge/typescript/src/model.ts
@@ -38,6 +38,8 @@ export interface Discovery {
   source?: string;               // manual | web_traversal | openapi | llm_inference
   observed_at?: string;
   verified_at?: string;
+  verified_by?: string;          // RFC-0020 §2.3 / §4.18 — verifier key id or identity
+  evidence?: string;             // RFC-0020 §2.3 / §4.18 — URL/path to verification artifact
   confidence?: number;
   contradicted_by?: string;
 }
@@ -126,6 +128,7 @@ export interface ManifestRef {
   local_mirror?: string;
   version_pin?: string;
   version_policy?: string; // "exact" | "minimum" | "compatible" (default: "compatible")
+  temporal?: Temporal;     // RFC-0021 / §3.6 (v0.21) — source-level validity window
 }
 
 /** A cross-manifest dependency for a knowledge unit. See SPEC.md §3.6. */

--- a/bridge/typescript/src/parser.ts
+++ b/bridge/typescript/src/parser.ts
@@ -329,6 +329,8 @@ function parseDiscovery(raw: unknown): Discovery | undefined {
     source: d["source"] !== undefined ? String(d["source"]) : undefined,
     observed_at: d["observed_at"] !== undefined ? String(d["observed_at"]) : undefined,
     verified_at: d["verified_at"] !== undefined ? String(d["verified_at"]) : undefined,
+    verified_by: d["verified_by"] !== undefined ? String(d["verified_by"]) : undefined,
+    evidence: d["evidence"] !== undefined ? String(d["evidence"]) : undefined,
     confidence: d["confidence"] !== undefined ? Number(d["confidence"]) : undefined,
     contradicted_by: d["contradicted_by"] !== undefined ? String(d["contradicted_by"]) : undefined,
   };
@@ -395,6 +397,7 @@ function parseManifestRef(raw: RawMap): ManifestRef {
     local_mirror: raw["local_mirror"] !== undefined ? String(raw["local_mirror"]) : undefined,
     version_pin: raw["version_pin"] !== undefined ? String(raw["version_pin"]) : undefined,
     version_policy: raw["version_policy"] !== undefined ? String(raw["version_policy"]) : undefined,
+    temporal: parseTemporal(raw["temporal"]),
   };
 }
 

--- a/bridge/typescript/src/validator.ts
+++ b/bridge/typescript/src/validator.ts
@@ -4,7 +4,7 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve, join } from "node:path";
-import type { KnowledgeManifest, ValidationResult } from "./model.js";
+import type { KnowledgeManifest, Temporal, ValidationResult } from "./model.js";
 
 // --- Per-unit content digest (RFC-0019 §3.2, draft) ---
 // Lives here (not in a render module) so the CLI and bridge validator
@@ -129,6 +129,34 @@ const VALID_UPDATE_FREQUENCIES = new Set([
   "never",
 ]);
 const ID_PATTERN = /^[a-z0-9.\-]+$/;
+
+// --- Temporal validation helpers (§4.22, §3.6 manifests[].temporal) ---
+
+/**
+ * Detect cycles in a single-successor (functional) graph — the shape of
+ * `superseded_by` chains. Returns the ids that participate in a cycle.
+ * Mirrors the depends_on cycle detection in the Python/Java validators.
+ */
+function supersededCycleIds(successor: Map<string, string>): string[] {
+  const cycle = new Set<string>();
+  const state = new Map<string, number>(); // 0/undefined = unvisited, 1 = in-path, 2 = done
+  for (const start of successor.keys()) {
+    if (state.get(start) === 2) continue;
+    const path: string[] = [];
+    let node: string | undefined = start;
+    while (node !== undefined && successor.has(node) && state.get(node) !== 2) {
+      if (state.get(node) === 1) {
+        for (const id of path.slice(path.indexOf(node))) cycle.add(id);
+        break;
+      }
+      state.set(node, 1);
+      path.push(node);
+      node = successor.get(node);
+    }
+    for (const id of path) if (state.get(id) === 1) state.set(id, 2);
+  }
+  return [...cycle].sort();
+}
 
 export function validate(
   manifest: KnowledgeManifest,
@@ -409,6 +437,94 @@ export function validate(
         );
       }
     }
+  }
+
+  // --- Temporal validation (§4.22 unit-level; §3.6 manifests[].temporal) ---
+  // Root-level temporal provides defaults; unit-level overrides field-by-field.
+  const today = new Date().toISOString().slice(0, 10);
+  const effectiveTemporal = (t?: Temporal): Temporal => {
+    const r = manifest.temporal ?? {};
+    const u = t ?? {};
+    return {
+      valid_from: u.valid_from ?? r.valid_from,
+      valid_until: u.valid_until ?? r.valid_until,
+      recorded_at: u.recorded_at ?? r.recorded_at,
+      superseded_by: u.superseded_by ?? r.superseded_by,
+    };
+  };
+
+  // Per-unit window + verification warnings; collect local superseded edges.
+  const unitSuccessor = new Map<string, string>();
+  for (const unit of manifest.units) {
+    const t = effectiveTemporal(unit.temporal);
+    if (t.valid_from && t.valid_until && t.valid_until < t.valid_from) {
+      warnings.push(
+        `Unit '${unit.id}': temporal.valid_until '${t.valid_until}' precedes valid_from '${t.valid_from}' (empty validity window — the unit can never be active)`
+      );
+    }
+    if (t.valid_until && t.valid_until < today && !t.superseded_by) {
+      warnings.push(
+        `Unit '${unit.id}': temporal.valid_until '${t.valid_until}' is in the past and no superseded_by is set (stale unit with no successor)`
+      );
+    }
+    // superseded_by may use namespace:id to target an unresolved include (§4.22);
+    // only local (non-namespaced) refs are checkable here.
+    if (t.superseded_by && !t.superseded_by.includes(":")) {
+      if (!unitIds.has(t.superseded_by)) {
+        warnings.push(
+          `Unit '${unit.id}': temporal.superseded_by references unknown unit '${t.superseded_by}'`
+        );
+      } else {
+        unitSuccessor.set(unit.id, t.superseded_by);
+      }
+    }
+    const disc = unit.discovery;
+    if (disc?.verification_status === "verified" && !disc.verified_by) {
+      warnings.push(
+        `Unit '${unit.id}': discovery.verification_status is 'verified' but discovery.verified_by is absent`
+      );
+    }
+  }
+  for (const id of supersededCycleIds(unitSuccessor)) {
+    errors.push(`temporal.superseded_by cycle detected involving unit '${id}'`);
+  }
+  if (
+    manifest.discovery?.verification_status === "verified" &&
+    !manifest.discovery.verified_by
+  ) {
+    warnings.push(
+      "manifest: discovery.verification_status is 'verified' but discovery.verified_by is absent"
+    );
+  }
+
+  // Federation: manifests[].temporal (§3.6, RFC-0021).
+  const refIds = new Set(manifest.manifests.map((m) => m.id));
+  const refSuccessor = new Map<string, string>();
+  for (const ref of manifest.manifests) {
+    const t = ref.temporal;
+    if (!t) continue;
+    if (t.valid_from && t.valid_until && t.valid_until < t.valid_from) {
+      warnings.push(
+        `manifests['${ref.id}']: temporal.valid_until '${t.valid_until}' precedes valid_from '${t.valid_from}' (empty validity window)`
+      );
+    }
+    if (t.valid_until && t.valid_until < today && !t.superseded_by) {
+      warnings.push(
+        `manifests['${ref.id}']: temporal.valid_until '${t.valid_until}' is in the past and no superseded_by is set (stale federation link)`
+      );
+    }
+    if (t.superseded_by) {
+      if (!refIds.has(t.superseded_by)) {
+        warnings.push(
+          `manifests['${ref.id}']: temporal.superseded_by references unknown manifests[].id '${t.superseded_by}'`
+        );
+      } else {
+        refSuccessor.set(ref.id, t.superseded_by);
+      }
+    }
+  }
+  for (const id of supersededCycleIds(refSuccessor)) {
+    errors.push(`manifests[].temporal.superseded_by cycle detected involving '${id}'`);
   }
 
   // Root-level delegation validation (§3.4)

--- a/cli/src/model.ts
+++ b/cli/src/model.ts
@@ -38,6 +38,8 @@ export interface Discovery {
   source?: string;               // manual | web_traversal | openapi | llm_inference
   observed_at?: string;
   verified_at?: string;
+  verified_by?: string;          // RFC-0020 §2.3 / §4.18 — verifier key id or identity
+  evidence?: string;             // RFC-0020 §2.3 / §4.18 — URL/path to verification artifact
   confidence?: number;
   contradicted_by?: string;
 }
@@ -126,6 +128,7 @@ export interface ManifestRef {
   local_mirror?: string;
   version_pin?: string;
   version_policy?: string; // "exact" | "minimum" | "compatible" (default: "compatible")
+  temporal?: Temporal;     // RFC-0021 / §3.6 (v0.21) — source-level validity window
 }
 
 /** A cross-manifest dependency for a knowledge unit. See SPEC.md §3.6. */

--- a/cli/src/parser.ts
+++ b/cli/src/parser.ts
@@ -12,6 +12,7 @@ import type {
   ContentStructure,
   Delegation,
   Discovery,
+  Temporal,
   ExternalDependency,
   ExternalRelationship,
   FreshnessPolicy,
@@ -146,6 +147,7 @@ function parseUnit(raw: RawMap): KnowledgeUnit {
       raw["not_for_strict"] !== undefined ? Boolean(raw["not_for_strict"]) : undefined,
     content_structure: parseContentStructure(raw["content_structure"]),
     content_hash: parseContentHash(raw["content_hash"]),
+    temporal: parseTemporal(raw["temporal"]),
   };
 }
 
@@ -327,8 +329,23 @@ function parseDiscovery(raw: unknown): Discovery | undefined {
     source: d["source"] !== undefined ? String(d["source"]) : undefined,
     observed_at: d["observed_at"] !== undefined ? String(d["observed_at"]) : undefined,
     verified_at: d["verified_at"] !== undefined ? String(d["verified_at"]) : undefined,
+    verified_by: d["verified_by"] !== undefined ? String(d["verified_by"]) : undefined,
+    evidence: d["evidence"] !== undefined ? String(d["evidence"]) : undefined,
     confidence: d["confidence"] !== undefined ? Number(d["confidence"]) : undefined,
     contradicted_by: d["contradicted_by"] !== undefined ? String(d["contradicted_by"]) : undefined,
+  };
+}
+
+// --- Temporal parsing (RFC-0010 §4.22 v0.19; RFC-0021 §3.6 v0.21) ---
+
+function parseTemporal(raw: unknown): Temporal | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const t = raw as RawMap;
+  return {
+    valid_from: t["valid_from"] !== undefined && t["valid_from"] !== null ? String(t["valid_from"]) : undefined,
+    valid_until: t["valid_until"] !== undefined && t["valid_until"] !== null ? String(t["valid_until"]) : undefined,
+    recorded_at: t["recorded_at"] !== undefined && t["recorded_at"] !== null ? String(t["recorded_at"]) : undefined,
+    superseded_by: t["superseded_by"] !== undefined && t["superseded_by"] !== null ? String(t["superseded_by"]) : undefined,
   };
 }
 
@@ -379,6 +396,7 @@ function parseManifestRef(raw: RawMap): ManifestRef {
     local_mirror: raw["local_mirror"] !== undefined ? String(raw["local_mirror"]) : undefined,
     version_pin: raw["version_pin"] !== undefined ? String(raw["version_pin"]) : undefined,
     version_policy: raw["version_policy"] !== undefined ? String(raw["version_policy"]) : undefined,
+    temporal: parseTemporal(raw["temporal"]),
   };
 }
 
@@ -438,6 +456,7 @@ export function parseDict(data: RawMap): KnowledgeManifest {
     authority: parseAuthority(data["authority"]),
     discovery: parseDiscovery(data["discovery"]),
     not_for: data["not_for"] !== undefined ? asStringArray(data["not_for"]) : undefined,
+    temporal: parseTemporal(data["temporal"]),
   };
 }
 

--- a/cli/src/temporal-validation.test.ts
+++ b/cli/src/temporal-validation.test.ts
@@ -1,0 +1,145 @@
+// Tests for temporal validation (§4.22 unit-level; §3.6 manifests[].temporal).
+// Covers the §7 advisory warnings and the superseded_by cycle MUST-errors that
+// v0.19/v0.21 promoted but no validator implemented until the backlog pass.
+
+import { describe, expect, it } from "vitest";
+import { parseDict } from "./parser.js";
+import { validate } from "./validator.js";
+
+const PAST = "2000-01-01"; // always in the past
+const FUTURE = "2999-12-31"; // always in the future
+
+function manifest(extra: Record<string, unknown>): Record<string, unknown> {
+  return { kcp_version: "0.21", project: "test", version: "1.0.0", ...extra };
+}
+
+function validateUnits(units: unknown[], extra: Record<string, unknown> = {}) {
+  return validate(parseDict(manifest({ units, ...extra })));
+}
+
+const unit = (id: string, t?: Record<string, unknown>, extra: Record<string, unknown> = {}) => ({
+  id,
+  path: `docs/${id}.md`,
+  intent: `Unit ${id}`,
+  scope: "project",
+  audience: ["agent"],
+  ...(t ? { temporal: t } : {}),
+  ...extra,
+});
+
+describe("unit-level temporal validation (§4.22)", () => {
+  it("warns on an empty validity window (valid_until before valid_from)", () => {
+    const r = validateUnits([unit("a", { valid_from: "2026-06-01", valid_until: "2026-01-01" })]);
+    expect(r.warnings.some((w) => w.includes("empty validity window"))).toBe(true);
+    expect(r.isValid).toBe(true); // warning, not error
+  });
+
+  it("does not warn on a normal window", () => {
+    const r = validateUnits([unit("a", { valid_from: "2026-01-01", valid_until: FUTURE })]);
+    expect(r.warnings.some((w) => w.includes("empty validity window"))).toBe(false);
+    expect(r.warnings.some((w) => w.includes("stale"))).toBe(false);
+  });
+
+  it("warns on a stale unit (valid_until past, no superseded_by)", () => {
+    const r = validateUnits([unit("a", { valid_until: PAST })]);
+    expect(r.warnings.some((w) => w.includes("stale unit with no successor"))).toBe(true);
+  });
+
+  it("does not warn stale when superseded_by is set", () => {
+    const r = validateUnits([
+      unit("a", { valid_until: PAST, superseded_by: "b" }),
+      unit("b"),
+    ]);
+    expect(r.warnings.some((w) => w.includes("stale unit"))).toBe(false);
+  });
+
+  it("warns on a dangling superseded_by reference", () => {
+    const r = validateUnits([unit("a", { superseded_by: "ghost" })]);
+    expect(r.warnings.some((w) => w.includes("superseded_by references unknown unit 'ghost'"))).toBe(true);
+  });
+
+  it("does not flag a namespaced superseded_by (targets an unresolved include)", () => {
+    const r = validateUnits([unit("a", { superseded_by: "platform:newer" })]);
+    expect(r.warnings.some((w) => w.includes("superseded_by references unknown"))).toBe(false);
+  });
+
+  it("errors on a superseded_by cycle (MUST)", () => {
+    const r = validateUnits([
+      unit("a", { superseded_by: "b" }),
+      unit("b", { superseded_by: "a" }),
+    ]);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => e.includes("superseded_by cycle"))).toBe(true);
+  });
+
+  it("does not error on a linear superseded_by chain", () => {
+    const r = validateUnits([
+      unit("a", { superseded_by: "b" }),
+      unit("b", { superseded_by: "c" }),
+      unit("c"),
+    ]);
+    expect(r.errors.some((e) => e.includes("superseded_by cycle"))).toBe(false);
+  });
+
+  it("applies root-level temporal defaults field-by-field", () => {
+    // root sets valid_until in the past; unit sets only valid_from -> effective valid_until past
+    const r = validateUnits([unit("a", { valid_from: "1999-01-01" })], {
+      temporal: { valid_until: PAST },
+    });
+    expect(r.warnings.some((w) => w.includes("stale unit"))).toBe(true);
+  });
+
+  it("warns when verification_status is verified without verified_by (unit and root)", () => {
+    const r = validateUnits([unit("a", {}, { discovery: { verification_status: "verified" } })], {
+      discovery: { verification_status: "verified" },
+    });
+    expect(r.warnings.filter((w) => w.includes("verified_by is absent")).length).toBe(2);
+  });
+
+  it("does not warn when verified_by is present", () => {
+    const r = validateUnits([
+      unit("a", {}, { discovery: { verification_status: "verified", verified_by: "key-1" } }),
+    ]);
+    expect(r.warnings.some((w) => w.includes("verified_by is absent"))).toBe(false);
+  });
+});
+
+describe("federation temporal validation (§3.6 manifests[].temporal)", () => {
+  const ref = (id: string, t?: Record<string, unknown>) => ({
+    id,
+    url: `https://example.com/${id}/knowledge.yaml`,
+    relationship: "governs",
+    ...(t ? { temporal: t } : {}),
+  });
+
+  function validateManifests(manifests: unknown[]) {
+    return validate(parseDict(manifest({ units: [unit("local")], manifests })));
+  }
+
+  it("exposes manifests[].temporal through the parser", () => {
+    const m = parseDict(manifest({ units: [unit("local")], manifests: [ref("a", { valid_from: "2020-01-01" })] }));
+    expect(m.manifests[0].temporal?.valid_from).toBe("2020-01-01");
+  });
+
+  it("warns on a stale federation link", () => {
+    const r = validateManifests([ref("a", { valid_until: PAST })]);
+    expect(r.warnings.some((w) => w.includes("stale federation link"))).toBe(true);
+  });
+
+  it("warns on an empty window and a dangling successor", () => {
+    const r = validateManifests([
+      ref("a", { valid_from: "2026-06-01", valid_until: "2026-01-01", superseded_by: "ghost" }),
+    ]);
+    expect(r.warnings.some((w) => w.includes("empty validity window"))).toBe(true);
+    expect(r.warnings.some((w) => w.includes("unknown manifests[].id 'ghost'"))).toBe(true);
+  });
+
+  it("errors on a superseded_by cycle among manifests (MUST)", () => {
+    const r = validateManifests([
+      ref("a", { superseded_by: "b" }),
+      ref("b", { superseded_by: "a" }),
+    ]);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => e.includes("manifests[].temporal.superseded_by cycle"))).toBe(true);
+  });
+});

--- a/cli/src/validator.ts
+++ b/cli/src/validator.ts
@@ -4,7 +4,7 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve, join } from "node:path";
-import type { KnowledgeManifest, ValidationResult } from "./model.js";
+import type { KnowledgeManifest, Temporal, ValidationResult } from "./model.js";
 
 // --- Per-unit content digest (RFC-0019 §3.2, draft) ---
 // Lives here (not in a render module) so the CLI and bridge validator
@@ -129,6 +129,34 @@ const VALID_UPDATE_FREQUENCIES = new Set([
   "never",
 ]);
 const ID_PATTERN = /^[a-z0-9.\-]+$/;
+
+// --- Temporal validation helpers (§4.22, §3.6 manifests[].temporal) ---
+
+/**
+ * Detect cycles in a single-successor (functional) graph — the shape of
+ * `superseded_by` chains. Returns the ids that participate in a cycle.
+ * Mirrors the depends_on cycle detection in the Python/Java validators.
+ */
+function supersededCycleIds(successor: Map<string, string>): string[] {
+  const cycle = new Set<string>();
+  const state = new Map<string, number>(); // 0/undefined = unvisited, 1 = in-path, 2 = done
+  for (const start of successor.keys()) {
+    if (state.get(start) === 2) continue;
+    const path: string[] = [];
+    let node: string | undefined = start;
+    while (node !== undefined && successor.has(node) && state.get(node) !== 2) {
+      if (state.get(node) === 1) {
+        for (const id of path.slice(path.indexOf(node))) cycle.add(id);
+        break;
+      }
+      state.set(node, 1);
+      path.push(node);
+      node = successor.get(node);
+    }
+    for (const id of path) if (state.get(id) === 1) state.set(id, 2);
+  }
+  return [...cycle].sort();
+}
 
 export function validate(
   manifest: KnowledgeManifest,
@@ -409,6 +437,94 @@ export function validate(
         );
       }
     }
+  }
+
+  // --- Temporal validation (§4.22 unit-level; §3.6 manifests[].temporal) ---
+  // Root-level temporal provides defaults; unit-level overrides field-by-field.
+  const today = new Date().toISOString().slice(0, 10);
+  const effectiveTemporal = (t?: Temporal): Temporal => {
+    const r = manifest.temporal ?? {};
+    const u = t ?? {};
+    return {
+      valid_from: u.valid_from ?? r.valid_from,
+      valid_until: u.valid_until ?? r.valid_until,
+      recorded_at: u.recorded_at ?? r.recorded_at,
+      superseded_by: u.superseded_by ?? r.superseded_by,
+    };
+  };
+
+  // Per-unit window + verification warnings; collect local superseded edges.
+  const unitSuccessor = new Map<string, string>();
+  for (const unit of manifest.units) {
+    const t = effectiveTemporal(unit.temporal);
+    if (t.valid_from && t.valid_until && t.valid_until < t.valid_from) {
+      warnings.push(
+        `Unit '${unit.id}': temporal.valid_until '${t.valid_until}' precedes valid_from '${t.valid_from}' (empty validity window — the unit can never be active)`
+      );
+    }
+    if (t.valid_until && t.valid_until < today && !t.superseded_by) {
+      warnings.push(
+        `Unit '${unit.id}': temporal.valid_until '${t.valid_until}' is in the past and no superseded_by is set (stale unit with no successor)`
+      );
+    }
+    // superseded_by may use namespace:id to target an unresolved include (§4.22);
+    // only local (non-namespaced) refs are checkable here.
+    if (t.superseded_by && !t.superseded_by.includes(":")) {
+      if (!unitIds.has(t.superseded_by)) {
+        warnings.push(
+          `Unit '${unit.id}': temporal.superseded_by references unknown unit '${t.superseded_by}'`
+        );
+      } else {
+        unitSuccessor.set(unit.id, t.superseded_by);
+      }
+    }
+    const disc = unit.discovery;
+    if (disc?.verification_status === "verified" && !disc.verified_by) {
+      warnings.push(
+        `Unit '${unit.id}': discovery.verification_status is 'verified' but discovery.verified_by is absent`
+      );
+    }
+  }
+  for (const id of supersededCycleIds(unitSuccessor)) {
+    errors.push(`temporal.superseded_by cycle detected involving unit '${id}'`);
+  }
+  if (
+    manifest.discovery?.verification_status === "verified" &&
+    !manifest.discovery.verified_by
+  ) {
+    warnings.push(
+      "manifest: discovery.verification_status is 'verified' but discovery.verified_by is absent"
+    );
+  }
+
+  // Federation: manifests[].temporal (§3.6, RFC-0021).
+  const refIds = new Set(manifest.manifests.map((m) => m.id));
+  const refSuccessor = new Map<string, string>();
+  for (const ref of manifest.manifests) {
+    const t = ref.temporal;
+    if (!t) continue;
+    if (t.valid_from && t.valid_until && t.valid_until < t.valid_from) {
+      warnings.push(
+        `manifests['${ref.id}']: temporal.valid_until '${t.valid_until}' precedes valid_from '${t.valid_from}' (empty validity window)`
+      );
+    }
+    if (t.valid_until && t.valid_until < today && !t.superseded_by) {
+      warnings.push(
+        `manifests['${ref.id}']: temporal.valid_until '${t.valid_until}' is in the past and no superseded_by is set (stale federation link)`
+      );
+    }
+    if (t.superseded_by) {
+      if (!refIds.has(t.superseded_by)) {
+        warnings.push(
+          `manifests['${ref.id}']: temporal.superseded_by references unknown manifests[].id '${t.superseded_by}'`
+        );
+      } else {
+        refSuccessor.set(ref.id, t.superseded_by);
+      }
+    }
+  }
+  for (const id of supersededCycleIds(refSuccessor)) {
+    errors.push(`manifests[].temporal.superseded_by cycle detected involving '${id}'`);
   }
 
   // Root-level delegation validation (§3.4)

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -282,7 +282,8 @@ public class KcpParser {
                 (String) m.get("update_frequency"),
                 (String) m.get("local_mirror"),
                 (String) m.get("version_pin"),
-                (String) m.get("version_policy")
+                (String) m.get("version_policy"),
+                parseTemporal((Map<String, Object>) m.get("temporal"))
         );
     }
 
@@ -348,6 +349,8 @@ public class KcpParser {
                 (String) d.get("source"),
                 (String) d.get("observed_at"),
                 (String) d.get("verified_at"),
+                (String) d.get("verified_by"),
+                (String) d.get("evidence"),
                 confidence,
                 (String) d.get("contradicted_by")
         );

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -12,6 +12,7 @@ import no.cantara.kcp.model.KnowledgeManifest;
 import no.cantara.kcp.model.KnowledgeUnit;
 import no.cantara.kcp.model.ManifestRef;
 import no.cantara.kcp.model.Relationship;
+import no.cantara.kcp.model.Temporal;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -22,6 +23,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -379,6 +381,72 @@ public class KcpValidator {
             }
         }
 
+        // --- Temporal validation (§4.22 unit-level; §3.6 manifests[].temporal) ---
+        // Root-level temporal provides defaults; unit-level overrides field-by-field.
+        String today = LocalDate.now().toString();
+        Temporal root = manifest.temporal();
+        Map<String, String> unitSuccessor = new HashMap<>();
+        for (KnowledgeUnit unit : manifest.units()) {
+            Temporal ut = unit.temporal();
+            String vf = ut != null && ut.validFrom() != null ? ut.validFrom() : (root != null ? root.validFrom() : null);
+            String vu = ut != null && ut.validUntil() != null ? ut.validUntil() : (root != null ? root.validUntil() : null);
+            String sb = ut != null && ut.supersededBy() != null ? ut.supersededBy() : (root != null ? root.supersededBy() : null);
+            if (vf != null && vu != null && vu.compareTo(vf) < 0) {
+                warnings.add("unit '" + unit.id() + "': temporal.valid_until '" + vu + "' precedes valid_from '" + vf
+                        + "' (empty validity window — the unit can never be active)");
+            }
+            if (vu != null && vu.compareTo(today) < 0 && sb == null) {
+                warnings.add("unit '" + unit.id() + "': temporal.valid_until '" + vu
+                        + "' is in the past and no superseded_by is set (stale unit with no successor)");
+            }
+            // superseded_by may use namespace:id to target an unresolved include (§4.22).
+            if (sb != null && !sb.contains(":")) {
+                if (!unitIds.contains(sb)) {
+                    warnings.add("unit '" + unit.id() + "': temporal.superseded_by references unknown unit '" + sb + "'");
+                } else {
+                    unitSuccessor.put(unit.id(), sb);
+                }
+            }
+            Discovery disc = unit.discovery();
+            if (disc != null && "verified".equals(disc.verificationStatus()) && disc.verifiedBy() == null) {
+                warnings.add("unit '" + unit.id()
+                        + "': discovery.verification_status is 'verified' but discovery.verified_by is absent");
+            }
+        }
+        for (String cid : supersededCycleIds(unitSuccessor)) {
+            errors.add("temporal.superseded_by cycle detected involving unit '" + cid + "'");
+        }
+        if (manifest.discovery() != null && "verified".equals(manifest.discovery().verificationStatus())
+                && manifest.discovery().verifiedBy() == null) {
+            warnings.add("manifest: discovery.verification_status is 'verified' but discovery.verified_by is absent");
+        }
+
+        // Federation: manifests[].temporal (§3.6, RFC-0021).
+        Map<String, String> refSuccessor = new HashMap<>();
+        for (ManifestRef ref : manifest.manifests()) {
+            Temporal t = ref.temporal();
+            if (t == null) continue;
+            if (t.validFrom() != null && t.validUntil() != null && t.validUntil().compareTo(t.validFrom()) < 0) {
+                warnings.add("manifests['" + ref.id() + "']: temporal.valid_until '" + t.validUntil()
+                        + "' precedes valid_from '" + t.validFrom() + "' (empty validity window)");
+            }
+            if (t.validUntil() != null && t.validUntil().compareTo(today) < 0 && t.supersededBy() == null) {
+                warnings.add("manifests['" + ref.id() + "']: temporal.valid_until '" + t.validUntil()
+                        + "' is in the past and no superseded_by is set (stale federation link)");
+            }
+            if (t.supersededBy() != null) {
+                if (!manifestIds.contains(t.supersededBy())) {
+                    warnings.add("manifests['" + ref.id() + "']: temporal.superseded_by references unknown manifests[].id '"
+                            + t.supersededBy() + "'");
+                } else {
+                    refSuccessor.put(ref.id(), t.supersededBy());
+                }
+            }
+        }
+        for (String cid : supersededCycleIds(refSuccessor)) {
+            errors.add("manifests[].temporal.superseded_by cycle detected involving '" + cid + "'");
+        }
+
         return new ValidationResult(errors, warnings);
     }
 
@@ -388,6 +456,33 @@ public class KcpValidator {
      *
      * @return The set of edges (as "from-&gt;to" strings) that would close a cycle.
      */
+    /**
+     * Cycle detection for single-successor {@code superseded_by} chains
+     * (§4.22, §3.6). Returns the ids participating in a cycle, sorted.
+     */
+    private static List<String> supersededCycleIds(Map<String, String> successor) {
+        Set<String> cycle = new HashSet<>();
+        Map<String, Integer> state = new HashMap<>(); // absent/0 = unvisited, 1 = in-path, 2 = done
+        for (String start : successor.keySet()) {
+            if (state.getOrDefault(start, 0) == 2) continue;
+            List<String> path = new ArrayList<>();
+            String node = start;
+            while (node != null && successor.containsKey(node) && state.getOrDefault(node, 0) != 2) {
+                if (state.getOrDefault(node, 0) == 1) {
+                    for (String id : path.subList(path.indexOf(node), path.size())) cycle.add(id);
+                    break;
+                }
+                state.put(node, 1);
+                path.add(node);
+                node = successor.get(node);
+            }
+            for (String id : path) if (state.getOrDefault(id, 0) == 1) state.put(id, 2);
+        }
+        List<String> result = new ArrayList<>(cycle);
+        result.sort(null);
+        return result;
+    }
+
     static Set<String> detectCycles(List<KnowledgeUnit> units, Set<String> unitIds) {
         Map<String, List<String>> adj = new HashMap<>();
         for (KnowledgeUnit unit : units) {

--- a/parsers/java/src/main/java/no/cantara/kcp/model/Discovery.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/Discovery.java
@@ -9,6 +9,8 @@ package no.cantara.kcp.model;
  *                            {@code openapi} | {@code llm_inference}. Default: {@code manual}.
  * @param observedAt          ISO 8601 datetime when the unit was first observed. Optional.
  * @param verifiedAt          ISO 8601 datetime when the unit was last verified. Optional.
+ * @param verifiedBy          RFC-0020 §2.3 / §4.18 — verifier key id or identity. Optional.
+ * @param evidence            RFC-0020 §2.3 / §4.18 — URL/path to verification artifact. Optional.
  * @param confidence          Float 0.0–1.0. Default: {@code 1.0}.
  *                            Normative: rumored MUST have confidence &lt; 0.5;
  *                            verified SHOULD have confidence &ge; 0.8.
@@ -19,6 +21,8 @@ public record Discovery(
         String source,
         String observedAt,
         String verifiedAt,
+        String verifiedBy,
+        String evidence,
         Double confidence,
         String contradictedBy
 ) {}

--- a/parsers/java/src/main/java/no/cantara/kcp/model/ManifestRef.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/ManifestRef.java
@@ -13,5 +13,6 @@ public record ManifestRef(
         String updateFrequency,
         String localMirror,
         String versionPin,
-        String versionPolicy
+        String versionPolicy,
+        Temporal temporal
 ) {}

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpParserTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpParserTest.java
@@ -1526,6 +1526,7 @@ class KcpParserTest {
         discoveryData.put("source", "manual");
         discoveryData.put("observed_at", "2026-01-10T08:00:00Z");
         discoveryData.put("verified_at", "2026-02-01T09:00:00Z");
+        discoveryData.put("verified_by", "ed25519:MCowBQYDK2VwAyEA");  // §4.18: verified SHOULD carry a verifier
         discoveryData.put("confidence", 0.95);
 
         Map<String, Object> unitData = new HashMap<>();
@@ -1550,6 +1551,7 @@ class KcpParserTest {
         assertEquals("manual", unit.discovery().source());
         assertEquals("2026-01-10T08:00:00Z", unit.discovery().observedAt());
         assertEquals("2026-02-01T09:00:00Z", unit.discovery().verifiedAt());
+        assertEquals("ed25519:MCowBQYDK2VwAyEA", unit.discovery().verifiedBy());
         assertEquals(0.95, unit.discovery().confidence(), 0.001);
         assertNull(unit.discovery().contradictedBy());
 

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpTemporalValidationTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpTemporalValidationTest.java
@@ -1,0 +1,185 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.KnowledgeManifest;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Temporal validation tests (§4.22 unit-level; §3.6 manifests[].temporal).
+ * Mirrors cli/src/temporal-validation.test.ts and the Python suite so the §7
+ * warnings and superseded_by cycle MUST-errors stay in cross-language parity.
+ */
+class KcpTemporalValidationTest {
+
+    private static final String PAST = "2000-01-01";
+    private static final String FUTURE = "2999-12-31";
+
+    private static Map<String, Object> unit(String id, Map<String, Object> temporal, Map<String, Object> discovery) {
+        Map<String, Object> u = new HashMap<>();
+        u.put("id", id);
+        u.put("path", "docs/" + id + ".md");
+        u.put("intent", "Unit " + id);
+        u.put("scope", "project");
+        u.put("audience", List.of("agent"));
+        if (temporal != null) u.put("temporal", temporal);
+        if (discovery != null) u.put("discovery", discovery);
+        return u;
+    }
+
+    private static Map<String, Object> manifest(List<Object> units, Map<String, Object> extra) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("kcp_version", "0.21");
+        m.put("project", "test");
+        m.put("version", "1.0.0");
+        m.put("units", units);
+        if (extra != null) m.putAll(extra);
+        return m;
+    }
+
+    private static KcpValidator.ValidationResult validateUnits(List<Object> units, Map<String, Object> extra) {
+        KnowledgeManifest m = KcpParser.fromMap(manifest(units, extra));
+        return KcpValidator.validate(m);
+    }
+
+    private static boolean anyWarn(KcpValidator.ValidationResult r, String needle) {
+        return r.warnings().stream().anyMatch(w -> w.contains(needle));
+    }
+
+    private static boolean anyErr(KcpValidator.ValidationResult r, String needle) {
+        return r.errors().stream().anyMatch(e -> e.contains(needle));
+    }
+
+    @Test
+    void emptyWindowWarns() {
+        var r = validateUnits(List.of(unit("a", Map.of("valid_from", "2026-06-01", "valid_until", "2026-01-01"), null)), null);
+        assertTrue(anyWarn(r, "empty validity window"));
+        assertTrue(r.isValid());
+    }
+
+    @Test
+    void normalWindowClean() {
+        var r = validateUnits(List.of(unit("a", Map.of("valid_from", "2026-01-01", "valid_until", FUTURE), null)), null);
+        assertFalse(anyWarn(r, "empty validity window"));
+        assertFalse(anyWarn(r, "stale"));
+    }
+
+    @Test
+    void staleUnitWarns() {
+        var r = validateUnits(List.of(unit("a", Map.of("valid_until", PAST), null)), null);
+        assertTrue(anyWarn(r, "stale unit with no successor"));
+    }
+
+    @Test
+    void staleSuppressedBySuccessor() {
+        var r = validateUnits(List.of(
+                unit("a", Map.of("valid_until", PAST, "superseded_by", "b"), null),
+                unit("b", null, null)), null);
+        assertFalse(anyWarn(r, "stale unit"));
+    }
+
+    @Test
+    void danglingSupersededByWarns() {
+        var r = validateUnits(List.of(unit("a", Map.of("superseded_by", "ghost"), null)), null);
+        assertTrue(anyWarn(r, "superseded_by references unknown unit 'ghost'"));
+    }
+
+    @Test
+    void namespacedSupersededByNotFlagged() {
+        var r = validateUnits(List.of(unit("a", Map.of("superseded_by", "platform:newer"), null)), null);
+        assertFalse(anyWarn(r, "superseded_by references unknown"));
+    }
+
+    @Test
+    void supersededByCycleErrors() {
+        var r = validateUnits(List.of(
+                unit("a", Map.of("superseded_by", "b"), null),
+                unit("b", Map.of("superseded_by", "a"), null)), null);
+        assertFalse(r.isValid());
+        assertTrue(anyErr(r, "superseded_by cycle"));
+    }
+
+    @Test
+    void linearChainNoCycle() {
+        var r = validateUnits(List.of(
+                unit("a", Map.of("superseded_by", "b"), null),
+                unit("b", Map.of("superseded_by", "c"), null),
+                unit("c", null, null)), null);
+        assertFalse(anyErr(r, "superseded_by cycle"));
+    }
+
+    @Test
+    void rootTemporalDefaultsApply() {
+        var r = validateUnits(
+                List.of(unit("a", Map.of("valid_from", "1999-01-01"), null)),
+                Map.of("temporal", Map.of("valid_until", PAST)));
+        assertTrue(anyWarn(r, "stale unit"));
+    }
+
+    @Test
+    void verifiedWithoutVerifiedByWarnsUnitAndRoot() {
+        var r = validateUnits(
+                List.of(unit("a", null, Map.of("verification_status", "verified"))),
+                Map.of("discovery", Map.of("verification_status", "verified")));
+        assertEquals(2, r.warnings().stream().filter(w -> w.contains("verified_by is absent")).count());
+    }
+
+    @Test
+    void verifiedWithVerifiedByClean() {
+        var r = validateUnits(
+                List.of(unit("a", null, Map.of("verification_status", "verified", "verified_by", "key-1"))), null);
+        assertFalse(anyWarn(r, "verified_by is absent"));
+    }
+
+    // --- federation temporal (§3.6 manifests[].temporal) ---
+
+    private static Map<String, Object> ref(String id, Map<String, Object> temporal) {
+        Map<String, Object> r = new HashMap<>();
+        r.put("id", id);
+        r.put("url", "https://example.com/" + id + "/knowledge.yaml");
+        r.put("relationship", "governs");
+        if (temporal != null) r.put("temporal", temporal);
+        return r;
+    }
+
+    private static KcpValidator.ValidationResult validateManifests(List<Object> manifests) {
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("manifests", manifests);
+        return validateUnits(List.of(unit("local", null, null)), extra);
+    }
+
+    @Test
+    void manifestsTemporalExposed() {
+        KnowledgeManifest m = KcpParser.fromMap(manifest(
+                List.of(unit("local", null, null)),
+                Map.of("manifests", List.of(ref("a", Map.of("valid_from", "2020-01-01"))))));
+        assertEquals("2020-01-01", m.manifests().get(0).temporal().validFrom());
+    }
+
+    @Test
+    void staleFederationLinkWarns() {
+        var r = validateManifests(List.of(ref("a", Map.of("valid_until", PAST))));
+        assertTrue(anyWarn(r, "stale federation link"));
+    }
+
+    @Test
+    void federationEmptyWindowAndDangling() {
+        var r = validateManifests(List.of(
+                ref("a", Map.of("valid_from", "2026-06-01", "valid_until", "2026-01-01", "superseded_by", "ghost"))));
+        assertTrue(anyWarn(r, "empty validity window"));
+        assertTrue(anyWarn(r, "unknown manifests[].id 'ghost'"));
+    }
+
+    @Test
+    void federationSupersededCycleErrors() {
+        var r = validateManifests(List.of(
+                ref("a", Map.of("superseded_by", "b")),
+                ref("b", Map.of("superseded_by", "a"))));
+        assertFalse(r.isValid());
+        assertTrue(anyErr(r, "manifests[].temporal.superseded_by cycle"));
+    }
+}

--- a/parsers/python/kcp/model.py
+++ b/parsers/python/kcp/model.py
@@ -16,6 +16,8 @@ class Discovery:
     source: Optional[str] = None  # manual | web_traversal | openapi | llm_inference
     observed_at: Optional[str] = None  # ISO 8601 datetime
     verified_at: Optional[str] = None  # ISO 8601 datetime
+    verified_by: Optional[str] = None  # RFC-0020 §2.3 / §4.18 — verifier key id or identity
+    evidence: Optional[str] = None  # RFC-0020 §2.3 / §4.18 — URL/path to verification artifact
     confidence: Optional[float] = None  # 0.0–1.0, default 1.0
     contradicted_by: Optional[str] = None  # unit id
 
@@ -196,6 +198,7 @@ class ManifestRef:
     local_mirror: Optional[str] = None
     version_pin: Optional[str] = None
     version_policy: Optional[str] = None  # "exact" | "minimum" | "compatible" (default)
+    temporal: Optional["Temporal"] = None  # RFC-0021 / §3.6 (v0.21) — source-level validity window
 
 
 @dataclass

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -166,6 +166,8 @@ def _parse_discovery(data: Optional[dict]) -> Optional[Discovery]:
         source=data.get("source"),
         observed_at=data.get("observed_at"),
         verified_at=data.get("verified_at"),
+        verified_by=data.get("verified_by"),
+        evidence=data.get("evidence"),
         confidence=data.get("confidence"),
         contradicted_by=data.get("contradicted_by"),
     )
@@ -253,6 +255,7 @@ def _parse_manifest_ref(data: dict) -> ManifestRef:
         local_mirror=data.get("local_mirror"),
         version_pin=data.get("version_pin"),
         version_policy=data.get("version_policy"),
+        temporal=_parse_temporal(data.get("temporal")),
     )
 
 

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -1,10 +1,37 @@
 import hashlib
 import os
 import re
+from datetime import date
 from pathlib import Path
 from typing import NamedTuple, Optional
 
 from .model import KnowledgeManifest
+
+
+def _superseded_cycle_ids(successor: dict[str, str]) -> list[str]:
+    """Detect cycles in a single-successor (functional) graph — the shape of
+    ``superseded_by`` chains. Returns the ids participating in a cycle, sorted.
+    Mirrors the depends_on cycle detection used elsewhere.
+    """
+    cycle: set[str] = set()
+    state: dict[str, int] = {}  # 0/absent = unvisited, 1 = in-path, 2 = done
+    for start in successor:
+        if state.get(start) == 2:
+            continue
+        path: list[str] = []
+        node: Optional[str] = start
+        while node is not None and node in successor and state.get(node) != 2:
+            if state.get(node) == 1:
+                for i in path[path.index(node):]:
+                    cycle.add(i)
+                break
+            state[node] = 1
+            path.append(node)
+            node = successor.get(node)
+        for i in path:
+            if state.get(i) == 1:
+                state[i] = 2
+    return sorted(cycle)
 
 # RFC-0019 (draft): allowed content_hash algorithms.
 HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
@@ -473,6 +500,78 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
             warnings.append(
                 f"{ep}: 'to_manifest' references unknown manifest id '{ext_rel.to_manifest}'"
             )
+
+    # --- Temporal validation (§4.22 unit-level; §3.6 manifests[].temporal) ---
+    # Root-level temporal provides defaults; unit-level overrides field-by-field.
+    today = date.today().isoformat()
+
+    def _effective(t):
+        r = manifest.temporal
+        vf = (t.valid_from if t and t.valid_from is not None else (r.valid_from if r else None))
+        vu = (t.valid_until if t and t.valid_until is not None else (r.valid_until if r else None))
+        sb = (t.superseded_by if t and t.superseded_by is not None else (r.superseded_by if r else None))
+        return vf, vu, sb
+
+    unit_successor: dict[str, str] = {}
+    for unit in manifest.units:
+        vf, vu, sb = _effective(unit.temporal)
+        if vf and vu and vu < vf:
+            warnings.append(
+                f"unit '{unit.id}': temporal.valid_until '{vu}' precedes valid_from '{vf}' "
+                f"(empty validity window — the unit can never be active)"
+            )
+        if vu and vu < today and not sb:
+            warnings.append(
+                f"unit '{unit.id}': temporal.valid_until '{vu}' is in the past and no "
+                f"superseded_by is set (stale unit with no successor)"
+            )
+        # superseded_by may use namespace:id to target an unresolved include (§4.22);
+        # only local (non-namespaced) refs are checkable here.
+        if sb and ":" not in sb:
+            if sb not in unit_ids:
+                warnings.append(f"unit '{unit.id}': temporal.superseded_by references unknown unit '{sb}'")
+            else:
+                unit_successor[unit.id] = sb
+        disc = unit.discovery
+        if disc and disc.verification_status == "verified" and not disc.verified_by:
+            warnings.append(
+                f"unit '{unit.id}': discovery.verification_status is 'verified' but "
+                f"discovery.verified_by is absent"
+            )
+    for cid in _superseded_cycle_ids(unit_successor):
+        errors.append(f"temporal.superseded_by cycle detected involving unit '{cid}'")
+    if (manifest.discovery and manifest.discovery.verification_status == "verified"
+            and not manifest.discovery.verified_by):
+        warnings.append(
+            "manifest: discovery.verification_status is 'verified' but discovery.verified_by is absent"
+        )
+
+    # Federation: manifests[].temporal (§3.6, RFC-0021)
+    ref_successor: dict[str, str] = {}
+    for ref in manifest.manifests:
+        t = ref.temporal
+        if not t:
+            continue
+        if t.valid_from and t.valid_until and t.valid_until < t.valid_from:
+            warnings.append(
+                f"manifests['{ref.id}']: temporal.valid_until '{t.valid_until}' precedes "
+                f"valid_from '{t.valid_from}' (empty validity window)"
+            )
+        if t.valid_until and t.valid_until < today and not t.superseded_by:
+            warnings.append(
+                f"manifests['{ref.id}']: temporal.valid_until '{t.valid_until}' is in the past "
+                f"and no superseded_by is set (stale federation link)"
+            )
+        if t.superseded_by:
+            if t.superseded_by not in manifest_ids:
+                warnings.append(
+                    f"manifests['{ref.id}']: temporal.superseded_by references unknown "
+                    f"manifests[].id '{t.superseded_by}'"
+                )
+            else:
+                ref_successor[ref.id] = t.superseded_by
+    for cid in _superseded_cycle_ids(ref_successor):
+        errors.append(f"manifests[].temporal.superseded_by cycle detected involving '{cid}'")
 
     return ValidationResult(errors=errors, warnings=warnings)
 

--- a/parsers/python/tests/test_temporal_validation.py
+++ b/parsers/python/tests/test_temporal_validation.py
@@ -1,0 +1,128 @@
+"""Temporal validation tests (§4.22 unit-level; §3.6 manifests[].temporal).
+
+Mirrors the TypeScript cli/src/temporal-validation.test.ts so the §7 warnings
+and superseded_by cycle MUST-errors stay in cross-language parity.
+"""
+
+from kcp import parse_dict, validate
+
+PAST = "2000-01-01"
+FUTURE = "2999-12-31"
+
+
+def _manifest(**extra):
+    return {"kcp_version": "0.21", "project": "test", "version": "1.0.0", **extra}
+
+
+def _unit(uid, temporal=None, **extra):
+    u = {"id": uid, "path": f"docs/{uid}.md", "intent": f"Unit {uid}",
+         "scope": "project", "audience": ["agent"], **extra}
+    if temporal is not None:
+        u["temporal"] = temporal
+    return u
+
+
+def _validate_units(units, **extra):
+    return validate(parse_dict(_manifest(units=units, **extra)))
+
+
+def test_empty_window_warns():
+    r = _validate_units([_unit("a", {"valid_from": "2026-06-01", "valid_until": "2026-01-01"})])
+    assert any("empty validity window" in w for w in r.warnings)
+    assert r.is_valid  # warning, not error
+
+
+def test_normal_window_clean():
+    r = _validate_units([_unit("a", {"valid_from": "2026-01-01", "valid_until": FUTURE})])
+    assert not any("empty validity window" in w for w in r.warnings)
+    assert not any("stale" in w for w in r.warnings)
+
+
+def test_stale_unit_warns():
+    r = _validate_units([_unit("a", {"valid_until": PAST})])
+    assert any("stale unit with no successor" in w for w in r.warnings)
+
+
+def test_stale_suppressed_by_successor():
+    r = _validate_units([_unit("a", {"valid_until": PAST, "superseded_by": "b"}), _unit("b")])
+    assert not any("stale unit" in w for w in r.warnings)
+
+
+def test_dangling_superseded_by_warns():
+    r = _validate_units([_unit("a", {"superseded_by": "ghost"})])
+    assert any("superseded_by references unknown unit 'ghost'" in w for w in r.warnings)
+
+
+def test_namespaced_superseded_by_not_flagged():
+    r = _validate_units([_unit("a", {"superseded_by": "platform:newer"})])
+    assert not any("superseded_by references unknown" in w for w in r.warnings)
+
+
+def test_superseded_by_cycle_errors():
+    r = _validate_units([_unit("a", {"superseded_by": "b"}), _unit("b", {"superseded_by": "a"})])
+    assert not r.is_valid
+    assert any("superseded_by cycle" in e for e in r.errors)
+
+
+def test_linear_chain_no_cycle():
+    r = _validate_units([
+        _unit("a", {"superseded_by": "b"}),
+        _unit("b", {"superseded_by": "c"}),
+        _unit("c"),
+    ])
+    assert not any("superseded_by cycle" in e for e in r.errors)
+
+
+def test_root_temporal_defaults_apply():
+    r = _validate_units([_unit("a", {"valid_from": "1999-01-01"})], temporal={"valid_until": PAST})
+    assert any("stale unit" in w for w in r.warnings)
+
+
+def test_verified_without_verified_by_warns_unit_and_root():
+    r = _validate_units(
+        [_unit("a", discovery={"verification_status": "verified"})],
+        discovery={"verification_status": "verified"},
+    )
+    assert len([w for w in r.warnings if "verified_by is absent" in w]) == 2
+
+
+def test_verified_with_verified_by_clean():
+    r = _validate_units([_unit("a", discovery={"verification_status": "verified", "verified_by": "key-1"})])
+    assert not any("verified_by is absent" in w for w in r.warnings)
+
+
+# --- federation temporal (§3.6 manifests[].temporal) ---
+
+def _ref(rid, temporal=None):
+    r = {"id": rid, "url": f"https://example.com/{rid}/knowledge.yaml", "relationship": "governs"}
+    if temporal is not None:
+        r["temporal"] = temporal
+    return r
+
+
+def _validate_manifests(manifests):
+    return validate(parse_dict(_manifest(units=[_unit("local")], manifests=manifests)))
+
+
+def test_manifests_temporal_exposed():
+    m = parse_dict(_manifest(units=[_unit("local")], manifests=[_ref("a", {"valid_from": "2020-01-01"})]))
+    assert m.manifests[0].temporal.valid_from == "2020-01-01"
+
+
+def test_stale_federation_link_warns():
+    r = _validate_manifests([_ref("a", {"valid_until": PAST})])
+    assert any("stale federation link" in w for w in r.warnings)
+
+
+def test_federation_empty_window_and_dangling():
+    r = _validate_manifests([
+        _ref("a", {"valid_from": "2026-06-01", "valid_until": "2026-01-01", "superseded_by": "ghost"}),
+    ])
+    assert any("empty validity window" in w for w in r.warnings)
+    assert any("unknown manifests[].id 'ghost'" in w for w in r.warnings)
+
+
+def test_federation_superseded_cycle_errors():
+    r = _validate_manifests([_ref("a", {"superseded_by": "b"}), _ref("b", {"superseded_by": "a"})])
+    assert not r.is_valid
+    assert any("manifests[].temporal.superseded_by cycle" in e for e in r.errors)


### PR DESCRIPTION
## Summary

Closes the spec-vs-implementation gap flagged during the v0.20/v0.21 analysis: normative `MUST`s promoted in v0.19/v0.21 with no code behind them. Now enforced across **all four** reference implementations (TypeScript CLI, TypeScript bridge, Python, Java).

## Parsing parity (Level 1 exposure)

- **CLI parser** now reads unit- and root-level `temporal` — it silently dropped them before (the field was in the model but never populated; bridge/Python/Java already parsed it).
- All four parsers now expose **`manifests[].temporal`** (RFC-0021) and **`discovery.verified_by` / `discovery.evidence`** (RFC-0020 §2.3 / §4.18). `ManifestRef` and `Discovery` models gained the fields (Java records + call sites updated).

## Validation (the previously-unimplemented MUSTs)

**Unit-level (§4.22):**
- `superseded_by` **cycle detection → manifest error** (single-successor functional-graph finder, mirroring the existing `depends_on` detection).
- §7 warnings: dangling `superseded_by`, stale `valid_until` (past, no successor), empty window (`valid_until` before `valid_from`), and `verification_status: verified` without `verified_by`.
- Root-level `temporal` defaults apply field-by-field; namespaced `superseded_by` refs are skipped (they target unresolved composition includes).

**Federation (§3.6):** the same window/dangling warnings and `superseded_by` cycle error for `manifests[].temporal`.

## Tests

Matched 15-case temporal-validation suites added to CLI, Python, and Java (cross-language parity). One outdated Java fixture (a `verified` discovery with no `verified_by`) was made spec-compliant — it was asserting the absence of a warning the spec now requires.

Suites: **CLI 77, bridge TS 203, Python 159, Java 143** — all green, including the byte-identical validator guard and the render harness (30/30).

## Still deferred (genuinely larger features, not validation)

- Composition resolution + **C17** enforcement in the renderer (the B21–B23 fixtures from #82 flip from PENDING when this lands).
- Bridge skip-before-fetch federation temporal filtering (Level 2).

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_