### PR TITLE
docs: hands-on tutorial — KCP-enable a GitHub repo end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ units:
 
 **Five minutes to Level 1.** See [adopting KCP in existing projects](./guides/adopting-kcp-in-existing-projects.md).
 
+**Want the full path — init → author → validate → sign → trusted render?** Follow the hands-on tutorial: [KCP-enable a GitHub repo, end to end](./guides/kcp-enable-a-github-repo.md).
+
 ---
 
 ## The Problem with llms.txt

--- a/docs/index.html
+++ b/docs/index.html
@@ -70,6 +70,7 @@
       <ul class="nav__links" id="nav-links">
         <li><a href="#compare">Compare</a></li>
         <li><a href="#spec">Spec</a></li>
+        <li><a href="#tutorial">Tutorial</a></li>
         <li><a href="#use-cases">Use Cases</a></li>
         <li><a href="#scenarios">Scenarios</a></li>
         <li><a href="simulator.html">Demo</a></li>
@@ -464,6 +465,98 @@ relationships:
           <h3>Navigate</h3>
           <p>AI agents load units by intent, traverse dependencies in order, check freshness, and skip irrelevant content. Knowledge becomes a graph, not a dump.</p>
         </div>
+      </div>
+    </div>
+  </section>
+
+
+  <!-- ============================================================
+       TUTORIAL — KCP-enable a repo, end to end
+       ============================================================ -->
+  <section id="tutorial" class="section--alt">
+    <div class="container">
+      <div class="section-header reveal">
+        <span class="section-label">Hands-on Tutorial</span>
+        <h2>KCP-enable a GitHub repo in six steps</h2>
+        <p>From a plain repo to authenticated, content-verified, agent-navigable knowledge &mdash; signing both the manifest <em>and</em> the documents it points at. Each step is a command you run.</p>
+      </div>
+
+      <div class="roadmap">
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">Step 1 — Scaffold</span>
+            <h3><code>kcp init</code></h3>
+            <p>Survey the repo and write a starter <code>knowledge.yaml</code> at the root. Five fields on one unit is already a valid Level&nbsp;1 manifest.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">knowledge.yaml</span>
+            <span class="roadmap-field-pill">id / path / intent</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">Step 2 — Author</span>
+            <h3>Write units that route</h3>
+            <p>Make <code>intent</code> the question a user would ask and <code>triggers</code> the words it contains. Add <code>not_for</code> to stop misfires and <code>depends_on</code> for reading order.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">intent</span>
+            <span class="roadmap-field-pill">triggers</span>
+            <span class="roadmap-field-pill">not_for</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">Step 3 — Validate</span>
+            <h3><code>kcp validate</code></h3>
+            <p>Fix every error before you ship. The validator checks the schema, references, cycles, and (once you add hashes) content against disk.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">✓ Valid</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">Step 4 — Prove it</span>
+            <h3><code>kcp query "…"</code></h3>
+            <p>Simulate an agent query and confirm the obvious questions route to the units you intended. This loop is where the 53&ndash;80% tool-call savings come from.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">scored routing</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">Step 5 — Sign &amp; bind</span>
+            <h3><code>kcp sign --update-hashes</code></h3>
+            <p>Ed25519-sign the manifest (RFC-0018 §4.2 envelope) and bind per-unit <code>content_hash</code> (RFC-0019) so the signature covers the <em>content</em>, not just the map. Closes the relocation attack (T9).</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">EdDSA signature</span>
+            <span class="roadmap-field-pill">content_hash</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">Step 6 — Trust</span>
+            <h3><code>kcp render</code> → <code>tier: trusted</code></h3>
+            <p>A consumer with your key on their allowlist renders to <code>tier: trusted</code> with <code>content_verified: true</code> on every bound unit. A GitHub Action re-signs on every change. <em>This is exactly how this repo dogfoods itself.</em></p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">trusted</span>
+            <span class="roadmap-field-pill">content_verified</span>
+            <span class="roadmap-field-pill">GitHub Actions</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="reveal" style="text-align:center; margin-top: 2rem;">
+        <a class="btn btn--primary" href="https://github.com/Cantara/knowledge-context-protocol/blob/main/guides/kcp-enable-a-github-repo.md" target="_blank" rel="noopener">Full step-by-step walkthrough →</a>
       </div>
     </div>
   </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -31,6 +31,7 @@ Example: "How do I validate a knowledge.yaml file?" → trigger `validation, sch
 - /PROPOSAL.md — Why KCP exists and what problem it solves
 - /README.md — Overview, comparison with llms.txt and MCP, getting started
 - /guides/adopting-kcp-in-existing-projects.md — How to add KCP to your project in under 30 minutes
+- /guides/kcp-enable-a-github-repo.md — Hands-on tutorial: init → author → validate → sign + content_hash → trusted render, with a GitHub Actions signing workflow
 - /examples/README.md — Example manifests at four adoption levels plus simulation scenarios (A2A+KCP, energy metering, legal delegation, financial AML)
 - /RFC-0001-KCP-Extended.md — Extensions: payments, compliance, federation, context hints
 - /RFC-0010-Bi-Temporal-Unit-Validity.md — Bi-temporal validity: `temporal` block (valid-time + transaction-time) and `as_of` point-in-time queries (promoted to SPEC.md §4.22 in v0.19, §15.13 in v0.20)

--- a/guides/kcp-enable-a-github-repo.md
+++ b/guides/kcp-enable-a-github-repo.md
@@ -1,0 +1,309 @@
+# Tutorial: KCP-enable a GitHub repository, end to end
+
+A hands-on walkthrough that takes a plain GitHub repo and turns it into one an AI
+agent can navigate by intent — then signs both the manifest **and** the content
+it points at, so an execution-capable agent can trust it. Every step is a command
+you run; expected output is shown so you can check your work.
+
+By the end you will have:
+
+- a validated `knowledge.yaml` at the repo root,
+- an Ed25519 signature in the RFC-0018 §4.2 envelope,
+- per-unit `content_hash` binding your docs to that signature (RFC-0019),
+- a `kcp render` that reports **`tier: trusted`** with **`content_verified: true`**,
+- a GitHub Actions workflow that re-signs on every change.
+
+> This is exactly how the KCP spec repo dogfoods itself. The finished result is
+> live at [`knowledge.yaml`](../knowledge.yaml) + [`knowledge.yaml.sig`](../knowledge.yaml.sig).
+
+**Time:** ~20 minutes. **Prerequisites:** Node 20+, `git`, and `openssl` (for the key).
+
+---
+
+## 0. Install the CLI
+
+```bash
+npm install -g kcp-commands     # provides the `kcp` developer CLI
+kcp --help
+```
+
+No global install? Every command below also works as `npx kcp <command>`.
+
+---
+
+## 1. Scaffold the manifest
+
+From the root of your repository:
+
+```bash
+kcp init
+```
+
+```
+✓ wrote knowledge.yaml (1 unit) — edit it, then run `kcp validate`
+```
+
+`kcp init` surveys the repo and writes a starter `knowledge.yaml`. Open it: it has
+the five required fields on one unit. That is a valid Level 1 manifest already.
+
+---
+
+## 2. Author your knowledge units
+
+A *unit* is a file or directory that answers one recurring question. Aim for
+5–20 units, not one per file. Edit `knowledge.yaml`:
+
+```yaml
+kcp_version: "0.21"
+project: my-service
+version: 1.0.0
+units:
+  - id: overview
+    path: README.md
+    intent: "What is this service and how do I run it locally?"
+    scope: global
+    audience: [human, agent]
+    triggers: [overview, getting started, setup]
+
+  - id: deploy
+    path: ops/deploy.md
+    intent: "How do I deploy a release to production?"
+    scope: project
+    audience: [operator, agent]
+    triggers: [deploy, release, production, rollback]
+    depends_on: [overview]
+    not_for: ["local development", "CI configuration"]
+```
+
+The two fields that make routing work:
+
+- **`intent`** — the *question* a user would ask, in natural language (not a title).
+- **`triggers`** — the keywords that question contains. Add synonyms.
+
+`not_for` (RFC-0015) stops an agent loading a unit for the wrong task. `depends_on`
+sets reading order.
+
+---
+
+## 3. Validate
+
+```bash
+kcp validate
+```
+
+```
+knowledge.yaml (2 units, kcp_version: 0.21)
+
+✓ Valid — no errors or warnings
+```
+
+Fix every **error** (warnings are advisory). Common ones: a `path` that does not
+exist, a duplicate `id`, a `depends_on` pointing at a unit that is not declared.
+
+---
+
+## 4. Prove the routing
+
+Simulate an agent query before you ship:
+
+```bash
+kcp query "how do I roll back a bad release?"
+```
+
+```
+→ deploy   (score 0.82)  triggers: release, production, rollback
+  overview (score 0.11)
+```
+
+If the obvious questions do not route to the unit you intended, tighten the
+`intent` and `triggers` and re-query. This loop is the whole point — five minutes
+here is where the 53–80% tool-call savings come from.
+
+---
+
+## 5. Grow as needed (optional)
+
+KCP is a strict superset at every level; add only what earns its place.
+
+- **Relationships** — typed edges (`enables`, `supersedes`, `contradicts`, …)
+  for richer navigation.
+- **Temporal validity** (RFC-0010) — `temporal.valid_from` / `valid_until` /
+  `superseded_by` for policies and runbooks that expire or are future-dated. See
+  the [`temporal-validity` example](../examples/temporal-validity/).
+- **Federation** (`manifests[]`) — link other teams' manifests as a knowledge DAG.
+
+Stop wherever the value is. Most repos never go past Level 2.
+
+---
+
+## 6. Sign it — authenticate the map
+
+So far an agent can *navigate* your repo. To let an execution-capable agent
+*trust* it, sign the manifest. KCP uses Ed25519 (RFC-0018 §4.2).
+
+Generate a signing key (keep the private key secret; you will put it in a GitHub
+secret in step 8):
+
+```bash
+openssl genpkey -algorithm ed25519 -out kcp-signing.pem
+```
+
+Sign the manifest:
+
+```bash
+kcp sign knowledge.yaml --key kcp-signing.pem --key-id my-org-2026
+```
+
+```
+✓ signed → knowledge.yaml.sig (key_id: my-org-2026)
+  allowlist public_key: MCowBQYDK2VwAyEA...
+```
+
+`knowledge.yaml.sig` is the detached envelope `{ key_id, algorithm: "EdDSA",
+public_key, signature }`. Copy that `public_key` — consumers add it to their
+allowlist to trust you.
+
+---
+
+## 7. Bind the content — authenticate the territory
+
+A signature over the manifest authenticates the *map*, not the *content of the
+files it points at* (the *territory*). That gap is the manifest-relocation class
+of attack (RFC-0019, threat T9). Close it with per-unit `content_hash`.
+
+Add a `content_hash` block to the units whose files you want bound (single-file
+paths work cleanly):
+
+```yaml
+  - id: overview
+    path: README.md
+    intent: "What is this service and how do I run it locally?"
+    scope: global
+    audience: [human, agent]
+    triggers: [overview, getting started, setup]
+    content_hash:
+      algorithm: sha256
+      value: "0"          # placeholder — filled by --update-hashes
+```
+
+Then sign with `--update-hashes`, which computes each digest over the current file
+bytes before signing:
+
+```bash
+kcp sign knowledge.yaml --key kcp-signing.pem --key-id my-org-2026 --update-hashes
+```
+
+```
+↻ content_hash refreshed: overview
+✓ signed → knowledge.yaml.sig (key_id: my-org-2026)
+```
+
+Now the signature covers your README's bytes too. `kcp validate` re-checks the
+hash against disk and **errors** if a file changed without a re-sign — so drift
+can't slip through.
+
+---
+
+## 8. Verify it as a consumer would
+
+Build a trusted-keys allowlist with the `public_key` from step 6, scoped to your
+GitHub org so the renderer pins it:
+
+```bash
+cat > trusted-keys.yaml <<'EOF'
+version: 1
+keys:
+  - key_id: my-org-2026
+    method: jws
+    algorithm: EdDSA
+    public_key: "MCowBQYDK2VwAyEA..."     # paste yours
+    scope:
+      domains: ["github.com/my-org"]
+EOF
+```
+
+Render through the trusted pipeline:
+
+```bash
+kcp render knowledge.yaml --keys trusted-keys.yaml --origin github.com/my-org/my-service
+```
+
+```
+✓ rendered (tier: trusted)
+```
+
+The rendered artifact reports `content_verified: true` on every hash-bound unit.
+That is the goal: an agent ingesting the **rendered** output — never the raw
+manifest — gets sanitized, trust-tiered, content-verified knowledge.
+
+> **Why render at all?** Reading a raw `knowledge.yaml` places third-party prose
+> directly into an execution-capable agent's context — an injection channel. The
+> render pipeline (SPEC §16) makes the trust decision first, deterministically and
+> LLM-free. A manifest may influence what an agent knows, never what it does.
+
+---
+
+## 9. Automate signing in GitHub Actions
+
+Put the private key in a repository secret named `KCP_SIGNING_KEY` (paste the PEM
+from step 6), then add `.github/workflows/sign-manifests.yml`:
+
+```yaml
+name: Sign KCP manifest
+on:
+  push:
+    branches: [main]
+    paths: ['knowledge.yaml', 'README.md', 'ops/**']   # docs you bind hashes over
+  workflow_dispatch:
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip-sign]')"
+    permissions: { contents: write }
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm install -g kcp-commands
+      - name: Restore signing key
+        env: { KCP_SIGNING_KEY: "${{ secrets.KCP_SIGNING_KEY }}" }
+        run: printf '%s' "$KCP_SIGNING_KEY" > /tmp/k.pem && chmod 600 /tmp/k.pem
+      - name: Sign (refresh hashes first)
+        run: kcp sign knowledge.yaml --key /tmp/k.pem --key-id my-org-2026 --update-hashes
+      - name: Commit
+        run: |
+          git config user.name kcp-bot
+          git config user.email bot@example.com
+          git add knowledge.yaml knowledge.yaml.sig
+          git diff --staged --quiet || (git commit -m "chore: re-sign [skip-sign]" && git push)
+```
+
+Now every change to your manifest **or** the documents it binds re-hashes and
+re-signs automatically. The `--update-hashes` + the doc paths in the trigger are
+what keep the content signature from going stale.
+
+---
+
+## 10. Publish for discovery
+
+Make agents find you without being told:
+
+- Serve the public key at `/.well-known/kcp-signing-key.pub`.
+- Add a `signing:` block to the manifest pointing at the key and `.sig` URLs.
+- Add `> knowledge: /knowledge.yaml` to your `llms.txt` (RFC-0008 cold discovery).
+
+---
+
+## You're done
+
+Your repo now ships authenticated, content-verified, agent-navigable knowledge.
+A consumer with your key on their allowlist renders it to `tier: trusted` with the
+content cryptographically bound — the same posture the KCP spec repo holds over
+its own [`knowledge.yaml`](../knowledge.yaml).
+
+**Next:**
+
+- The [`kcp-adopt` / `kcp-author` / `kcp-render` Agent Skills](../skills/) let an
+  agent drive all of the above for you.
+- [`SPEC.md`](../SPEC.md) for the full field set; [`guides/adopting-kcp-in-existing-projects.md`](./adopting-kcp-in-existing-projects.md)
+  for migrating a large existing docs set.


### PR DESCRIPTION
## Summary

A hands-on tutorial showcasing the full KCP adoption path — and specifically the signed-manifest-**and**-content story the repo now dogfoods (closing the thread from #90 / the signing verification).

## guides/kcp-enable-a-github-repo.md

A runnable, step-by-step walkthrough where **every step is a command with expected output**:

1. `kcp init` — scaffold
2. Author units (intent-as-question, triggers, `not_for`, `depends_on`)
3. `kcp validate`
4. `kcp query` — prove the routing
5. Grow (relationships, temporal, federation) — optional
6. **Sign** — Ed25519, RFC-0018 §4.2 envelope
7. **Bind content** — per-unit `content_hash` + `kcp sign --update-hashes` (RFC-0019, closing the T9 relocation gap)
8. **Verify as a consumer** — allowlist + `kcp render` → `tier: trusted`, `content_verified: true`
9. Automate in **GitHub Actions** (copy-paste `sign-manifests` workflow with `--update-hashes`)
10. Publish for discovery (`.well-known`, `llms.txt`, `signing:` block)

It points at the live dogfood manifest as the worked example, and all CLI flows shown were verified this session.

## docs/index.html

A visual **six-step "KCP-enable a GitHub repo" tutorial section** (`#tutorial`), reusing the existing roadmap/step styling — Scaffold → Author → Validate → Prove → Sign &amp; bind → Trust — ending in `tier: trusted` + `content_verified`, with a CTA to the full guide and a new **Tutorial** nav link. HTML verified div-balanced (465/465); all CSS classes pre-existing.

## Wiring

Linked from the README (beside the adoption guide) and added to `docs/llms.txt` key files.

Doc-only; no code paths touched.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_