### PR TITLE
docs: deep sweep to v0.21 — version drift, RFC index, roadmap, parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MCP solved the tool connectivity problem. KCP addresses the knowledge structure 
 Drop a `knowledge.yaml` at the root of any project. Agents stop guessing and start navigating.
 
 ```yaml
-kcp_version: "0.17"
+kcp_version: "0.21"
 project: my-project
 version: 1.0.0
 units:
@@ -67,6 +67,9 @@ project or documentation site. It adds the metadata layer that llms.txt cannot e
 - **Freshness**: when each unit was last validated, and against what
 - **Selective loading**: agents query by task context, not by URL guessing
 - **Audience targeting**: which units are for humans, which for agents, which for both
+- **Trust & integrity** (v0.16+): signed manifests, per-unit content hashes, and a trusted render pipeline so execution-capable agents never ingest unauthenticated prose
+- **Temporal validity** (v0.19+): validity windows (`valid_from`/`valid_until`), supersession chains, and point-in-time (`as_of`) queries for audit and future-dated policy
+- **Composition** (v0.19+): compose manifests from other manifests — include, override, exclude — without forking
 
 ---
 
@@ -206,7 +209,7 @@ external_relationships:                # optional — cross-manifest relationshi
 Five fields per unit are enough to start:
 
 ```yaml
-kcp_version: "0.17"
+kcp_version: "0.21"
 project: my-project
 version: 1.0.0
 units:
