### PR TITLE
docs(render): animated SVG terminal cast of the render demo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1828,6 +1828,9 @@ units:
         Open Simulator &rarr;
       </a>
       <p style="margin-top: var(--space-6);">Or watch the <strong>trusted render pipeline</strong> neutralise each attack in its threat model &mdash; replaying authentic <code>kcp render</code> output, one runnable terminal demo per use case.</p>
+      <a href="render-simulator.html" aria-label="Open the trusted render pipeline demo">
+        <img src="render-cast.svg" alt="Animated terminal: kcp render across six trusted-render-pipeline scenarios" style="max-width: 760px; width: 100%; border-radius: 10px; margin: var(--space-4) auto; display: block; box-shadow: var(--shadow-md, 0 4px 16px rgba(0,0,0,.12));">
+      </a>
       <a href="render-simulator.html" class="btn btn--secondary">
         Open Render Demo &rarr;
       </a>

--- a/docs/render-cast.svg
+++ b/docs/render-cast.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="321" viewBox="0 0 800 321" font-size="14.5" role="img" aria-label="Animated terminal cast of kcp render across six trusted-render-pipeline scenarios">
+<style>
+  .win{font-family:'JetBrains Mono','SFMono-Regular',Menlo,Consolas,monospace}
+  text{dominant-baseline:hanging}
+  .cmd{fill:#e6edf3;font-weight:600}
+  .out{fill:#adbac7}
+  .prompt{fill:#3fb950;font-weight:700}
+  .vtag{font-weight:700}
+  .vsub{fill:#768390}
+  .cursor{fill:#e6edf3;animation:blink 1s steps(2) infinite}
+  @keyframes blink{50%{opacity:0}}
+@keyframes cast0{0%,0.00%{opacity:0}1.20%{opacity:1}15.47%{opacity:1}16.67%,100%{opacity:0}}
+@keyframes seg0{0%,0.00%{opacity:.25}0.50%{opacity:1}16.67%,100%{opacity:.25}}
+@keyframes cast1{0%,16.67%{opacity:0}17.87%{opacity:1}32.13%{opacity:1}33.33%,100%{opacity:0}}
+@keyframes seg1{0%,16.67%{opacity:.25}17.17%{opacity:1}33.33%,100%{opacity:.25}}
+@keyframes cast2{0%,33.33%{opacity:0}34.53%{opacity:1}48.80%{opacity:1}50.00%,100%{opacity:0}}
+@keyframes seg2{0%,33.33%{opacity:.25}33.83%{opacity:1}50.00%,100%{opacity:.25}}
+@keyframes cast3{0%,50.00%{opacity:0}51.20%{opacity:1}65.47%{opacity:1}66.67%,100%{opacity:0}}
+@keyframes seg3{0%,50.00%{opacity:.25}50.50%{opacity:1}66.67%,100%{opacity:.25}}
+@keyframes cast4{0%,66.67%{opacity:0}67.87%{opacity:1}82.13%{opacity:1}83.33%,100%{opacity:0}}
+@keyframes seg4{0%,66.67%{opacity:.25}67.17%{opacity:1}83.33%,100%{opacity:.25}}
+@keyframes cast5{0%,83.33%{opacity:0}84.53%{opacity:1}98.80%{opacity:1}100.00%,100%{opacity:0}}
+@keyframes seg5{0%,83.33%{opacity:.25}83.83%{opacity:1}100.00%,100%{opacity:.25}}
+</style>
+<rect width="800" height="321" rx="10" fill="#0d1117"/>
+<rect width="800" height="38" rx="10" fill="#161b22"/>
+<rect y="28" width="800" height="10" fill="#161b22"/>
+<circle cx="20" cy="19" r="6" fill="#ff5f57"/>
+<circle cx="40" cy="19" r="6" fill="#febc2e"/>
+<circle cx="60" cy="19" r="6" fill="#28c840"/>
+<text x="400" y="12" text-anchor="middle" class="win" fill="#768390" font-size="13" font-weight="600">kcp render — trusted render pipeline</text>
+<g class="win"><g style="animation:cast0 18s infinite"><text x="22" y="60"><tspan class="prompt">$ </tspan><tspan class="cmd">kcp render knowledge.yaml --keys trusted-keys.yaml --origin github.com/Cantara/…</tspan><tspan class="cursor" dx="2">▋</tspan></text><text x="22" y="102" class="out" fill="#3fb950">  tier: trusted</text><text x="22" y="123" class="out" fill="#adbac7">  origin_evidence: asserted</text><text x="22" y="144" class="out" fill="#adbac7">  pinned: true</text><text x="22" y="165" class="out" fill="#3fb950">    load_eligible: true</text><text x="22" y="186" class="out" fill="#3fb950">    content_verified: true</text><text x="22" y="249" class="vtag" fill="#58a6ff">✓ tier: trusted</text><text x="22" y="270" class="vsub">signed + allowlisted + hashes match → load-eligible</text></g>
+<g style="animation:cast1 18s infinite"><text x="22" y="60"><tspan class="prompt">$ </tspan><tspan class="cmd">kcp render knowledge.yaml --keys trusted-keys.yaml --origin github.com/some-str…</tspan><tspan class="cursor" dx="2">▋</tspan></text><text x="22" y="102" class="out" fill="#d29922">  tier: unsigned</text><text x="22" y="123" class="out" fill="#adbac7">  pinned: false</text><text x="22" y="144" class="out" fill="#adbac7">    intent: What is this project?</text><text x="22" y="165" class="out" fill="#f85149">    load_eligible: false</text><text x="22" y="249" class="vtag" fill="#58a6ff">✓ tier: unsigned</text><text x="22" y="270" class="vsub">readable data, never auto-loaded</text></g>
+<g style="animation:cast2 18s infinite"><text x="22" y="60"><tspan class="prompt">$ </tspan><tspan class="cmd">kcp render knowledge.yaml --keys trusted-keys.yaml</tspan><tspan class="cursor" dx="2">▋</tspan></text><text x="22" y="102" class="out" fill="#d29922">  tier: known</text><text x="22" y="123" class="out" fill="#adbac7">  origin_evidence: derived</text><text x="22" y="144" class="out" fill="#adbac7">  reason: origin_evidence_derived</text><text x="22" y="165" class="out" fill="#f85149">    load_eligible: false</text><text x="22" y="186" class="out" fill="#f85149">    content_verified: mismatch</text><text x="22" y="207" class="out" fill="#f85149">      reason: content_hash_mismatch</text><text x="22" y="249" class="vtag" fill="#3fb950">✓ T9 relocation blocked</text><text x="22" y="270" class="vsub">derived-evidence cap + hash mismatch → not load-eligible</text></g>
+<g style="animation:cast3 18s infinite"><text x="22" y="60"><tspan class="prompt">$ </tspan><tspan class="cmd">kcp render knowledge.yaml --keys trusted-keys.yaml --origin github.com/Cantara/…</tspan><tspan class="cursor" dx="2">▋</tspan></text><text x="22" y="102" class="out" fill="#f85149">✗ render refused: tier=failed (unsigned manifest from pinned origin (§4.1))</text><text x="22" y="249" class="vtag" fill="#3fb950">✓ T7 stripping blocked</text><text x="22" y="270" class="vsub">pinned + unsigned → failed, nothing emitted</text></g>
+<g style="animation:cast4 18s infinite"><text x="22" y="60"><tspan class="prompt">$ </tspan><tspan class="cmd">kcp render knowledge.yaml --keys trusted-keys.yaml --origin github.com/some-str…</tspan><tspan class="cursor" dx="2">▋</tspan></text><text x="22" y="102" class="out" fill="#adbac7">    path: knowledge.yaml</text><text x="22" y="123" class="out" fill="#d29922">  tier: unsigned</text><text x="22" y="144" class="out" fill="#adbac7">    path: docs/setup.md</text><text x="22" y="165" class="out" fill="#f85149">  quarantined:</text><text x="22" y="186" class="out" fill="#adbac7">    - path: units[0].intent</text><text x="22" y="207" class="out" fill="#adbac7">      reason: imperative_mood</text><text x="22" y="249" class="vtag" fill="#3fb950">✓ T1 injection blocked</text><text x="22" y="270" class="vsub">imperative intent quarantined, payload dropped</text></g>
+<g style="animation:cast5 18s infinite"><text x="22" y="60"><tspan class="prompt">$ </tspan><tspan class="cmd">kcp render knowledge.yaml --keys trusted-keys.yaml --origin github.com/Cantara/…</tspan><tspan class="cursor" dx="2">▋</tspan></text><text x="22" y="102" class="out" fill="#3fb950">  tier: trusted</text><text x="22" y="123" class="out" fill="#adbac7">  - id: platform:submit-expense</text><text x="22" y="144" class="out" fill="#f85149">    load_eligible: false</text><text x="22" y="165" class="out" fill="#adbac7">  - id: local-overview</text><text x="22" y="186" class="out" fill="#3fb950">    load_eligible: true</text><text x="22" y="249" class="vtag" fill="#3fb950">✓ T10 substitution blocked</text><text x="22" y="270" class="vsub">unverified include not load-eligible (C17)</text></g>
+</g>
+<rect x="22.0" y="307" width="121.0" height="4" rx="2" fill="#58a6ff" style="animation:seg0 18s infinite"/><rect x="149.0" y="307" width="121.0" height="4" rx="2" fill="#58a6ff" style="animation:seg1 18s infinite"/><rect x="276.0" y="307" width="121.0" height="4" rx="2" fill="#58a6ff" style="animation:seg2 18s infinite"/><rect x="403.0" y="307" width="121.0" height="4" rx="2" fill="#58a6ff" style="animation:seg3 18s infinite"/><rect x="530.0" y="307" width="121.0" height="4" rx="2" fill="#58a6ff" style="animation:seg4 18s infinite"/><rect x="657.0" y="307" width="121.0" height="4" rx="2" fill="#58a6ff" style="animation:seg5 18s infinite"/>
+</svg>

--- a/examples/trusted-render-demo/README.md
+++ b/examples/trusted-render-demo/README.md
@@ -1,5 +1,9 @@
 # Trusted Render Pipeline — interactive demo
 
+<p align="center">
+  <img src="../../docs/render-cast.svg" alt="Animated terminal cast: kcp render across six trusted-render-pipeline scenarios" width="760">
+</p>
+
 A runnable, narrated walk-through of the use cases for `kcp render`
 ([SPEC §16](../../SPEC.md#16-trusted-render-pipeline-v016),
 [RFC-0018](../../RFC-0018-Trusted-Render-Pipeline.md) /
@@ -60,3 +64,17 @@ node demo.js --capture   # writes docs/js/render-captures.js
 Because the page only replays authentic `kcp render` output, it cannot drift from
 the implementation. Regenerate the captures whenever the renderer's output
 changes.
+
+## The animated cast (top of this README)
+
+[`docs/render-cast.svg`](../../docs/render-cast.svg) is a pure-CSS animated
+terminal that cycles through all six scenarios. It is generated from the same
+captures — no recording tools, no rasterization, regenerable in-repo:
+
+```bash
+node demo.js --capture   # refresh docs/js/render-captures.js
+node gen-cast.js         # rebuild docs/render-cast.svg from those captures
+```
+
+Like the simulator, it never reimplements the renderer — the frames are the real
+output, so the cast can't drift either.

--- a/examples/trusted-render-demo/gen-cast.js
+++ b/examples/trusted-render-demo/gen-cast.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Generate an animated SVG "terminal cast" of the trusted-render demo.
+//
+// Reads the captures produced by `demo.js --capture` (docs/js/render-captures.js)
+// and emits docs/render-cast.svg — a pure-CSS animated terminal that cycles
+// through every scenario's real `kcp render` output. No external tools, no JS in
+// the SVG (GitHub strips <script> but animates CSS keyframes in img-embedded
+// SVG), and nothing reimplemented: the frames are the authentic renderer output.
+//
+// Usage:  node gen-cast.js   (run `node demo.js --capture` first)
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.dirname(fileURLToPath(import.meta.url));
+const CAPTURES = path.resolve(ROOT, '..', '..', 'docs', 'js', 'render-captures.js');
+const OUT = path.resolve(ROOT, '..', '..', 'docs', 'render-cast.svg');
+
+if (!fs.existsSync(CAPTURES)) {
+  console.error('Captures missing. Run:  node demo.js --capture');
+  process.exit(1);
+}
+// The captures file is our own generated `window.RENDER_CAPTURES = [...]`.
+const sandbox = {};
+new Function('window', fs.readFileSync(CAPTURES, 'utf8'))(sandbox);
+const caps = sandbox.RENDER_CAPTURES || [];
+
+// Terse, punchy verdict per scenario for the cast (the README/page carry the long form).
+const CAST_VERDICT = {
+  trusted:     ['✓ tier: trusted', 'signed + allowlisted + hashes match → load-eligible'],
+  unsigned:    ['✓ tier: unsigned', 'readable data, never auto-loaded'],
+  relocation:  ['✓ T9 relocation blocked', 'derived-evidence cap + hash mismatch → not load-eligible'],
+  stripping:   ['✓ T7 stripping blocked', 'pinned + unsigned → failed, nothing emitted'],
+  injection:   ['✓ T1 injection blocked', 'imperative intent quarantined, payload dropped'],
+  composition: ['✓ T10 substitution blocked', 'unverified include not load-eligible (C17)'],
+};
+
+// ── layout ───────────────────────────────────────────────────────────────────
+const W = 800, PAD = 22, BAR = 38;
+const FONT = 14.5, LH = 21, COLS = 80;
+const BODY_LINES = 11;                 // fixed text rows reserved in the body
+const H = BAR + PAD * 2 + BODY_LINES * LH + 8;
+const SLOT = 3.0;                      // seconds per scenario
+const TOTAL = caps.length * SLOT;
+
+const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const clip = (s) => (s.length > COLS ? s.slice(0, COLS - 1) + '…' : s);
+
+// Colour a single output line by its content.
+function lineColor(line) {
+  if (/tier:\s*trusted/.test(line)) return '#3fb950';
+  if (/tier:\s*failed|mismatch|refused/.test(line)) return '#f85149';
+  if (/tier:\s*(known|unsigned)/.test(line)) return '#d29922';
+  if (/load_eligible:\s*true|content_verified:\s*true/.test(line)) return '#3fb950';
+  if (/load_eligible:\s*false|quarantined|content_verified:\s*mismatch/.test(line)) return '#f85149';
+  return '#adbac7';
+}
+
+// Build the text rows for one scenario: command, output, blank, verdict.
+function rowsFor(cap) {
+  const rows = [];
+  rows.push({ t: '$ ' + clip(cap.renderCommand), cls: 'cmd' });
+  rows.push({ t: '', cls: 'out' });
+  const outLines = cap.output.split('\n').filter((l) => l.trim()).slice(0, 6);
+  for (const l of outLines) rows.push({ t: clip(l), cls: 'out', color: lineColor(l) });
+  return rows;
+}
+
+// ── animation: each scenario group is opaque only during its slot ────────────
+function groupKeyframes(i) {
+  const s = (i * SLOT) / TOTAL * 100;
+  const e = ((i + 1) * SLOT) / TOTAL * 100;
+  const f = 1.2;                       // fade width in %
+  const p = (n) => n.toFixed(2);
+  // hidden everywhere except a fade-in/hold/fade-out inside the slot
+  return `@keyframes cast${i}{`
+    + `0%,${p(Math.max(0, s))}%{opacity:0}`
+    + `${p(s + f)}%{opacity:1}`
+    + `${p(e - f)}%{opacity:1}`
+    + `${p(e)}%,100%{opacity:0}}`;
+}
+
+// progress bar segments (one per scenario) lighting up in sequence
+function progressKeyframes(i) {
+  const s = (i * SLOT) / TOTAL * 100;
+  const e = ((i + 1) * SLOT) / TOTAL * 100;
+  return `@keyframes seg${i}{`
+    + `0%,${(Math.max(0, s)).toFixed(2)}%{opacity:.25}`
+    + `${(s + 0.5).toFixed(2)}%{opacity:1}`
+    + `${(e).toFixed(2)}%,100%{opacity:.25}}`;
+}
+
+let styles = `
+  .win{font-family:'JetBrains Mono','SFMono-Regular',Menlo,Consolas,monospace}
+  text{dominant-baseline:hanging}
+  .cmd{fill:#e6edf3;font-weight:600}
+  .out{fill:#adbac7}
+  .prompt{fill:#3fb950;font-weight:700}
+  .vtag{font-weight:700}
+  .vsub{fill:#768390}
+  .cursor{fill:#e6edf3;animation:blink 1s steps(2) infinite}
+  @keyframes blink{50%{opacity:0}}
+`;
+for (let i = 0; i < caps.length; i++) { styles += groupKeyframes(i) + '\n' + progressKeyframes(i) + '\n'; }
+
+// ── render groups ────────────────────────────────────────────────────────────
+const bodyTop = BAR + PAD;
+let groups = '';
+caps.forEach((cap, i) => {
+  const rows = rowsFor(cap);
+  let lines = '';
+  rows.forEach((r, j) => {
+    const y = bodyTop + j * LH;
+    if (r.cls === 'cmd') {
+      const cmd = esc(r.t.slice(2));
+      lines += `<text x="${PAD}" y="${y}"><tspan class="prompt">$ </tspan><tspan class="cmd">${cmd}</tspan>`
+        + `<tspan class="cursor" dx="2">▋</tspan></text>`;
+    } else if (r.t) {
+      lines += `<text x="${PAD}" y="${y}" class="out" fill="${r.color || '#adbac7'}">${esc(r.t)}</text>`;
+    }
+  });
+  // verdict band near the bottom of the body
+  const [vtag, vsub] = CAST_VERDICT[cap.id] || ['✓', ''];
+  const vy = bodyTop + (BODY_LINES - 2) * LH;
+  const vColor = cap.threat ? '#3fb950' : '#58a6ff';
+  lines += `<text x="${PAD}" y="${vy}" class="vtag" fill="${vColor}">${esc(vtag)}</text>`;
+  lines += `<text x="${PAD}" y="${vy + LH}" class="vsub">${esc(clip(vsub))}</text>`;
+
+  groups += `<g style="animation:cast${i} ${TOTAL}s infinite">${lines}</g>\n`;
+});
+
+// progress segments along the bottom
+const segW = (W - PAD * 2 - (caps.length - 1) * 6) / caps.length;
+let segs = '';
+caps.forEach((_, i) => {
+  const x = PAD + i * (segW + 6);
+  segs += `<rect x="${x.toFixed(1)}" y="${H - 14}" width="${segW.toFixed(1)}" height="4" rx="2" `
+    + `fill="#58a6ff" style="animation:seg${i} ${TOTAL}s infinite"/>`;
+});
+
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" font-size="${FONT}" role="img" aria-label="Animated terminal cast of kcp render across six trusted-render-pipeline scenarios">
+<style>${styles}</style>
+<rect width="${W}" height="${H}" rx="10" fill="#0d1117"/>
+<rect width="${W}" height="${BAR}" rx="10" fill="#161b22"/>
+<rect y="${BAR - 10}" width="${W}" height="10" fill="#161b22"/>
+<circle cx="20" cy="${BAR / 2}" r="6" fill="#ff5f57"/>
+<circle cx="40" cy="${BAR / 2}" r="6" fill="#febc2e"/>
+<circle cx="60" cy="${BAR / 2}" r="6" fill="#28c840"/>
+<text x="${W / 2}" y="${BAR / 2 - 7}" text-anchor="middle" class="win" fill="#768390" font-size="13" font-weight="600">kcp render — trusted render pipeline</text>
+<g class="win">${groups}</g>
+${segs}
+</svg>
+`;
+
+fs.writeFileSync(OUT, svg);
+console.log(`Wrote ${path.relative(process.cwd(), OUT)} — ${caps.length} scenarios, ${TOTAL}s loop, ${(svg.length / 1024).toFixed(1)} KB`);


### PR DESCRIPTION
## Summary

The "GIF" for the trusted-render demo — but as an **animated SVG terminal cast** rather than a binary: crisp at any size, ~7 KB, diff-able, and regenerated in-repo from the same captures the simulator uses (so it can't drift).

No recording tooling was available (no asciinema/agg/ffmpeg/imagemagick), and a rasterized GIF would be a heavy binary needing a font renderer. A pure-CSS animated SVG sidesteps all of that and GitHub renders it inline as an image.

### What's new
- **`examples/trusted-render-demo/gen-cast.js`** — zero-dependency generator. Reads `docs/js/render-captures.js` and emits `docs/render-cast.svg`: a terminal window (title bar + traffic lights, GitHub-dark palette) that cycles through all six scenarios (3s each, 18s loop), each showing the real `kcp render` command, its content-colored output, a blinking cursor, and a terse verdict, with a progress bar of segments lighting in sequence.
- **`docs/render-cast.svg`** — the generated cast (committed so GitHub/Pages can serve it).
- Embedded at the top of the demo README and as an animated teaser in the docs landing page's Live Demo section (linking to the render simulator).

```bash
node demo.js --capture   # refresh captures
node gen-cast.js         # rebuild docs/render-cast.svg
```

### Why CSS, not SMIL/JS
GitHub strips `<script>` from SVG but animates CSS `@keyframes` in img-embedded SVG — so the cast animates in the README and on the site without any runtime.

### Verification
- SVG is well-formed (balanced `<text>`/`<tspan>`/`<g>`/`<style>`/`<svg>`, zero bare ampersands).
- Frame content spot-checked: each scenario's command, output, and verdict render truthfully (e.g. T9 shows `tier: known` + `content_verified: mismatch`).
- Built from authentic captures — same no-drift guarantee as the simulator.

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_