### PR TITLE
docs: fill content gaps — RFC cards through 0022, llms.txt coverage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2409,6 +2409,195 @@ relationships:
           </div>
         </div>
 
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0007 / 0008</span>
+            <span class="rfc-card__theme">Query</span>
+          </div>
+          <h4>Query Vocabulary &amp; Agent Readiness</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">terms</span>
+            <span class="rfc-card__block">max_token_budget</span>
+            <span class="rfc-card__block">freshness_policy</span>
+          </div>
+          <p>A structured query shape for agent tools — <code>terms</code>, <code>audience</code>, <code>has_capabilities</code>, <code>federation_scope</code> — plus token-budget-aware scored selection and freshness policy, so a bridge returns the right units within a budget instead of the whole manifest.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.14 &sect;15</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0007-Query-Vocabulary.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0009</span>
+            <span class="rfc-card__theme">Authority</span>
+          </div>
+          <h4>Visibility &amp; Authority</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">visibility</span>
+            <span class="rfc-card__block">authority</span>
+          </div>
+          <p>Conditional visibility rules and per-action authority (<code>read</code>, <code>summarize</code>, <code>modify</code>, <code>share_externally</code>, <code>execute</code>) with safe defaults — knowledge declares what an agent may do with it, not just what it says.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.12</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0009-Visibility-and-Authority.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0010</span>
+            <span class="rfc-card__theme">Time</span>
+          </div>
+          <h4>Bi-Temporal Validity</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">temporal</span>
+            <span class="rfc-card__block">as_of</span>
+            <span class="rfc-card__block">superseded_by</span>
+          </div>
+          <p>Two clocks for knowledge: valid-time (<code>valid_from</code>/<code>valid_until</code>) for when a fact is true in the world, and transaction-time (<code>recorded_at</code>/<code>superseded_by</code>) for when the manifest recorded it. <code>as_of</code> queries reconstruct what a manifest declared on any past date — for audits and future-dated policy.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.19 &sect;4.22 / v0.20 &sect;15.13</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0010-Bi-Temporal-Unit-Validity.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0012</span>
+            <span class="rfc-card__theme">Provenance</span>
+          </div>
+          <h4>Capability Discovery Provenance</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">discovery</span>
+            <span class="rfc-card__block">verification_status</span>
+            <span class="rfc-card__block">verified_by</span>
+          </div>
+          <p>Every claim a manifest makes about itself carries provenance: <code>verification_status</code> (rumored &lt; declared &lt; observed &lt; verified), <code>confidence</code>, <code>source</code>, <code>contradicted_by</code>, and (v0.19) <code>verified_by</code>/<code>evidence</code> attributing who verified what.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.12 &sect;4.18</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0012-Capability-Discovery-Provenance.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0015 / 0016</span>
+            <span class="rfc-card__theme">Content</span>
+          </div>
+          <h4>Negative Space &amp; Content Structure</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">not_for</span>
+            <span class="rfc-card__block">content_structure</span>
+          </div>
+          <p>Two routing signals. <code>not_for</code> is the spec's first <em>subtractive</em> field — it declares what a unit does NOT answer. <code>content_structure</code> declares a unit's modality (prose/table/code/&hellip;) and density so RAG pipelines route and pick an extraction strategy before fetching.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.17 &sect;4.19/&sect;4.20</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0016-Content-Structure-Declaration.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0017</span>
+            <span class="rfc-card__theme">Observability</span>
+          </div>
+          <h4>Observability Hooks</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">usage_events</span>
+            <span class="rfc-card__block">kcp stats</span>
+          </div>
+          <p>A local-first usage event store at <code>~/.kcp/usage.db</code> — queries served, units fetched, tokens saved — so adopters can prove KCP is working. <code>kcp stats</code> reads it; render and quarantine events make security drift diffable in CI.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.16 &sect;17</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0017-Observability-Hooks.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0018</span>
+            <span class="rfc-card__theme">Trust</span>
+          </div>
+          <h4>Trusted Render Pipeline</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">kcp render</span>
+            <span class="rfc-card__block">trust tiers</span>
+          </div>
+          <p>A deterministic, LLM-free, fail-closed renderer (<code>kcp render</code>) emits a sanitized, trust-tiered artifact so an execution-capable agent never ingests raw third-party manifest prose. Signatures gate placement; they never endorse content. Validated by 30 executable adversarial experiments.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.16 &sect;16</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0018-Trusted-Render-Pipeline.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0019</span>
+            <span class="rfc-card__theme">Integrity</span>
+          </div>
+          <h4>Unit Content Integrity</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">content_hash</span>
+            <span class="rfc-card__block">origin_evidence</span>
+          </div>
+          <p>Per-unit <code>content_hash</code> binds the bytes a unit points at to the signed manifest — the signature now covers the territory, not just the map. Origin evidence classes close the manifest-relocation attack (T9): a copied signature behind a fabricated git origin can pin but never escalate.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.18 &sect;3.2 (C11&ndash;C14)</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0019-Unit-Content-Integrity-and-Origin-Evidence.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0020</span>
+            <span class="rfc-card__theme">Composition</span>
+          </div>
+          <h4>Temporal Composition</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">composition</span>
+            <span class="rfc-card__block">temporal</span>
+          </div>
+          <p>Promotes the bi-temporal schema and manifest <code>composition</code> together: include, override, and exclude units from other manifests without forking, with integrity-pinned includes and <code>discovery.verified_by</code>/<code>evidence</code> attribution.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.19 &sect;3.11/&sect;4.22 (C15)</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0020-Temporal-Composition.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0021</span>
+            <span class="rfc-card__theme">Federation</span>
+          </div>
+          <h4>Federation Temporal</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">manifests[].temporal</span>
+          </div>
+          <p>A hub manifest declares when a federated source is relevant as a knowledge provider (<code>valid_from</code>/<code>valid_until</code>/<code>superseded_by</code>), so bridges skip out-of-window sub-manifests before fetching — distinct from when individual units are valid.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.21 &sect;3.6 (C18)</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0021-Federation-Temporal.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
+        <div class="rfc-card">
+          <div class="rfc-card__header">
+            <span class="rfc-card__num">RFC-0022</span>
+            <span class="rfc-card__theme">Integrity</span>
+          </div>
+          <h4>Composition Integrity</h4>
+          <div class="rfc-card__blocks">
+            <span class="rfc-card__block">integrity</span>
+            <span class="rfc-card__block">C17</span>
+          </div>
+          <p>Makes composition <code>integrity</code> enforcing at <code>trusted</code> tier: an unverified or substituted include can't reach an agent's standing context. Closes the composition-substitution attack (T10) — the same map-vs-territory boundary RFC-0019 drew for local content, applied to composed includes.</p>
+          <div class="rfc-card__footer">
+            <span class="rfc-card__status">Promoted &mdash; v0.21 &sect;3.11 (C17)</span>
+            <a class="rfc-card__link" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0022-Composition-Integrity.md" target="_blank" rel="noopener">Read RFC →</a>
+          </div>
+        </div>
+
       </div>
     </div>
   </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -33,9 +33,15 @@ Example: "How do I validate a knowledge.yaml file?" → trigger `validation, sch
 - /guides/adopting-kcp-in-existing-projects.md — How to add KCP to your project in under 30 minutes
 - /examples/README.md — Example manifests at four adoption levels plus simulation scenarios (A2A+KCP, energy metering, legal delegation, financial AML)
 - /RFC-0001-KCP-Extended.md — Extensions: payments, compliance, federation, context hints
+- /RFC-0010-Bi-Temporal-Unit-Validity.md — Bi-temporal validity: `temporal` block (valid-time + transaction-time) and `as_of` point-in-time queries (promoted to SPEC.md §4.22 in v0.19, §15.13 in v0.20)
 - /RFC-0015-Negative-Space-Declarations.md — Negative-space declarations: `not_for` / `not_for_strict` (promoted to SPEC.md §4.20 in v0.17)
 - /RFC-0016-Content-Structure-Declaration.md — Content structure: `content_structure` modality + density (promoted to SPEC.md §4.19 in v0.17)
+- /RFC-0017-Observability-Hooks.md — Local-first usage events at `~/.kcp/usage.db`, read by `kcp stats` (promoted to SPEC.md §17 in v0.16)
 - /RFC-0018-Trusted-Render-Pipeline.md — Trusted render pipeline: `kcp render` emits a sanitized, trust-tiered artifact (promoted to SPEC.md §16 in v0.16)
+- /RFC-0019-Unit-Content-Integrity-and-Origin-Evidence.md — Per-unit `content_hash` + origin evidence classes; closes the manifest-relocation attack T9 (promoted to SPEC.md §3.2 in v0.18)
+- /RFC-0020-Temporal-Composition.md — Manifest `composition` (include/override/exclude) + bi-temporal schema (promoted to SPEC.md §3.11/§4.22 in v0.19)
+- /RFC-0021-Federation-Temporal.md — `manifests[].temporal`: when a federated source is relevant; bridges skip out-of-window sub-manifests (promoted to SPEC.md §3.6 in v0.21)
+- /RFC-0022-Composition-Integrity.md — Enforcing composition integrity at `trusted` tier; closes the composition-substitution attack T10 (promoted to SPEC.md §3.11 in v0.21)
 - /docs/ecosystem/webmcp-comparison.md — WebMCP vs KCP: Google+Microsoft browser-action standard vs KCP knowledge layer (complementary, not competing)
 
 ## How KCP Relates to llms.txt and MCP


### PR DESCRIPTION
## Summary

Fills the content gaps the v0.21 doc audit surfaced — two surfaces still only described the early spec.

## docs/index.html — RFC cards grid

The featured RFC cards stopped at **RFC-0006**: a visitor saw 5 cards while the repo has 22 RFCs, and the entire query → governance → trust → temporal → composition arc was invisible. Added cards for the promoted RFCs that follow, each with its promoted-version/section status:

- RFC-0007/0008 — Query Vocabulary & Agent Readiness
- RFC-0009 — Visibility & Authority
- RFC-0010 — Bi-Temporal Validity
- RFC-0012 — Capability Discovery Provenance
- RFC-0015/0016 — Negative Space & Content Structure
- RFC-0017 — Observability Hooks
- RFC-0018 — Trusted Render Pipeline
- RFC-0019 — Unit Content Integrity
- RFC-0020 — Temporal Composition
- RFC-0021 — Federation Temporal
- RFC-0022 — Composition Integrity

HTML verified div-balanced (443/443); all card links resolve to real RFC files.

## docs/llms.txt — agent-facing index

The Key Files list named only RFC-0001/0015/0016/0018. Added the recent substantive RFCs (0010, 0017, 0019, 0020, 0021, 0022) with their promoted sections, so the docs site's own machine-readable index reflects the v0.21 spec.

Doc-only; no code paths touched.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_