### PR TITLE
examples: add temporal-validity example (was zero v0.13+ feature coverage)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ Reference implementations and runnable simulation scenarios — from the minimum
 The smallest valid `knowledge.yaml`. Start here if you are not sure whether you need KCP yet.
 
 ```yaml
-kcp_version: "0.10"
+kcp_version: "0.21"
 project: my-project
 version: 1.0.0
 units:
@@ -90,6 +90,18 @@ A NovaPlatform v1-to-v2 migration with 8 units exercising five of the six relati
 - `context` — legacy-security-policy provides context for zero-trust-policy
 
 ---
+
+## [temporal-validity/](./temporal-validity/)
+
+**Bi-temporal validity. Future-dated rollout, supersession, point-in-time queries.**
+
+A platform-security knowledge base that versions itself over time (RFC-0010, SPEC §4.22 / §15.13, v0.19–v0.20):
+- `temporal.valid_from` / `valid_until` — when knowledge is true in the world
+- `temporal.recorded_at` / `superseded_by` — when the manifest recorded it, and what replaces it
+- Future-dated policy rollout (`mfa-policy-2026` activates on its date), an expiring migration runbook, and a verified compliance unit with `discovery.verified_by` provenance
+- `as_of` point-in-time queries reconstruct what the manifest declared on any past date
+
+Validates clean: `kcp validate examples/temporal-validity/knowledge.yaml`.
 
 ---
 

--- a/examples/temporal-validity/README.md
+++ b/examples/temporal-validity/README.md
@@ -1,0 +1,46 @@
+# temporal-validity/
+
+**Bi-temporal knowledge: validity windows, future-dated rollout, supersession, and point-in-time queries.**
+
+Demonstrates the `temporal` block (RFC-0010, promoted to SPEC §4.22 in v0.19, with `as_of` queries in §15.13, v0.20) — the features that let a manifest say *when* its knowledge is true, not just *what* it says.
+
+## What this shows
+
+| Pattern | Units | Field usage |
+|---------|-------|-------------|
+| **Future-dated rollout** | `mfa-policy-2026` | `valid_from` in the future — pre-load the new policy; it activates on its date with no manifest edit |
+| **Supersession** | `mfa-policy-legacy → mfa-policy-2026` | `valid_until` + `superseded_by` — the old policy retires cleanly, no "stale" warning, audit trail preserved |
+| **Expiring runbook** | `db-migration-runbook` | `valid_until` bounded to the migration window; `superseded_by` the post-migration runbook |
+| **Two clocks** | all units | valid-time (`valid_from`/`valid_until`) vs transaction-time (`recorded_at`) — root `temporal.recorded_at` sets the manifest-wide default |
+| **Verified provenance** | `gdpr-retention` | `discovery.verification_status: verified` with `verified_by` (RFC-0012/§4.18) |
+
+## Evaluation (today = 2026-06-13)
+
+A default query returns the units active **now**:
+
+- `overview` — always valid (no `temporal` block)
+- `mfa-policy-2026` — active since 2026-04-01
+- `db-migration-runbook` — active through 2026-06-30
+- `gdpr-retention` — active since 2024
+
+…and excludes `mfa-policy-legacy` (retired 2026-03-31) and `db-runbook-postmigration` (not active until 2026-07-01).
+
+## Point-in-time queries (§15.13)
+
+```bash
+# What MFA policy was in effect on 2026-02-15?  ->  mfa-policy-legacy
+kcp query "mfa policy" --as-of 2026-02-15
+
+# Full audit view: every version with its temporal metadata
+kcp query "mfa policy" --include-all-temporal
+```
+
+`as_of` and `include_all_temporal` are mutually exclusive; a bridge that implements §15.13 returns `temporal_query_conflict` if both are set. Bridges without temporal evaluation safely return all currently-active units.
+
+## Validate
+
+```bash
+kcp validate examples/temporal-validity/knowledge.yaml
+```
+
+The validator checks `superseded_by` for cycles (a manifest error) and warns on dangling successors, empty windows (`valid_until` before `valid_from`), and stale units (`valid_until` in the past with no successor). This manifest is clean on all of them.

--- a/examples/temporal-validity/compliance/gdpr-retention.md
+++ b/examples/temporal-validity/compliance/gdpr-retention.md
@@ -1,0 +1,3 @@
+# GDPR Data Retention
+
+Data retention rules for the platform under GDPR. Verified compliance unit, valid since 2024-01-01.

--- a/examples/temporal-validity/knowledge.yaml
+++ b/examples/temporal-validity/knowledge.yaml
@@ -1,0 +1,99 @@
+# Temporal validity example (RFC-0010, SPEC §4.22 + §15.13).
+#
+# Demonstrates the bi-temporal `temporal` block: valid-time (when knowledge is
+# true in the world) and transaction-time (when the manifest recorded it), plus
+# future-dated rollout, supersession chains, and expiring runbooks. Validates
+# clean under `kcp validate`; query it with `kcp query "..." --as-of <date>`
+# once your bridge implements §15.13 temporal filtering.
+kcp_version: "0.21"
+project: platform-security
+version: 2.0.0
+updated: "2026-03-15"
+language: en
+license: "Apache-2.0"
+
+# Root-level temporal provides defaults; unit-level overrides field-by-field.
+# Here it records when this manifest version was authored (transaction time).
+temporal:
+  recorded_at: "2026-03-15"
+
+units:
+  - id: overview
+    path: README.md
+    intent: "What is the platform security knowledge base and how is it versioned over time?"
+    scope: global
+    audience: [human, agent]
+    triggers: [overview, getting started]
+    # No temporal block: always valid (backward-compatible default).
+
+  # --- Future-dated policy rollout: declare the new policy before it takes
+  #     effect, without disrupting agents running today. ---
+  - id: mfa-policy-legacy
+    path: policies/mfa-2025.md
+    intent: "What MFA requirements apply to agent authentication (2025 policy)?"
+    scope: project
+    audience: [developer, operator, agent]
+    triggers: [mfa, authentication, policy]
+    temporal:
+      valid_from: "2025-01-01"
+      valid_until: "2026-03-31"          # retired at the end of Q1 2026
+      superseded_by: mfa-policy-2026      # successor — no "stale" warning
+
+  - id: mfa-policy-2026
+    path: policies/mfa-2026.md
+    intent: "What MFA requirements apply to agent authentication (current policy)?"
+    scope: project
+    audience: [developer, operator, agent]
+    triggers: [mfa, authentication, policy]
+    temporal:
+      valid_from: "2026-04-01"            # activates automatically — no manifest edit needed
+      valid_until: null                   # open-ended
+      recorded_at: "2026-01-28"           # pre-authored, future-dated
+
+  # --- Expiring runbook with a successor that activates post-migration. ---
+  - id: db-migration-runbook
+    path: ops/migration-runbook.md
+    intent: "How do I run the Q2 database migration?"
+    scope: project
+    audience: [operator, agent]
+    triggers: [migration, database, runbook]
+    temporal:
+      valid_from: "2026-04-01"
+      valid_until: "2026-06-30"           # only relevant during the migration window
+      recorded_at: "2026-03-28"
+      superseded_by: db-runbook-postmigration
+
+  - id: db-runbook-postmigration
+    path: ops/deploy-postmigration.md
+    intent: "How do I deploy to the database after the Q2 migration completes?"
+    scope: project
+    audience: [operator, agent]
+    triggers: [deploy, database, runbook]
+    temporal:
+      valid_from: "2026-07-01"            # not yet active
+
+  # --- Audit trail: a verified compliance unit with provenance, valid since
+  #     2024 and still current. `as_of: "2025-06-01"` reconstructs past state. ---
+  - id: gdpr-retention
+    path: compliance/gdpr-retention.md
+    intent: "What are the GDPR data retention rules for this platform?"
+    scope: project
+    audience: [operator, agent, security_auditor]
+    triggers: [gdpr, retention, compliance, data residency]
+    temporal:
+      valid_from: "2024-01-01"
+      valid_until: null
+      recorded_at: "2026-03-01"
+    discovery:
+      verification_status: verified
+      verified_at: "2026-03-01"
+      verified_by: "ed25519:platform-compliance-2026"   # §4.18: verified carries a verifier
+      confidence: 0.95
+
+relationships:
+  - from: mfa-policy-2026
+    to: mfa-policy-legacy
+    type: supersedes
+  - from: db-runbook-postmigration
+    to: db-migration-runbook
+    type: supersedes

--- a/examples/temporal-validity/ops/deploy-postmigration.md
+++ b/examples/temporal-validity/ops/deploy-postmigration.md
@@ -1,0 +1,3 @@
+# Post-Migration Deploy Runbook
+
+Deployment procedure for the new database, effective once the Q2 migration completes (2026-07-01).

--- a/examples/temporal-validity/ops/migration-runbook.md
+++ b/examples/temporal-validity/ops/migration-runbook.md
@@ -1,0 +1,3 @@
+# Q2 Database Migration Runbook
+
+Step-by-step procedure for the Q2 2026 database migration. Valid only during the migration window (2026-04-01 to 2026-06-30).

--- a/examples/temporal-validity/policies/mfa-2025.md
+++ b/examples/temporal-validity/policies/mfa-2025.md
@@ -1,0 +1,3 @@
+# MFA Policy (2025)
+
+Legacy multi-factor authentication requirements for agent authentication, effective 2025-01-01 through 2026-03-31. Superseded by the 2026 policy.

--- a/examples/temporal-validity/policies/mfa-2026.md
+++ b/examples/temporal-validity/policies/mfa-2026.md
@@ -1,0 +1,3 @@
+# MFA Policy (2026)
+
+Current multi-factor authentication requirements for agent authentication, effective 2026-04-01.


### PR DESCRIPTION
## Summary

The content gap was in `examples/`: the directory was frozen at the **v0.12 era** — a feature scan found **zero** coverage of `temporal`, `composition`, `content_hash`, `content_structure`, or `not_for` across every example manifest, and the README's flagship snippet still declared `kcp_version: "0.10"`.

## Adds `examples/temporal-validity/`

A platform-security knowledge base that versions itself over time — the v0.19/v0.20 marquee feature (RFC-0010, SPEC §4.22 / §15.13) that had no example at all:

- **Future-dated rollout** — `mfa-policy-2026` carries a future `valid_from` and activates on its date with no manifest edit.
- **Supersession** — `mfa-policy-legacy → mfa-policy-2026` via `valid_until` + `superseded_by` (retires cleanly, no "stale" warning, audit trail preserved).
- **Expiring runbook** — `db-migration-runbook` bounded to the migration window, superseded by the post-migration runbook.
- **Two clocks** — root-level `temporal.recorded_at` as a manifest-wide transaction-time default.
- **Verified provenance** — a compliance unit with `discovery.verification_status: verified` + `verified_by`.
- README documents `as_of` / `include_all_temporal` point-in-time queries.

Self-contained with stub content files so `kcp validate` reports **no errors or warnings** — which also exercises the new `superseded_by` cycle / empty-window / stale checks on a realistic clean manifest. Wired into `examples/README.md` and bumped its minimal snippet 0.10 → 0.21.

Example/doc-only; no code paths touched.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_