@@ -225,7 +228,7 @@ The standard allows complexity but does not demand it.
 
 ```yaml
 # knowledge.yaml
-kcp_version: "0.17"
+kcp_version: "0.21"
 project: wiki.example.org
 version: 1.0.0
 updated: "2026-02-28"
@@ -411,7 +414,7 @@ Until formal acceptance, KCP remains an Apache 2.0 open specification proposed b
 
 ## Status
 
-**Current:** Draft specification — v0.17 (there is no v0.15 spec; the number was skipped to re-sync with the `kcp` CLI release train)
+**Current:** Draft specification — v0.21 (there is no v0.15 spec; the number was skipped to re-sync with the `kcp` CLI release train)
 
 The format is intentionally minimal and builds incrementally through promoted RFCs. Feedback, use cases, and pull requests are welcome.
 
@@ -424,20 +427,38 @@ The format is intentionally minimal and builds incrementally through promoted RF
 - **[RFC-0005](./RFC-0005-Payment-and-Rate-Limits.md)** — Payment and rate-limit metadata proposal (`payment.default_tier` promoted to core in v0.5; `rate_limits` promoted to core in v0.8; payment methods and x402 remain RFC)
 - **[RFC-0006](./RFC-0006-Context-Window-Hints.md)** — Context window hints (accepted; promoted to SPEC.md §4.10 in v0.4)
 - **[RFC-0007](./RFC-0007-Query-Vocabulary.md)** — Query vocabulary (accepted; promoted to SPEC.md §15 in v0.14): `terms`, `audience`, `max_token_budget`, `has_capabilities`, `exclude_stale`, `federation_scope`
-- **[RFC-0008](./RFC-0008-Budget-Constrained-Selection.md)** — Budget-constrained selection (accepted; promoted to SPEC.md §15 in v0.14): scored results, token-budget-aware ranking
-- **[RFC-0012](./RFC-0012-Capability-Discovery-Provenance.md)** — Capability discovery provenance (accepted; promoted to SPEC.md v0.12): `discovery` block with `verification_status`, `confidence`, `source`, `contradicted_by`
-- **[RFC-0014](./RFC-0014-Manifest-Composition.md)** — Manifest composition (open RFC): `includes`, `overrides`, `excludes` — inherit base manifests without forking. Open for discussion.
+- **[RFC-0008](./RFC-0008-Agent-Readiness.md)** — Agent readiness and budget-constrained selection (accepted; promoted to SPEC.md §15 in v0.14): scored results, token-budget-aware ranking, `freshness_policy`
+- **[RFC-0009](./RFC-0009-Visibility-and-Authority.md)** — Visibility and authority (accepted; promoted to SPEC.md in v0.12): `visibility` conditions and `authority` action permissions (read/summarize/modify/share/execute)
+- **[RFC-0010](./RFC-0010-Bi-Temporal-Unit-Validity.md)** — Bi-temporal unit validity (accepted; schema promoted §4.22 in v0.19, query layer §15.13 in v0.20): `temporal` block with valid-time (`valid_from`/`valid_until`) and transaction-time (`recorded_at`/`superseded_by`), plus `as_of` / `include_all_temporal` queries
+- **[RFC-0011](./RFC-0011-Org-Federation.md)** — Organisational federation patterns (RFC): hub-and-spoke and multi-org topologies over the §3.6 federation core
+- **[RFC-0012](./RFC-0012-Capability-Discovery-Provenance.md)** — Capability discovery provenance (accepted; promoted to SPEC.md v0.12): `discovery` block with `verification_status`, `confidence`, `source`, `contradicted_by`; `verified_by`/`evidence` added in v0.19
+- **[RFC-0013](./RFC-0013-Cartridge-Catalog-Distribution.md)** — Cartridge catalog and distribution (RFC; see [CATALOG-SPEC.md](./CATALOG-SPEC.md)): packaging and distributing reusable knowledge cartridges
+- **[RFC-0014](./RFC-0014-Manifest-Composition.md)** — Manifest composition (accepted; core promoted to SPEC.md §3.11 in v0.19 via RFC-0020): `includes`, `overrides`, `excludes` — inherit base manifests without forking
 - **[RFC-0015](./RFC-0015-Negative-Space-Declarations.md)** — Negative space declarations (accepted; promoted to SPEC.md in v0.17): `not_for` declares what a unit does NOT answer. `not_for_strict: true` for hard exclusion. First subtractive field in the spec.
 - **[RFC-0016](./RFC-0016-Content-Structure-Declaration.md)** — Content structure declaration (accepted; promoted to SPEC.md in v0.17): `content_structure.primary` (prose/table/code/list/diagram/reference/mixed), `contains`, `density` (sparse/normal/dense). Lets RAG pipelines route before fetching.
 - **[RFC-0017](./RFC-0017-Observability-Hooks.md)** — Observability hooks (accepted; promoted to SPEC.md §17 in v0.16): local-first usage event schema at `~/.kcp/usage.db`, extended with `render_events`/`quarantine_events`. Powers `kcp stats`.
-- **[RFC-0018](./RFC-0018-Trusted-Render-Pipeline.md)** — Trusted render pipeline (accepted; promoted to SPEC.md §16 in v0.16): `kcp render` emits a sanitized, trust-tiered artifact so execution-capable agents never ingest raw manifest prose. Activates RFC-0004 `content_integrity` (EdDSA/JWS); adds `declared` to the RFC-0012 vocabulary. Validated by 22 executable experiments (`experiments/rfc-0018-render/`).
-- **parsers/** — Reference parser/validator implementations (Python, Java) — 401 tests passing
+- **[RFC-0018](./RFC-0018-Trusted-Render-Pipeline.md)** — Trusted render pipeline (accepted; promoted to SPEC.md §16 in v0.16): `kcp render` emits a sanitized, trust-tiered artifact so execution-capable agents never ingest raw manifest prose. Activates RFC-0004 `content_integrity` (EdDSA/JWS); adds `declared` to the RFC-0012 vocabulary. Validated by executable experiments (`experiments/rfc-0018-render/`).
+- **[RFC-0019](./RFC-0019-Unit-Content-Integrity-and-Origin-Evidence.md)** — Unit content integrity and origin evidence (accepted; promoted in v0.18): per-unit `content_hash` binds referenced files to the signed manifest; origin evidence classes close the manifest-relocation attack (T9). Conformance C11–C14.
+- **[RFC-0020](./RFC-0020-Temporal-Composition.md)** — Temporal composition (accepted; promoted to SPEC.md §4.22/§3.11 in v0.19): promotes the bi-temporal schema and manifest composition together, with integrity-pinned includes and `discovery.verified_by`/`evidence`. Conformance C15.
+- **[RFC-0021](./RFC-0021-Federation-Temporal.md)** — Federation-level temporal validity (accepted; promoted to SPEC.md §3.6 in v0.21): `manifests[].temporal` lets a hub declare when a federated source is relevant; bridges skip out-of-window sub-manifests before fetching. Conformance C18.
+- **[RFC-0022](./RFC-0022-Composition-Integrity.md)** — Composition integrity (accepted; promoted in v0.21): makes composition `integrity` enforcing at `trusted` tier (an unauthenticated include can't reach standing context), closing the composition-substitution attack (T10). Conformance C17.
+- **parsers/** — Reference parser/validator implementations (Python, Java) with full cross-language test suites (parser, validator, conformance)
 - **bridge/** — MCP servers: expose any `knowledge.yaml` as MCP resources (TypeScript · Python · Java). The TypeScript parser, validator, and mapper live in `bridge/typescript/src/` (parser.ts, validator.ts, mapper.ts).
 - **cli/** — Developer CLI: `init`, `validate`, `query`, `stats`. Installed automatically by [kcp-commands](https://github.com/Cantara/kcp-commands) — run `kcp stats` to see queries served, tokens saved, and top units from your local usage log.
 - **plugins/opencode/** — OpenCode plugin (`opencode-kcp-plugin` on npm)
 - **examples/** — Reference manifests at four adoption levels plus 4 simulation scenarios (150 adversarial tests: A2A+KCP clinical research, energy metering HITL, legal delegation chains, financial AML)
 - **[kcp-memory](https://github.com/Cantara/kcp-memory)** — Episodic memory daemon for Claude Code (separate repo)
 - **[kcp-dashboard](https://github.com/Cantara/kcp-dashboard)** — Live terminal dashboard for KCP usage stats (Go + Bubble Tea, single binary)
+
+---
+
+## Further Reading
+
+Background writing on the design and practice of KCP and AI-augmented development by the author:
+
+- **[Thor Henning Hetland — Writing](https://wiki.totto.org/blog/)** · the blog index
+- **[AI-Augmented Development](https://wiki.totto.org/blog/category/ai-augmented-development/)** · the series the KCP articles belong to (manifest design, the knowledge layer, applying KCP to agent frameworks)
+- **[The Prompt Cache as Infrastructure](https://wiki.totto.org/blog/2026/03/04/the-prompt-cache-as-infrastructure-lessons-from-3007-claude-code-sessions/)** · why a structured knowledge layer belongs in the cache between sessions
 
 ---
 

--- a/RFC-0010-Bi-Temporal-Unit-Validity.md
+++ b/RFC-0010-Bi-Temporal-Unit-Validity.md
@@ -5,7 +5,7 @@
 **Date:** 2026-03-15
 **Discussion:** [#50 KCP Treasure Map Service](https://github.com/Cantara/knowledge-context-protocol/discussions/50)
 **Related:** [André Lindenberg — "The Memory Problem No One Talks About: Why AI Agents Need Two Clocks"](https://www.linkedin.com/pulse/memory-problem-one-talks-why-ai-agents-need-two-andr%C3%A9-lindenberg-spjvf/)
-**Spec:** [SPEC.md](./SPEC.md) (current: v0.10)
+**Spec:** [SPEC.md](./SPEC.md) (current: v0.21)
 
 ---
 
@@ -27,12 +27,16 @@ manifests. It enables agents and serving layers to answer:
 All additions are backward compatible. All new fields are optional. Existing manifests
 require no changes.
 
-**Release staging:**
+**Release staging (as shipped):**
 
-- **v0.12 (schema):** The `temporal` block as manifest and unit fields. Zero bridge query
-  changes required. Authors can immediately declare validity windows and recorded-at dates.
-- **v0.13 (query):** Query extensions — `as_of` (point-in-time) and `include_all_temporal`
-  (audit mode) filters. Ships after all three bridges implement the RFC-0008 query baseline.
+- **v0.19 (schema):** The `temporal` block as manifest and unit fields (SPEC §4.22), promoted
+  together with manifest composition via RFC-0020. Zero bridge query changes required —
+  authors can immediately declare validity windows and recorded-at dates.
+- **v0.20 (query):** Query extensions — `as_of` (point-in-time) and `include_all_temporal`
+  (audit mode) filters (SPEC §15.13). Shipped after the bridges implemented the query baseline.
+
+> Note: this RFC originally targeted v0.12/v0.13; the schema and query phases ultimately
+> landed in v0.19 and v0.20 respectively, as the spec re-synced with the CLI release train.
 
 ---
 
@@ -444,8 +448,8 @@ policy was in mid-2025.
 | `temporal.recorded_at` on unit | Level 2 | Informational; no evaluation required |
 | `temporal.superseded_by` chain | Level 2 | Agent follows chain to current unit |
 | Root-level `temporal` defaults | Level 2 | Field-level inheritance to units |
-| `as_of` query parameter | Level 3 (v0.13) | Deferred — requires bridge query baseline |
-| `include_all_temporal` query parameter | Level 3 (v0.13) | Deferred — audit mode |
+| `as_of` query parameter | Level 3 (v0.20) | Point-in-time reconstruction (SPEC §15.13) |
+| `include_all_temporal` query parameter | Level 3 (v0.20) | Audit mode (SPEC §15.13) |
 
 A unit that adds only `valid_from` and `valid_until` meets Level 2. Point-in-time and audit
 queries are Level 3 serving-layer capabilities.
@@ -524,7 +528,7 @@ treat all date-only values as UTC midnight unless a timezone offset is explicitl
 - **RFC-0004 (Trust and Compliance):** `compliance.sensitivity` declares the sensitivity of
   content *now*. `temporal` + `as_of` queries allow audit tooling to retrieve the
   sensitivity declaration that was in effect at any past date.
-- **RFC-0007 (Query Vocabulary):** The v0.13 query extensions (`as_of`,
+- **RFC-0007 (Query Vocabulary):** The v0.20 query extensions (`as_of`,
   `include_all_temporal`) are additive parameters on the RFC-0007 query shape.
 
 ---

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.20.0 (all three bridges — aligned with KCP spec version)
+**Current version:** 0.21.0 (all three bridges — aligned with KCP spec version)
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -103,6 +103,7 @@ No known gaps — all three bridges are at full parity.
 | 0.15.0 | 2026-06-12 | §15.11 `not_for` filtering: strict exclusion + soft score halving with `caution` annotation — all three bridges. |
 | 0.20.0 | 2026-06-12 | §15.13 temporal query: `as_of` + `include_all_temporal` parameters, `temporal_query_conflict` error — all three bridges. Bridge versions now aligned with KCP spec version. |
 | 0.20.1 | 2026-06-13 | Python bridge: added `sdd-review` and `kcp-explore` MCP prompts — closes last Tier 1 parity gaps. |
+| 0.21.0 | 2026-06-13 | Spec v0.21: parsers expose `manifests[].temporal` (RFC-0021) and `discovery.verified_by`/`evidence`; temporal validation (`superseded_by` cycle detection, validity-window §7 warnings) implemented in all four parser/validator implementations. Bridge skip-before-fetch federation temporal filtering deferred. |
 
 > **Note:** v0.7.0--v0.9.0 were internal development milestones that shipped combined as v0.10.0.
 > v0.11.0--v0.13.0 were bridge feature additions that culminated in v0.14.0.

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
   <section class="hero" id="hero">
     <div class="container">
       <div class="hero__badge">
-        <span>v0.16 Spec</span>
+        <span>v0.21 Spec</span>
         &middot;
         <span>Open Standard</span>
         &middot;
@@ -644,7 +644,7 @@ relationships:
               <pre><code id="ex-minimal" class="language-yaml"># Minimal KCP example — five minutes to add.
 # This is a valid knowledge.yaml at Level 1 conformance.
 
-kcp_version: "0.16"
+kcp_version: "0.21"
 project: my-project
 version: 1.0.0
 
@@ -672,7 +672,7 @@ units:
               <pre><code id="ex-personal" class="language-yaml"># Personal site / portfolio example
 # Shows: audience differentiation, freshness, depends_on
 
-kcp_version: "0.16"
+kcp_version: "0.21"
 project: wiki.example.org
 version: 1.0.0
 updated: "2026-02-28"
@@ -746,7 +746,7 @@ relationships:
 # Dependency chains across architecture layers
 # Freshness: archived (2022) vs active (2026) content
 
-kcp_version: "0.16"
+kcp_version: "0.21"
 project: community-wiki
 version: 1.0.0
 updated: "2026-02-28"
@@ -1803,7 +1803,7 @@ units:
               </button>
             </div>
             <div class="code-block__body">
-              <pre><code id="qs-code-l1" class="language-yaml">kcp_version: "0.16"
+              <pre><code id="qs-code-l1" class="language-yaml">kcp_version: "0.21"
 project: my-project
 version: 1.0.0
 
@@ -1840,7 +1840,7 @@ units:
               </button>
             </div>
             <div class="code-block__body">
-              <pre><code id="qs-code-l2" class="language-yaml">kcp_version: "0.16"
+              <pre><code id="qs-code-l2" class="language-yaml">kcp_version: "0.21"
 project: my-project
 version: 1.0.0
 updated: "2026-01-01"
@@ -1894,7 +1894,7 @@ units:
               </button>
             </div>
             <div class="code-block__body">
-              <pre><code id="qs-code-l3" class="language-yaml">kcp_version: "0.16"
+              <pre><code id="qs-code-l3" class="language-yaml">kcp_version: "0.21"
 project: my-project
 version: 1.0.0
 updated: "2026-01-01"
@@ -2004,7 +2004,7 @@ relationships:
       <div class="adopters-cta-box reveal">
         <h3>Add your project</h3>
         <p>Using KCP in a public repository? Open an issue and we'll add you to this list. You can also add a badge to your own README.</p>
-        <div class="adopter-snippet">[![KCP](https://img.shields.io/badge/KCP-v0.16-2563eb?style=flat-square&logo=yaml&logoColor=white)](https://cantara.github.io/knowledge-context-protocol/)</div>
+        <div class="adopter-snippet">[![KCP](https://img.shields.io/badge/KCP-v0.21-2563eb?style=flat-square&logo=yaml&logoColor=white)](https://cantara.github.io/knowledge-context-protocol/)</div>
         <div style="display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap;">
           <a href="https://github.com/Cantara/knowledge-context-protocol/issues/new?title=Add+adopter:+[your+project]&body=Project+name:%0ARepository+URL:%0ABrief+description:" target="_blank" rel="noopener" class="btn btn--primary">Open issue to add your project</a>
           <a href="https://github.com/Cantara/knowledge-context-protocol" target="_blank" rel="noopener" class="btn btn--outline">View on GitHub</a>
@@ -2013,7 +2013,7 @@ relationships:
 
       <div class="adopters-badges reveal">
         <img src="https://img.shields.io/badge/License-Apache_2.0-blue?style=flat-square" alt="License: Apache 2.0" height="20">
-        <img src="https://img.shields.io/badge/KCP-v0.16-22c55e?style=flat-square&logo=yaml&logoColor=white" alt="KCP v0.16" height="20">
+        <img src="https://img.shields.io/badge/KCP-v0.21-22c55e?style=flat-square&logo=yaml&logoColor=white" alt="KCP v0.21" height="20">
         <img src="https://img.shields.io/badge/spec-stable-22c55e?style=flat-square" alt="Spec: Stable" height="20">
       </div>
 
@@ -2034,7 +2034,7 @@ relationships:
             <p>The KCP specification repository ships its own <code>knowledge.yaml</code> &mdash; dogfooding the protocol with the spec, RFCs, parsers, and guides as declared units.</p>
             <div class="usecase-card__fields">
               <span class="usecase-field-tag">L3 conformance</span>
-              <span class="usecase-field-tag">6 RFCs</span>
+              <span class="usecase-field-tag">22 RFCs</span>
               <span class="usecase-field-tag">Cantara</span>
             </div>
           </div>
@@ -2070,7 +2070,7 @@ relationships:
       <div class="section-header reveal">
         <span class="section-label">Roadmap</span>
         <h2>Where KCP is headed</h2>
-        <p>v0.16 is the current release. Fields are promoted from RFC proposals to core as they accumulate real-world validation. Remaining RFCs are open for community feedback through 2026.</p>
+        <p>v0.21 is the current release. Fields are promoted from RFC proposals to core as they accumulate real-world validation. Remaining RFCs are open for community feedback through 2026.</p>
       </div>
 
       <div class="roadmap-core reveal">
@@ -2250,7 +2250,7 @@ relationships:
 
       <div class="roadmap-core reveal">
         <div class="roadmap-core__info">
-          <span class="roadmap-core__badge">v0.17 — Current</span>
+          <span class="roadmap-core__badge">v0.17 — Shipped</span>
           <h3>Content Wave</h3>
           <p>Two unit-level routing signals promoted to core. <code>content_structure</code> (SPEC §4.19) declares the internal modality composition and density of a unit (<code>primary</code>, <code>contains</code>, <code>density</code>) so RAG pipelines route and pick an extraction strategy before fetching. <code>not_for</code> (SPEC §4.20) is the spec's first <em>subtractive</em> field — it declares what a unit does NOT answer, with soft demotion by default and <code>not_for_strict</code> for hard exclusion. Promoted from RFC-0016 and RFC-0015.</p>
         </div>
@@ -2260,6 +2260,62 @@ relationships:
           <span class="roadmap-field-pill">not_for_strict</span>
           <span class="roadmap-field-pill">RFC-0015</span>
           <span class="roadmap-field-pill">RFC-0016</span>
+        </div>
+      </div>
+
+      <div class="roadmap-core reveal">
+        <div class="roadmap-core__info">
+          <span class="roadmap-core__badge">v0.18 — Shipped</span>
+          <h3>Unit Integrity</h3>
+          <p>Per-unit <code>content_hash</code> (SPEC §3.2) binds the bytes a unit points at to the signed manifest, so a <code>trusted</code>-tier render can't serve content the signing key never covered. Origin evidence classes (asserted / fetched / derived) close the manifest-relocation attack (T9): a copied signature behind a fabricated git origin can pin but never escalate. Promoted from RFC-0019; conformance C11–C14.</p>
+        </div>
+        <div class="roadmap-core__fields">
+          <span class="roadmap-field-pill">content_hash</span>
+          <span class="roadmap-field-pill">origin_evidence</span>
+          <span class="roadmap-field-pill">kcp sign</span>
+          <span class="roadmap-field-pill">RFC-0019</span>
+        </div>
+      </div>
+
+      <div class="roadmap-core reveal">
+        <div class="roadmap-core__info">
+          <span class="roadmap-core__badge">v0.19 — Shipped</span>
+          <h3>Temporal Composition</h3>
+          <p>Knowledge gains a time axis and a layering model. The bi-temporal <code>temporal</code> block (SPEC §4.22) declares valid-time (<code>valid_from</code>/<code>valid_until</code>) and transaction-time (<code>recorded_at</code>/<code>superseded_by</code>). Manifest <code>composition</code> (SPEC §3.11) includes, overrides, and excludes units from other manifests without forking. Promoted from RFC-0010 and RFC-0020; conformance C15.</p>
+        </div>
+        <div class="roadmap-core__fields">
+          <span class="roadmap-field-pill">temporal</span>
+          <span class="roadmap-field-pill">composition</span>
+          <span class="roadmap-field-pill">verified_by</span>
+          <span class="roadmap-field-pill">RFC-0010</span>
+          <span class="roadmap-field-pill">RFC-0020</span>
+        </div>
+      </div>
+
+      <div class="roadmap-core reveal">
+        <div class="roadmap-core__info">
+          <span class="roadmap-core__badge">v0.20 — Shipped</span>
+          <h3>Temporal Query</h3>
+          <p>Point-in-time reconstruction for agents and auditors. <code>as_of</code> (SPEC §15.13) returns the units valid on a given date; <code>include_all_temporal</code> is audit mode, returning every version with its temporal metadata. Bridges without temporal evaluation safely ignore both. Promoted from RFC-0010's query phase; conformance C16.</p>
+        </div>
+        <div class="roadmap-core__fields">
+          <span class="roadmap-field-pill">as_of</span>
+          <span class="roadmap-field-pill">include_all_temporal</span>
+          <span class="roadmap-field-pill">RFC-0010</span>
+        </div>
+      </div>
+
+      <div class="roadmap-core reveal">
+        <div class="roadmap-core__info">
+          <span class="roadmap-core__badge">v0.21 — Current</span>
+          <h3>Federation Temporal &amp; Composition Integrity</h3>
+          <p><code>manifests[].temporal</code> (SPEC §3.6) lets a hub declare when a federated source is relevant, so bridges skip out-of-window sub-manifests before fetching. Composition <code>integrity</code> becomes enforcing at <code>trusted</code> tier (SPEC §3.11 / C17): an unverified or substituted include can't reach an agent's standing context — closing the composition-substitution attack (T10). Promoted from RFC-0021 and RFC-0022.</p>
+        </div>
+        <div class="roadmap-core__fields">
+          <span class="roadmap-field-pill">manifests[].temporal</span>
+          <span class="roadmap-field-pill">integrity</span>
+          <span class="roadmap-field-pill">RFC-0021</span>
+          <span class="roadmap-field-pill">RFC-0022</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

A deep documentation sweep to bring the docs current with **v0.21** (the spec moved v0.17 → v0.21 this cycle and the docs had drifted). Driven by a full audit of every doc surface.

## README.md
- `kcp_version` examples 0.17 → 0.21; Status "Current" → v0.21.
- **Fixed a broken link:** RFC-0008 pointed at a nonexistent `RFC-0008-Budget-Constrained-Selection.md` — the file is `RFC-0008-Agent-Readiness.md`.
- **RFC index was missing eight RFCs** — added 0009, 0010, 0011, 0013, 0019, 0020, 0021, 0022, and corrected RFC-0014's status (promoted via RFC-0020 in v0.19, not "open RFC").
- "What KCP Provides" gains trust/integrity, temporal validity, and composition bullets.
- New **Further Reading** section linking the author's writing (see note below).

## docs/index.html
- Hero badge, adopter badges, and "current release" text 0.16 → 0.21.
- Six `kcp_version` code examples 0.16 → 0.21.
- Founding-repo card "6 RFCs" → "22 RFCs".
- **Roadmap:** retagged v0.17 as Shipped and added v0.18 (Unit Integrity), v0.19 (Temporal Composition), v0.20 (Temporal Query), v0.21 (Federation Temporal & Composition Integrity). HTML verified div-balanced.

## docs/PARITY.md
- Current version → 0.21.0; added a v0.21 version-history row.

## RFC-0010-Bi-Temporal-Unit-Validity.md
- Corrected the stale "release staging" (originally targeted v0.12/v0.13; actually shipped v0.19 schema / v0.20 query), the conformance table (`Level 3 (v0.13)` → `(v0.20)`), and the `Spec: current v0.10` header → v0.21.

## Verification
All README RFC links resolve to real files; no residual stale current-version claims across README, the docs site, PARITY, guides, or component READMEs. Signed manifests (`knowledge.yaml`/`.sig`) intentionally untouched.

## Note on the blog links
The wiki (`wiki.totto.org`) returns **403 to the fetch tooling on every path** (including `/knowledge.yaml` and `/llms.txt`), so per-article permalinks couldn't be auto-discovered. The Further Reading section links the search-confirmed blog index and the "AI-Augmented Development" category as a foundation; per-feature article links (mapping specific posts to RFCs/releases) are a fast follow once the URLs are in hand.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_