### PR TITLE
feat(bridge): federated temporal filtering (C18) across TS, Python, Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Implemented — federated temporal filtering (C18) in all three bridges
+
+- The TypeScript, Python, and Java MCP bridges now apply manifest-level (federation source)
+  temporal filtering at query time (RFC-0021, SPEC §3.6 / §16.5 C18). Each `manifests[]`
+  entry's `local_mirror` is associated with the sub-manifest loaded from it, so its units
+  inherit the source's `temporal` window. On `search_knowledge`, a sub-manifest whose source
+  window excludes the effective date (`as_of`, else today) is skipped *before* scoring and
+  *before* unit-level temporal — none of its units are scored or returned. `include_all_temporal`
+  bypasses the stage, consistent with the unit-level semantics. This is the resolution-time half
+  of C18; parsers already exposed `manifests[].temporal` and detected `superseded_by` cycles.
+- `list_manifests` now surfaces each federation entry's `temporal` block and a computed
+  `temporally_active` flag (evaluated against today).
+- Validated: 5 discriminating tests per bridge (mutation-verified) over a shared `fed-temporal`
+  fixture — a compliance hub federating an expired GDPR-2018 corpus and an active GDPR-2023
+  corpus with disjoint source windows, where neither corpus declares unit-level temporal so the
+  source window is the only discriminator.
+
 ### Implemented — composition resolution + enforcing C17 in `kcp render`
 
 - `kcp render` now resolves a `composition` block (RFC-0020/0022 §3.11): fetches/reads

--- a/RFC-0021-Federation-Temporal.md
+++ b/RFC-0021-Federation-Temporal.md
@@ -266,6 +266,20 @@ parsers that do not implement temporal evaluation MUST treat all units as active
 | `superseded_by` cycle detection on `manifests[]` entries | Level 1 | Parsers MUST detect and report as manifest error. |
 | `include_all_temporal` bypasses manifest-level filtering | Level 2 | Consistent with existing `include_all_temporal` semantics (§15.13). |
 
+### Implementation status
+
+All four reference implementations now satisfy this RFC:
+
+- **Parsers (Level 1):** The TypeScript, Python, and Java parsers read and expose
+  `manifests[].temporal` and detect `superseded_by` cycles among `manifests[]` entries as a
+  manifest error.
+- **Bridges (Level 2):** The TypeScript, Python, and Java MCP bridges apply manifest-level
+  temporal filtering at query time. A sub-manifest loaded from a `local_mirror` inherits its
+  `manifests[]` entry's `temporal` window; on `search_knowledge` a source outside the effective
+  date window (`as_of`, else today) is skipped before scoring and before unit-level temporal,
+  and `include_all_temporal: true` bypasses the stage. `list_manifests` exposes each entry's
+  `temporal` block and a computed `temporally_active` flag.
+
 ---
 
 *Co-authored with Claude. The design and normative choices are mine; Claude helped draft

--- a/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
+++ b/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
@@ -9,6 +9,7 @@ import no.cantara.kcp.KcpParser;
 import no.cantara.kcp.model.KnowledgeManifest;
 import no.cantara.kcp.model.KnowledgeUnit;
 import no.cantara.kcp.model.ManifestRef;
