### PR TITLE
docs(changelog): consolidate 0.21.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+_Nothing yet._
+
+---
+
+## [0.21.0] — 2026-06-13 — Composition Integrity & Federation Temporal
+
+**Spec version:** `"0.21"` | **Prior:** `"0.20"` (v0.20.0, 2026-06-12)
+
 ### Implemented — federated temporal filtering (C18) in all three bridges
 
 - The TypeScript, Python, and Java MCP bridges now apply manifest-level (federation source)
@@ -85,15 +93,9 @@ all four reference implementations (TypeScript CLI + bridge, Python, Java):
   Python, and Java (15 cases each). An outdated Java parser test fixture (a
   `verified` discovery with no `verified_by`) was made spec-compliant.
 
-Still deferred (the one remaining serving-side feature): bridge skip-before-fetch
-federation temporal filtering (RFC-0021 Level 2). (Composition resolution + C17
-enforcement in the renderer has since landed — see the top of this Unreleased section.)
-
----
-
-## [0.21.0] — 2026-06-13 — Composition Integrity & Federation Temporal
-
-**Spec version:** `"0.21"` | **Prior:** `"0.20"` (v0.20.0, 2026-06-12)
+Both remaining serving-side features have since landed in this release: bridge
+skip-before-fetch federation temporal filtering (RFC-0021 Level 2 / C18) and composition
+resolution + C17 enforcement in the renderer — see the implementation subsections above.
 
 ### Federation temporal — RFC-0021 (promoted to SPEC §3.6, §16.5 C18)
 
@@ -136,9 +138,10 @@ enforcement in the renderer has since landed — see the top of this Unreleased 
 
 ### Notes
 
-- At v0.21.0, `manifests[].temporal` parser exposure (Level 1) and the composition resolver
-  (which C17 governs) were not yet implemented — the spec promotion deliberately led the
-  implementation. Both landed shortly after; see the [Unreleased] section above.
+- The RFC-0021 and RFC-0022 spec promotions deliberately led the implementation: the
+  `manifests[].temporal` parser exposure (Level 1), the bridge skip-before-fetch filter
+  (Level 2 / C18), and the composition resolver (which C17 governs) all ship together in
+  this release — see the implementation subsections above.
 
 ---
 


### PR DESCRIPTION
Prep for cutting **v0.21.0** (releases currently stop at v0.19.0; both 0.20.0 and 0.21.0 were never tagged).

This is the first cut of v0.21.0, and the `[Unreleased]` items are all 0.21 *implementation* work that followed the 0.21.0 spec-promotion entry — they ship under spec version `0.21` (SPEC and all packages are `0.21.0`; there is no 0.22). So this folds them into the `[0.21.0]` section:

- bridge C18 federation temporal filtering (all three bridges)
- composition resolution + enforcing C17 in `kcp render`
- content-integrity dogfooding on the repo's own manifest
- agent skills
- temporal-validation backlog

`[Unreleased]` is reset to empty and the now-stale "landed shortly after / still deferred" notes are corrected to "ship together in this release." Pure docs change.

After merge I'll tag `v0.21.0` at the merge commit.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_