+import no.cantara.kcp.model.Temporal;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -36,6 +37,10 @@ public final class KcpServer {
         Map<String, ResourceHandler> handlers,
         Map<String, KnowledgeUnit> units,
         Map<String, Path> unitDirs,
+        // unit.id -> the federation source's temporal window (manifests[].temporal, §3.6),
+        // for units from a sub-manifest associated with a manifests[] entry via local_mirror.
+        // Primary units and unassociated sub-manifests have no entry (always included).
+        Map<String, Temporal> sourceTemporals,
         KnowledgeManifest primaryManifest,
         int totalUnits,
         int manifestTokenTotal
@@ -85,15 +90,27 @@ public final class KcpServer {
         // ── unit context: unit.id -> [unit, manifestDir]  (primary wins on dup) ───
         Map<String, KnowledgeUnit> unitMap  = new LinkedHashMap<>();
         Map<String, Path>          dirMap   = new LinkedHashMap<>();
+        Map<String, Temporal>      srcTempMap = new LinkedHashMap<>();
         for (KnowledgeUnit unit : manifest.units()) {
             unitMap.put(unit.id(), unit);
             dirMap.put(unit.id(), manifestDir);
+        }
+
+        // Associate each federation entry's local_mirror (resolved against the primary dir)
+        // with its manifests[] declaration so a sub-manifest loaded from disk inherits its
+        // source temporal window (§3.6 / C18). Keyed by the resolved absolute mirror path.
+        Map<Path, ManifestRef> mirrorToRef = new LinkedHashMap<>();
+        for (ManifestRef ref : manifest.manifests()) {
+            if (ref.localMirror() != null && !ref.localMirror().isEmpty() && manifestDir != null) {
+                mirrorToRef.put(manifestDir.resolve(ref.localMirror()).normalize().toAbsolutePath(), ref);
+            }
         }
 
         // ── merge sub-manifests ───────────────────────────────────────────────────
         for (Path subPath : subManifestPaths) {
             Path resolvedSub = subPath.toAbsolutePath();
             Path subDir = resolvedSub.getParent();
+            ManifestRef sourceRef = mirrorToRef.get(resolvedSub.normalize());
             KnowledgeManifest subManifest;
             try {
                 subManifest = KcpParser.parse(resolvedSub);
@@ -112,6 +129,9 @@ public final class KcpServer {
                 }
                 unitMap.put(unit.id(), unit);
                 dirMap.put(unit.id(), subDir);
+                if (sourceRef != null && sourceRef.temporal() != null) {
+                    srcTempMap.put(unit.id(), sourceRef.temporal());
+                }
                 added++;
             }
             System.err.printf("  [kcp-mcp] loaded sub-manifest %s — %d unit(s)%n",
@@ -159,7 +179,7 @@ public final class KcpServer {
                 if (te instanceof Number n) manifestTokenTotal += n.intValue();
             }
         }
-        return new ResourceSet(resources, handlers, unitMap, dirMap, manifest, unitMap.size(), manifestTokenTotal);
+        return new ResourceSet(resources, handlers, unitMap, dirMap, srcTempMap, manifest, unitMap.size(), manifestTokenTotal);
     }
 
     // ── Search scoring (package-private for tests) ─────────────────────────────
@@ -244,6 +264,19 @@ public final class KcpServer {
         if (t == null) return true;
         if (t.validFrom()  != null && t.validFrom().compareTo(asOf)  > 0) return false;
         if (t.validUntil() != null && t.validUntil().compareTo(asOf) < 0) return false;
+        return true;
+    }
+
+    /**
+     * §3.6 / C18 manifest-level (federation source) temporal check. Returns true when a
+     * sub-manifest is relevant as a knowledge source on the effective date. A source with no
+     * temporal block is always included. Applied <em>before</em> unit-level temporal: a source
+     * filtered out here contributes no units at all — the bridge skips it entirely.
+     */
+    static boolean isSourceTemporallyIncluded(Temporal t, String effectiveDate) {
+        if (t == null) return true;
+        if (t.validFrom()  != null && t.validFrom().compareTo(effectiveDate)  > 0) return false;
+        if (t.validUntil() != null && t.validUntil().compareTo(effectiveDate) < 0) return false;
         return true;
     }
 
@@ -464,6 +497,15 @@ public final class KcpServer {
         for (Map.Entry<String, KnowledgeUnit> entry : rs.units().entrySet()) {
             KnowledgeUnit unit = entry.getValue();
 
+            // §3.6 / C18: manifest-level (federation source) temporal filter, applied before
+            // scoring and before unit-level temporal. A source outside its validity window is
+            // skipped entirely — none of its units are scored or returned. Bypassed by
+            // include_all_temporal, consistent with the unit-level semantics below.
+            if (!includeAllTemporal && !isSourceTemporallyIncluded(
+                    rs.sourceTemporals().get(entry.getKey()), temporalDate)) {
+                continue;
+            }
+
             // Apply filters
             if (audienceFilter != null && (unit.audience() == null
                     || !unit.audience().contains(audienceFilter))) {
@@ -666,7 +708,10 @@ public final class KcpServer {
             sb.append("\"has_local_mirror\":").append(m.localMirror() != null && !m.localMirror().isEmpty()).append(",");
             sb.append("\"update_frequency\":").append(m.updateFrequency() != null ? "\"" + escapeJson(m.updateFrequency()) + "\"" : "null").append(",");
             sb.append("\"version_pin\":").append(m.versionPin() != null ? "\"" + escapeJson(m.versionPin()) + "\"" : "null").append(",");
-            sb.append("\"version_policy\":").append(m.versionPolicy() != null ? "\"" + escapeJson(m.versionPolicy()) + "\"" : "null");
+            sb.append("\"version_policy\":").append(m.versionPolicy() != null ? "\"" + escapeJson(m.versionPolicy()) + "\"" : "null").append(",");
+            sb.append("\"temporal\":").append(temporalJson(m.temporal())).append(",");
+            sb.append("\"temporally_active\":").append(
+                isSourceTemporallyIncluded(m.temporal(), LocalDate.now().toString()));
             sb.append("}");
         }
         sb.append("\n]");
@@ -674,6 +719,19 @@ public final class KcpServer {
         return new McpSchema.CallToolResult(
             List.of(new McpSchema.TextContent(sb.toString())),
             false, null, null);
+    }
+
+    /** Serialize a Temporal block to a JSON object (only non-null fields), or {@code null}. */
+    static String temporalJson(Temporal t) {
+        if (t == null) return "null";
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        if (t.validFrom() != null)    { sb.append("\"valid_from\":\"").append(escapeJson(t.validFrom())).append("\""); first = false; }
+        if (t.validUntil() != null)   { if (!first) sb.append(","); sb.append("\"valid_until\":\"").append(escapeJson(t.validUntil())).append("\""); first = false; }
+        if (t.recordedAt() != null)   { if (!first) sb.append(","); sb.append("\"recorded_at\":\"").append(escapeJson(t.recordedAt())).append("\""); first = false; }
+        if (t.supersededBy() != null) { if (!first) sb.append(","); sb.append("\"superseded_by\":\"").append(escapeJson(t.supersededBy())).append("\""); }
+        sb.append("}");
+        return sb.toString();
     }
 
     // ── Prompt registration ───────────────────────────────────────────────────

--- a/bridge/java/src/test/java/no/cantara/kcp/mcp/KcpServerToolsTest.java
+++ b/bridge/java/src/test/java/no/cantara/kcp/mcp/KcpServerToolsTest.java
@@ -411,4 +411,70 @@ class KcpServerToolsTest {
         assertTrue(text.contains("\"id\":\"future-feature\""),
             "future-feature should appear when include_all_temporal is true");
     }
+
+    // ── Federation temporal (RFC-0021 / C18) ──────────────────────────────────
+    // The hub federates two GDPR corpora via local_mirror with disjoint source windows —
+    // gdpr-2018 (valid_until 2023-09-01) and gdpr-2023 (valid_from 2023-09-01). Neither corpus
+    // declares unit-level temporal, so manifests[].temporal is the only thing that includes or
+    // excludes their units. Both consent units match "consent gdpr".
+
+    private static Path subFixture(String name, String sub) {
+        URL url = KcpServerToolsTest.class.getClassLoader()
+            .getResource("fixtures/" + name + "/" + sub + "/knowledge.yaml");
+        assertNotNull(url, "sub-fixture not found: " + name + "/" + sub);
+        return Paths.get(url.getPath());
+    }
+
+    private static KcpServer.ResourceSet fedRs() throws Exception {
+        return KcpServer.buildResources(
+            fixture("fed-temporal"), false,
+            List.of(subFixture("fed-temporal", "mirror-old"),
+                    subFixture("fed-temporal", "mirror-new")));
+    }
+
+    private static String fedSearch(KcpServer.ResourceSet rs, Map<String, Object> args) {
+        McpSchema.CallToolRequest request = new McpSchema.CallToolRequest("search_knowledge", args);
+        McpSchema.CallToolResult result = KcpServer.handleSearchKnowledge(
+            request, rs, KcpMapper.projectSlug(rs.primaryManifest().project()));
+        return ((McpSchema.TextContent) result.content().get(0)).text();
+    }
+
+    @Test void fedTemporalAsOfActiveWindowExcludesExpiredSource() throws Exception {
+        // 2026 is after gdpr-2018's valid_until and inside gdpr-2023's window.
+        String text = fedSearch(fedRs(), Map.of("query", "consent gdpr", "as_of", "2026-06-13"));
+        assertTrue(text.contains("\"id\":\"gdpr-2023-consent\""), text);
+        assertFalse(text.contains("\"id\":\"gdpr-2018-consent\""), text);
+    }
+
+    @Test void fedTemporalAsOfExpiredWindowIncludesIt() throws Exception {
+        // 2020 is inside gdpr-2018's window and before gdpr-2023's valid_from.
+        String text = fedSearch(fedRs(), Map.of("query", "consent gdpr", "as_of", "2020-01-01"));
+        assertTrue(text.contains("\"id\":\"gdpr-2018-consent\""), text);
+        assertFalse(text.contains("\"id\":\"gdpr-2023-consent\""), text);
+    }
+
+    @Test void fedTemporalIncludeAllReturnsBothSources() throws Exception {
+        String text = fedSearch(fedRs(), Map.of("query", "consent gdpr", "include_all_temporal", true));
+        assertTrue(text.contains("\"id\":\"gdpr-2018-consent\""), text);
+        assertTrue(text.contains("\"id\":\"gdpr-2023-consent\""), text);
+    }
+
+    @Test void fedTemporalAsOfAndIncludeAllConflict() throws Exception {
+        McpSchema.CallToolRequest request = new McpSchema.CallToolRequest("search_knowledge",
+            Map.of("query", "consent gdpr", "as_of", "2020-01-01", "include_all_temporal", true));
+        McpSchema.CallToolResult result = KcpServer.handleSearchKnowledge(
+            request, fedRs(), "fed-temporal-hub");
+        assertTrue(result.isError());
+        assertTrue(((McpSchema.TextContent) result.content().get(0)).text()
+            .contains("temporal_query_conflict"));
+    }
+
+    @Test void fedTemporalListManifestsExposesTemporalAndActivity() throws Exception {
+        McpSchema.CallToolResult result = KcpServer.handleListManifests(fedRs().primaryManifest());
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertTrue(text.contains("\"valid_until\":\"2023-09-01\""), text);
+        // gdpr-2018 expired as of today; gdpr-2023 active. Both flags present.
+        assertTrue(text.contains("\"temporally_active\":false"), text);
+        assertTrue(text.contains("\"temporally_active\":true"), text);
+    }
 }

--- a/bridge/java/src/test/resources/fixtures/fed-temporal/README.md
+++ b/bridge/java/src/test/resources/fixtures/fed-temporal/README.md
@@ -1,0 +1,3 @@
+# Compliance Hub
+
+Federation entry point for GDPR compliance corpora.

--- a/bridge/java/src/test/resources/fixtures/fed-temporal/knowledge.yaml
+++ b/bridge/java/src/test/resources/fixtures/fed-temporal/knowledge.yaml
@@ -1,0 +1,32 @@
+kcp_version: "0.21"
+project: fed-temporal-hub
+version: 1.0.0
+
+# A compliance hub federating two GDPR corpora. The 2018 corpus was superseded by
+# the 2023 corpus; its source window has closed. Manifest-level temporal (§3.6) is
+# the only thing distinguishing the two — neither corpus declares unit-level temporal.
+manifests:
+  - id: gdpr-2018
+    url: "https://legal.example.com/gdpr-2018/knowledge.yaml"
+    relationship: governs
+    local_mirror: "./mirror-old/knowledge.yaml"
+    temporal:
+      valid_from: "2018-05-25"
+      valid_until: "2023-09-01"
+      superseded_by: gdpr-2023
+  - id: gdpr-2023
+    url: "https://legal.example.com/gdpr-2023/knowledge.yaml"
+    relationship: governs
+    local_mirror: "./mirror-new/knowledge.yaml"
+    temporal:
+      valid_from: "2023-09-01"
+
+units:
+  - id: hub-overview
+    path: README.md
+    intent: "Compliance hub overview and federation entry point"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["compliance", "hub"]
+
+relationships: []

--- a/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-new/consent.md
+++ b/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-new/consent.md
@@ -1,0 +1,3 @@
+# GDPR 2023 Consent
+
+Updated consent requirements and lawful basis under the 2023 corpus.

--- a/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-new/knowledge.yaml
+++ b/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-new/knowledge.yaml
@@ -1,0 +1,11 @@
+kcp_version: "0.21"
+project: gdpr-2023-corpus
+version: 1.0.0
+
+units:
+  - id: gdpr-2023-consent
+    path: consent.md
+    intent: "GDPR 2023 updated consent requirements and lawful basis"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["consent", "gdpr", "lawful basis"]

--- a/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-old/consent.md
+++ b/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-old/consent.md
@@ -1,0 +1,3 @@
+# GDPR 2018 Consent
+
+Consent requirements and lawful basis under the original 2018 corpus.

--- a/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-old/knowledge.yaml
+++ b/bridge/java/src/test/resources/fixtures/fed-temporal/mirror-old/knowledge.yaml
@@ -1,0 +1,11 @@
+kcp_version: "0.21"
+project: gdpr-2018-corpus
+version: 1.0.0
+
+units:
+  - id: gdpr-2018-consent
+    path: consent.md
+    intent: "GDPR 2018 consent requirements and lawful basis under the original corpus"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["consent", "gdpr", "lawful basis"]

--- a/bridge/python/kcp_mcp/server.py
+++ b/bridge/python/kcp_mcp/server.py
@@ -90,11 +90,25 @@ def create_server(
         u.id: (u, manifest_dir) for u in manifest.units
     }
 
+    # Maps unit_id → the federation source's temporal window (manifests[].temporal, §3.6),
+    # for units that came from a sub-manifest associated with a manifests[] entry. Primary
+    # units and sub-manifests not declared as a local_mirror have no entry (always included).
+    source_temporal: dict[str, object] = {}
+
+    # Associate each federation entry's local_mirror (resolved against the primary dir) with
+    # its manifests[] declaration, so a sub-manifest loaded from disk inherits its source
+    # temporal window (§3.6 / C18). Keyed by the resolved absolute mirror path.
+    mirror_to_ref: dict[Path, object] = {}
+    for ref in manifest.manifests:
+        if ref.local_mirror:
+            mirror_to_ref[(manifest_dir / ref.local_mirror).resolve()] = ref
+
     # Load sub-manifests and merge units
     added_total = 0
     for sub_path in sub_manifests:
         sub_path = Path(sub_path).resolve()
         sub_dir = sub_path.parent
+        source_ref = mirror_to_ref.get(sub_path)
         try:
             sub_manifest: KnowledgeManifest = parse(sub_path)
         except Exception as e:
@@ -110,6 +124,8 @@ def create_server(
                 )
                 continue
             unit_context[unit.id] = (unit, sub_dir)
+            if source_ref is not None and getattr(source_ref, "temporal", None) is not None:
+                source_temporal[unit.id] = source_ref.temporal
             added += 1
         added_total += added
         sys.stderr.write(
@@ -276,7 +292,7 @@ def create_server(
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         if name == "search_knowledge":
-            return _handle_search_knowledge(unit_context, slug, arguments or {})
+            return _handle_search_knowledge(unit_context, slug, arguments or {}, source_temporal)
         if name == "get_unit":
             return _handle_get_unit(unit_context, arguments or {})
         if name == "get_command_syntax":
@@ -392,6 +408,20 @@ def _is_temporally_active(unit, as_of: str) -> bool:
     return True
 
 
+def _is_source_temporally_included(temporal, effective_date: str) -> bool:
+    """§3.6 / C18 manifest-level (federation source) temporal check. Returns True when a
+    sub-manifest is relevant as a knowledge source on the effective date. A source with no
+    temporal block is always included. Applied *before* unit-level temporal: a source filtered
+    out here contributes no units at all — the bridge skips it entirely."""
+    if temporal is None:
+        return True
+    if temporal.valid_from is not None and temporal.valid_from > effective_date:
+        return False
+    if temporal.valid_until is not None and temporal.valid_until < effective_date:
+        return False
+    return True
+
+
 def _match_not_for(unit, terms: list[str]) -> str | None:
     """Return the first not_for phrase matched by any query term, or None (§15.11)."""
     not_for = getattr(unit, "not_for", None) or []
@@ -407,6 +437,7 @@ def _handle_search_knowledge(
     unit_context: dict,
     slug: str,
     arguments: dict,
+    source_temporal: dict | None = None,
 ) -> list[TextContent]:
     """Search knowledge units by query (RFC-0007 query baseline)."""
     query = arguments.get("query", "").strip()
@@ -426,10 +457,19 @@ def _handle_search_knowledge(
         }))]
     temporal_date = as_of if as_of is not None else _date.today().isoformat()
 
+    source_temporal = source_temporal or {}
     terms = query.split()
     results = []
 
     for unit_id, (unit, _unit_dir) in unit_context.items():
+        # §3.6 / C18: manifest-level (federation source) temporal filter, applied before
+        # scoring and before unit-level temporal. A source outside its validity window is
+        # skipped entirely — none of its units are scored or returned. Bypassed by
+        # include_all_temporal, consistent with the unit-level semantics below.
+        if not include_all_temporal and not _is_source_temporally_included(
+            source_temporal.get(unit_id), temporal_date
+        ):
+            continue
         # Filter: audience
         if audience_filter and audience_filter not in (unit.audience or []):
             continue
@@ -520,6 +560,18 @@ def _handle_get_command_syntax(
     return [TextContent(type="text", text=format_syntax_block(found))]
 
 
+def _temporal_to_dict(temporal) -> dict | None:
+    """Serialize a Temporal block to a plain dict for JSON output, or None when absent."""
+    if temporal is None:
+        return None
+    out: dict = {}
+    for field_name in ("valid_from", "valid_until", "recorded_at", "superseded_by"):
+        value = getattr(temporal, field_name, None)
+        if value is not None:
+            out[field_name] = value
+    return out
+
+
 def _handle_list_manifests(manifest: KnowledgeManifest) -> list[TextContent]:
     """Return JSON array of declared sub-manifests."""
     entries = []
@@ -533,6 +585,10 @@ def _handle_list_manifests(manifest: KnowledgeManifest) -> list[TextContent]:
             "update_frequency": m.update_frequency,
             "version_pin": m.version_pin,
             "version_policy": m.version_policy,
+            "temporal": _temporal_to_dict(m.temporal),
+            "temporally_active": _is_source_temporally_included(
+                m.temporal, _date.today().isoformat()
+            ),
         }
         entries.append(entry)
     return [TextContent(type="text", text=json.dumps(entries, indent=2))]

--- a/bridge/python/tests/fixtures/fed-temporal/README.md
+++ b/bridge/python/tests/fixtures/fed-temporal/README.md
@@ -1,0 +1,3 @@
+# Compliance Hub
+
+Federation entry point for GDPR compliance corpora.

--- a/bridge/python/tests/fixtures/fed-temporal/knowledge.yaml
+++ b/bridge/python/tests/fixtures/fed-temporal/knowledge.yaml
@@ -1,0 +1,32 @@
+kcp_version: "0.21"
+project: fed-temporal-hub
+version: 1.0.0
+
+# A compliance hub federating two GDPR corpora. The 2018 corpus was superseded by
+# the 2023 corpus; its source window has closed. Manifest-level temporal (§3.6) is
+# the only thing distinguishing the two — neither corpus declares unit-level temporal.
+manifests:
+  - id: gdpr-2018
+    url: "https://legal.example.com/gdpr-2018/knowledge.yaml"
+    relationship: governs
+    local_mirror: "./mirror-old/knowledge.yaml"
+    temporal:
+      valid_from: "2018-05-25"
+      valid_until: "2023-09-01"
+      superseded_by: gdpr-2023
+  - id: gdpr-2023
+    url: "https://legal.example.com/gdpr-2023/knowledge.yaml"
+    relationship: governs
+    local_mirror: "./mirror-new/knowledge.yaml"
+    temporal:
+      valid_from: "2023-09-01"
+
+units:
+  - id: hub-overview
+    path: README.md
+    intent: "Compliance hub overview and federation entry point"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["compliance", "hub"]
+
+relationships: []

--- a/bridge/python/tests/fixtures/fed-temporal/mirror-new/consent.md
+++ b/bridge/python/tests/fixtures/fed-temporal/mirror-new/consent.md
@@ -1,0 +1,3 @@
+# GDPR 2023 Consent
+
+Updated consent requirements and lawful basis under the 2023 corpus.

--- a/bridge/python/tests/fixtures/fed-temporal/mirror-new/knowledge.yaml
+++ b/bridge/python/tests/fixtures/fed-temporal/mirror-new/knowledge.yaml
@@ -1,0 +1,11 @@
+kcp_version: "0.21"
+project: gdpr-2023-corpus
+version: 1.0.0
+
+units:
+  - id: gdpr-2023-consent
+    path: consent.md
+    intent: "GDPR 2023 updated consent requirements and lawful basis"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["consent", "gdpr", "lawful basis"]

--- a/bridge/python/tests/fixtures/fed-temporal/mirror-old/consent.md
+++ b/bridge/python/tests/fixtures/fed-temporal/mirror-old/consent.md
@@ -1,0 +1,3 @@
+# GDPR 2018 Consent
+
+Consent requirements and lawful basis under the original 2018 corpus.

--- a/bridge/python/tests/fixtures/fed-temporal/mirror-old/knowledge.yaml
+++ b/bridge/python/tests/fixtures/fed-temporal/mirror-old/knowledge.yaml
@@ -1,0 +1,11 @@
+kcp_version: "0.21"
+project: gdpr-2018-corpus
+version: 1.0.0
+
+units:
+  - id: gdpr-2018-consent
+    path: consent.md
+    intent: "GDPR 2018 consent requirements and lawful basis under the original corpus"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["consent", "gdpr", "lawful basis"]

--- a/bridge/python/tests/test_server.py
+++ b/bridge/python/tests/test_server.py
@@ -23,6 +23,7 @@ MINIMAL_DIR = Path(__file__).parent / "fixtures" / "minimal"
 FULL_DIR = Path(__file__).parent / "fixtures" / "full"
 SUB_DIR = Path(__file__).parent / "fixtures" / "sub"
 RFC007_DIR = Path(__file__).parent / "fixtures" / "rfc007"
+FED_TEMPORAL_DIR = Path(__file__).parent / "fixtures" / "fed-temporal"
 
 
 def get_server(fixture_dir: Path, agent_only: bool = False) -> Server:
@@ -1032,3 +1033,73 @@ async def test_get_prompt_unknown_raises():
     server = get_server(MINIMAL_DIR)
     with pytest.raises(Exception):
         await call_get_prompt(server, "nonexistent-prompt")
+
+
+# ── Federation temporal (RFC-0021 / C18) ─────────────────────────────────────
+# The hub federates two GDPR corpora via local_mirror with disjoint source windows —
+# gdpr-2018 (valid_until 2023-09-01) and gdpr-2023 (valid_from 2023-09-01). Neither corpus
+# declares unit-level temporal, so the manifests[].temporal source window is the only thing
+# that can include or exclude their units. Both consent units match "consent gdpr".
+
+def _fed_server() -> Server:
+    return create_server(
+        FED_TEMPORAL_DIR / "knowledge.yaml",
+        warn_on_validation=False,
+        sub_manifests=[
+            FED_TEMPORAL_DIR / "mirror-old" / "knowledge.yaml",
+            FED_TEMPORAL_DIR / "mirror-new" / "knowledge.yaml",
+        ],
+    )
+
+
+async def _fed_search_ids(arguments: dict) -> list[str]:
+    server = _fed_server()
+    result = await call_tool(server, "search_knowledge", arguments)
+    parsed = json.loads(result.content[0].text)
+    return [r["id"] for r in parsed] if isinstance(parsed, list) else []
+
+
+@pytest.mark.asyncio
+async def test_fed_temporal_as_of_active_window_excludes_expired_source():
+    # 2026 is after gdpr-2018's valid_until and inside gdpr-2023's window.
+    ids = await _fed_search_ids({"query": "consent gdpr", "as_of": "2026-06-13"})
+    assert "gdpr-2023-consent" in ids
+    assert "gdpr-2018-consent" not in ids
+
+
+@pytest.mark.asyncio
+async def test_fed_temporal_as_of_expired_window_includes_it():
+    # 2020 is inside gdpr-2018's window and before gdpr-2023's valid_from.
+    ids = await _fed_search_ids({"query": "consent gdpr", "as_of": "2020-01-01"})
+    assert "gdpr-2018-consent" in ids
+    assert "gdpr-2023-consent" not in ids
+
+
+@pytest.mark.asyncio
+async def test_fed_temporal_include_all_returns_both_sources():
+    ids = await _fed_search_ids({"query": "consent gdpr", "include_all_temporal": True})
+    assert "gdpr-2018-consent" in ids
+    assert "gdpr-2023-consent" in ids
+
+
+@pytest.mark.asyncio
+async def test_fed_temporal_as_of_and_include_all_conflict():
+    server = _fed_server()
+    result = await call_tool(
+        server,
+        "search_knowledge",
+        {"query": "consent gdpr", "as_of": "2020-01-01", "include_all_temporal": True},
+    )
+    assert json.loads(result.content[0].text)["error"] == "temporal_query_conflict"
+
+
+@pytest.mark.asyncio
+async def test_fed_temporal_list_manifests_exposes_temporal_and_activity():
+    server = _fed_server()
+    result = await call_tool(server, "list_manifests")
+    entries = json.loads(result.content[0].text)
+    old = next(e for e in entries if e["id"] == "gdpr-2018")
+    cur = next(e for e in entries if e["id"] == "gdpr-2023")
+    assert old["temporal"]["valid_until"] == "2023-09-01"
+    assert old["temporally_active"] is False  # expired as of today
+    assert cur["temporally_active"] is True

--- a/bridge/typescript/src/server.ts
+++ b/bridge/typescript/src/server.ts
@@ -23,7 +23,7 @@ import {
   type McpResourceMeta,
 } from "./mapper.js";
 import { readUnitContent } from "./content.js";
-import type { KnowledgeManifest, KnowledgeUnit } from "./model.js";
+import type { KnowledgeManifest, KnowledgeUnit, Temporal } from "./model.js";
 import type { CommandManifest } from "./commands.js";
 import { formatSyntaxBlock, lookupCommand } from "./commands.js";
 
@@ -48,6 +48,10 @@ export interface KcpMcpServer {
 interface UnitContext {
   unit: KnowledgeUnit;
   manifestDir: string;
+  /** The `manifests[].id` of the sub-manifest this unit came from; undefined for primary units. */
+  sourceManifestId?: string;
+  /** The federation source's validity window (`manifests[].temporal`, §3.6); undefined when none. */
+  sourceTemporal?: Temporal;
 }
 
 // ── Search scoring ───────────────────────────────────────────────────────────
@@ -140,6 +144,20 @@ function isTemporallyActive(unit: KnowledgeUnit, asOf: string): boolean {
   return true;
 }
 
+/**
+ * §3.6 / C18 manifest-level (federation source) temporal check. Returns true when a
+ * sub-manifest is relevant *as a knowledge source* on the effective date. A source with no
+ * `manifests[].temporal` block is always included. This applies *before* unit-level temporal
+ * (§4.22): a source filtered out here contributes no units at all — the bridge skips it
+ * entirely, equivalent to never fetching it.
+ */
+function isSourceTemporallyIncluded(t: Temporal | undefined, effectiveDate: string): boolean {
+  if (!t) return true;
+  if (t.valid_from && t.valid_from > effectiveDate) return false;
+  if (t.valid_until && t.valid_until < effectiveDate) return false;
+  return true;
+}
+
 /** Returns the first not_for phrase matched by any query term, or null (§15.11). */
 function matchNotFor(unit: KnowledgeUnit, terms: string[]): string | null {
   if (!unit.not_for || unit.not_for.length === 0) return null;
@@ -201,10 +219,21 @@ export function createKcpServer(
     manifest.units.map((u) => [u.id, { unit: u, manifestDir: primaryDir }])
   );
 
+  // Associate each federation entry's local_mirror with its manifests[] declaration so a
+  // sub-manifest loaded from disk inherits its source id + temporal window (§3.6 / C18).
+  // Keyed by the resolved absolute path of the mirror file.
+  const mirrorToRef = new Map<string, { id: string; temporal?: Temporal }>();
+  for (const ref of manifest.manifests) {
+    if (ref.local_mirror) {
+      mirrorToRef.set(resolve(primaryDir, ref.local_mirror), { id: ref.id, temporal: ref.temporal });
+    }
+  }
+
   // Load each sub-manifest and merge its units
   for (const subPath of subManifests) {
     const resolvedSub = resolve(subPath);
     const subDir = dirname(resolvedSub);
+    const sourceRef = mirrorToRef.get(resolvedSub);
 
     let subManifest: KnowledgeManifest;
     try {
@@ -239,7 +268,12 @@ export function createKcpServer(
         );
         continue;
       }
-      unitContextMap.set(unit.id, { unit, manifestDir: subDir });
+      unitContextMap.set(unit.id, {
+        unit,
+        manifestDir: subDir,
+        sourceManifestId: sourceRef?.id,
+        sourceTemporal: sourceRef?.temporal,
+      });
       added++;
     }
     if (warnOnValidation || added > 0) {
@@ -453,7 +487,17 @@ export function createKcpServer(
         const terms = query.trim().split(/\s+/);
         const results: SearchResult[] = [];
 
-        for (const { unit } of unitContextMap.values()) {
+        for (const ctx of unitContextMap.values()) {
+          const unit = ctx.unit;
+
+          // §3.6 / C18: manifest-level (federation source) temporal filter, applied before
+          // scoring and before unit-level temporal. A source outside its validity window is
+          // skipped entirely — none of its units are scored or returned. Bypassed by
+          // include_all_temporal, consistent with the unit-level semantics below.
+          if (!includeAllTemporal && !isSourceTemporallyIncluded(ctx.sourceTemporal, temporalDate)) {
+            continue;
+          }
+
           // Apply filters
           if (
             audienceFilter &&
@@ -570,6 +614,11 @@ export function createKcpServer(
           update_frequency: m.update_frequency ?? null,
           version_pin: m.version_pin ?? null,
           version_policy: m.version_policy ?? null,
+          temporal: m.temporal ?? null,
+          temporally_active: isSourceTemporallyIncluded(
+            m.temporal,
+            new Date().toISOString().slice(0, 10)
+          ),
         }));
         return {
           content: [

--- a/bridge/typescript/tests/fixtures/fed-temporal/README.md
+++ b/bridge/typescript/tests/fixtures/fed-temporal/README.md
@@ -1,0 +1,3 @@
+# Compliance Hub
+
+Federation entry point for GDPR compliance corpora.

--- a/bridge/typescript/tests/fixtures/fed-temporal/knowledge.yaml
+++ b/bridge/typescript/tests/fixtures/fed-temporal/knowledge.yaml
@@ -1,0 +1,32 @@
+kcp_version: "0.21"
+project: fed-temporal-hub
+version: 1.0.0
+
+# A compliance hub federating two GDPR corpora. The 2018 corpus was superseded by
+# the 2023 corpus; its source window has closed. Manifest-level temporal (§3.6) is
+# the only thing distinguishing the two — neither corpus declares unit-level temporal.
+manifests:
+  - id: gdpr-2018
+    url: "https://legal.example.com/gdpr-2018/knowledge.yaml"
+    relationship: governs
+    local_mirror: "./mirror-old/knowledge.yaml"
+    temporal:
+      valid_from: "2018-05-25"
+      valid_until: "2023-09-01"
+      superseded_by: gdpr-2023
+  - id: gdpr-2023
+    url: "https://legal.example.com/gdpr-2023/knowledge.yaml"
+    relationship: governs
+    local_mirror: "./mirror-new/knowledge.yaml"
+    temporal:
+      valid_from: "2023-09-01"
+
+units:
+  - id: hub-overview
+    path: README.md
+    intent: "Compliance hub overview and federation entry point"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["compliance", "hub"]
+
+relationships: []

--- a/bridge/typescript/tests/fixtures/fed-temporal/mirror-new/consent.md
+++ b/bridge/typescript/tests/fixtures/fed-temporal/mirror-new/consent.md
@@ -1,0 +1,3 @@
+# GDPR 2023 Consent
+
+Updated consent requirements and lawful basis under the 2023 corpus.

--- a/bridge/typescript/tests/fixtures/fed-temporal/mirror-new/knowledge.yaml
+++ b/bridge/typescript/tests/fixtures/fed-temporal/mirror-new/knowledge.yaml
@@ -1,0 +1,11 @@
+kcp_version: "0.21"
+project: gdpr-2023-corpus
+version: 1.0.0
+
+units:
+  - id: gdpr-2023-consent
+    path: consent.md
+    intent: "GDPR 2023 updated consent requirements and lawful basis"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["consent", "gdpr", "lawful basis"]

--- a/bridge/typescript/tests/fixtures/fed-temporal/mirror-old/consent.md
+++ b/bridge/typescript/tests/fixtures/fed-temporal/mirror-old/consent.md
@@ -1,0 +1,3 @@
+# GDPR 2018 Consent
+
+Consent requirements and lawful basis under the original 2018 corpus.

--- a/bridge/typescript/tests/fixtures/fed-temporal/mirror-old/knowledge.yaml
+++ b/bridge/typescript/tests/fixtures/fed-temporal/mirror-old/knowledge.yaml
@@ -1,0 +1,11 @@
+kcp_version: "0.21"
+project: gdpr-2018-corpus
+version: 1.0.0
+
+units:
+  - id: gdpr-2018-consent
+    path: consent.md
+    intent: "GDPR 2018 consent requirements and lawful basis under the original corpus"
+    scope: global
+    audience: [developer, agent]
+    triggers: ["consent", "gdpr", "lawful basis"]

--- a/bridge/typescript/tests/tools.test.ts
+++ b/bridge/typescript/tests/tools.test.ts
@@ -449,6 +449,89 @@ describe("list_manifests tool", () => {
   });
 });
 
+// RFC-0021 / C18: manifest-level (federation source) temporal filtering. The hub federates
+// two GDPR corpora via local_mirror with disjoint source windows — gdpr-2018
+// (valid_until 2023-09-01) and gdpr-2023 (valid_from 2023-09-01). Neither corpus declares
+// unit-level temporal, so the *only* thing that can include or exclude their units is the
+// manifests[].temporal source window. Both consent units match the query "consent gdpr".
+describe("federation temporal (C18)", () => {
+  const FED_TEMPORAL_DIR = join(import.meta.dirname, "fixtures/fed-temporal");
+  const HUB = join(FED_TEMPORAL_DIR, "knowledge.yaml");
+  const MIRRORS = [
+    join(FED_TEMPORAL_DIR, "mirror-old/knowledge.yaml"),
+    join(FED_TEMPORAL_DIR, "mirror-new/knowledge.yaml"),
+  ];
+
+  async function connectFed() {
+    const { server } = createKcpServer(HUB, {
+      warnOnValidation: false,
+      subManifests: MIRRORS,
+    });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "test-client", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  async function searchIds(args: Record<string, unknown>): Promise<string[]> {
+    const client = await connectFed();
+    const result = await client.callTool({ name: "search_knowledge", arguments: args });
+    await client.close();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed.map((r: { id: string }) => r.id) : [];
+  }
+
+  it("as_of inside only the active window excludes the expired source's units", async () => {
+    // 2026 is after gdpr-2018's valid_until and inside gdpr-2023's window.
+    const ids = await searchIds({ query: "consent gdpr", as_of: "2026-06-13" });
+    expect(ids).toContain("gdpr-2023-consent");
+    expect(ids).not.toContain("gdpr-2018-consent");
+  });
+
+  it("as_of inside the expired window includes it and excludes the not-yet-valid source", async () => {
+    // 2020 is inside gdpr-2018's window and before gdpr-2023's valid_from.
+    const ids = await searchIds({ query: "consent gdpr", as_of: "2020-01-01" });
+    expect(ids).toContain("gdpr-2018-consent");
+    expect(ids).not.toContain("gdpr-2023-consent");
+  });
+
+  it("include_all_temporal bypasses manifest-level filtering and returns both sources", async () => {
+    const ids = await searchIds({ query: "consent gdpr", include_all_temporal: true });
+    expect(ids).toContain("gdpr-2018-consent");
+    expect(ids).toContain("gdpr-2023-consent");
+  });
+
+  it("as_of and include_all_temporal together are a conflict error", async () => {
+    const client = await connectFed();
+    const result = await client.callTool({
+      name: "search_knowledge",
+      arguments: { query: "consent gdpr", as_of: "2020-01-01", include_all_temporal: true },
+    });
+    await client.close();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(JSON.parse(text).error).toBe("temporal_query_conflict");
+  });
+
+  it("list_manifests exposes the temporal block and computed activity", async () => {
+    const client = await connectFed();
+    const result = await client.callTool({ name: "list_manifests", arguments: {} });
+    await client.close();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const entries = JSON.parse(text) as Array<{
+      id: string;
+      temporal: { valid_until?: string } | null;
+      temporally_active: boolean;
+    }>;
+    const old = entries.find((e) => e.id === "gdpr-2018")!;
+    const cur = entries.find((e) => e.id === "gdpr-2023")!;
+    expect(old.temporal?.valid_until).toBe("2023-09-01");
+    expect(old.temporally_active).toBe(false); // expired as of today
+    expect(cur.temporally_active).toBe(true);
+  });
+});
+
 describe("prompts/list", () => {
   it("lists both prompts", async () => {
     const client = await connectClient(join(MINIMAL_DIR, "knowledge.yaml"));


### PR DESCRIPTION
## Summary

Implements the **resolution-time half of RFC-0021 / SPEC §16.5 C18** in all three MCP bridges (TypeScript, Python, Java). The parsers already exposed `manifests[].temporal` and detected `superseded_by` cycles (Level 1); this closes the bridge (Level 2) side.

### How it works
- Each `manifests[]` entry's `local_mirror` is resolved against the hub dir and matched to the sub-manifest loaded from it, so that sub-manifest's units inherit the federation **source's** `temporal` window.
- On `search_knowledge`, a sub-manifest whose source window excludes the effective date (`as_of`, else today) is **skipped before scoring and before unit-level temporal** — none of its units are scored or returned. This is the "skip-before-fetch" semantics for a local-mirror bridge: the source contributes nothing, invisible to the caller.
- `include_all_temporal: true` bypasses the stage, consistent with the existing unit-level semantics.
- `list_manifests` now surfaces each entry's `temporal` block and a computed `temporally_active` flag.

The filter order is now: **manifest-level temporal → score → not_for → unit-level temporal → top-N**, exactly as §3.6 specifies.

## Validation

5 discriminating tests **per bridge** (mutation-verified) over a shared `fed-temporal` fixture — a compliance hub federating an **expired** GDPR-2018 corpus (`valid_until 2023-09-01`) and an **active** GDPR-2023 corpus (`valid_from 2023-09-01`) with disjoint source windows. Neither corpus declares unit-level temporal, so the source window is the *only* discriminator:

| `as_of` | included | excluded |
|---------|----------|----------|
| 2026-06-13 (today) | gdpr-2023-consent | gdpr-2018-consent |
| 2020-01-01 | gdpr-2018-consent | gdpr-2023-consent |
| `include_all_temporal` | both | — |

Full suites green: **TypeScript 208**, **Python 153**, **Java 154**. Mutation-verified in each language — neutering the manifest-level filter fails exactly the two `as_of` exclusion tests.

Also updates `CHANGELOG.md` and the RFC-0021 implementation-status section.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_