### PR TITLE
fix(bridge): harden C18 federation temporal filtering (issue #98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Security/correctness — C18 federation temporal hardening (bridges 0.21.1, issue #98)
+
+A downstream-consumer adversarial panel review of the v0.21 C18 filter (PR #95) found the
+temporal guard was enforced only in `search_knowledge`. Fixed across all three bridges, TDD:
+
+- **F1 (critical):** the filter now holds on **every** retrieval path — `get_unit`,
+  `read_resource`, and `list_resources` — not just search. A unit whose federation source is
+  out of window (or whose own window is invalid) is unreadable and unlisted, not merely
+  unsearchable. `get_unit` returns a `temporally_unavailable` error; resource paths omit it.
+- **F2:** `local_mirror` ↔ sub-manifest association is canonicalised (symlink-resolved), so it
+  can't silently fail open on a symlinked/non-canonical path; a loaded sub-manifest that matches
+  no declared `local_mirror` now emits a warning.
+- **F3:** `as_of` is validated as ISO-8601 and rejected (`invalid_as_of`) rather than fed into
+  lexicographic comparison.
+- **F4 (semantic, spec change):** supersession is now enforced — a source whose
+  `temporal.superseded_by` references a *temporally-active* successor is excluded, not co-served.
+  SPEC §3.6 and RFC-0021 updated; this changes the previous "overlap = both active" wording for
+  the supersession case specifically.
+- **F5:** results returned via `include_all_temporal` carry a `caution` so the bypass is observable.
+- **F6:** the effective "today" is pinned to **UTC** in all three bridges and in SPEC/RFC, so
+  they agree at a timezone boundary.
+- **F9:** `list_manifests` accepts an optional `as_of`; `temporally_active` reflects it.
+- **F7/F10:** the duplicate unit/source temporal predicates collapsed to one per bridge; Python
+  source/ref maps now typed `Temporal` rather than `object`.
+- Each fix is mutation-verified; new discriminating tests on the resource paths (TS 216, Python
+  161, Java 161). SPEC §16.5 C18 expanded to require every-path enforcement, UTC, supersession,
+  and `as_of` validation.
 
 ---
 

--- a/RFC-0021-Federation-Temporal.md
+++ b/RFC-0021-Federation-Temporal.md
@@ -136,26 +136,36 @@ manifest-level temporal filtering before fetching and evaluating sub-manifest un
 The effective date for manifest-level filtering is determined identically to unit-level
 temporal filtering (§15.13):
 
-- If `as_of` is set: effective date = `as_of`.
-- If `as_of` is absent: effective date = current date (today).
+- If `as_of` is set: effective date = `as_of`. An `as_of` that is not a valid ISO-8601
+  date/datetime MUST be **rejected** (error), not compared lexically.
+- If `as_of` is absent: effective date = current date (today), computed in **UTC** so all
+  implementations agree at a timezone boundary.
 
 #### Filter rule
 
 A sub-manifest is **temporally included** if and only if:
 
 - The entry has no `temporal` block, **or**
-- `valid_from` is null **or** `valid_from <= effective_date`, **and**
-- `valid_until` is null **or** `valid_until >= effective_date`
+- (`valid_from` is null **or** `valid_from <= effective_date`) **and**
+  (`valid_until` is null **or** `valid_until >= effective_date`), **and**
+- it is **not superseded** — i.e. `temporal.superseded_by` is absent, references an unknown
+  entry, or references an entry that is *not itself temporally included* on the effective date
+  (see *Supersession*, below).
 
 Sub-manifests that fail this filter MUST NOT be fetched. The bridge skips them entirely —
-no HTTP request, no unit loading, no unit-level temporal filtering.
+no HTTP request, no unit loading, no unit-level temporal filtering. The filter applies on
+**every retrieval path** (search, point lookups, resource enumeration), so an excluded
+source's units are unreadable, not merely unsearchable. Bare retrieval paths carry no
+`as_of` and use today (UTC); point-in-time access is via the query path's `as_of`.
 
 #### `include_all_temporal` override
 
 When `include_all_temporal: true`, manifest-level temporal filtering is also bypassed.
 All sub-manifests are traversed regardless of their validity window. This is consistent
 with the parameter's existing semantics: it disables all temporal filtering, not just
-unit-level.
+unit-level. Because the bypass can surface expired or not-yet-valid sources, query results
+returned through it SHOULD carry a `caution` marker so the bypass is observable rather than
+silent.
 
 #### Two-layer composition
 
@@ -176,15 +186,23 @@ The complete filter order for federated queries becomes:
 
 > **manifest-level temporal filter → fetch sub-manifest → score → `not_for` filter → unit-level temporal filter → top-N cut**
 
-#### Overlapping validity windows
+#### Overlapping validity windows and supersession
 
-Multiple sub-manifests MAY be temporally active at the same effective date. This is
-expected and correct — a hub may federate a 2018 corpus (no `valid_until`) alongside a
-2023 corpus (valid from 2023-09-01), and both will be active after that date. Bridges
-query all temporally-included sub-manifests and merge results identically to the existing
-`federation_scope: declared` behaviour. The `source_manifest` field in each result
-identifies the origin. Prioritising results from one sub-manifest over another is a
+Multiple sub-manifests MAY be temporally active at the same effective date when their
+windows merely *overlap* — a hub may federate two unrelated corpora whose windows coincide,
+and both are served. Bridges query all temporally-included sub-manifests and merge results;
+the `source_manifest` field identifies the origin, and prioritising one over another is a
 scoring decision, not a temporal one.
+
+**Supersession is different from mere overlap (v0.21).** When a source declares
+`temporal.superseded_by: <id>` and that successor entry is *itself temporally included* on
+the effective date, the superseded source is **excluded** — the two are not co-served. A
+supersession is an explicit statement that one corpus *replaces* another, not that they
+coexist; once the successor is live, continuing to serve the predecessor is the exact
+compliance hazard (e.g. an expired GDPR-2018 corpus alongside the active GDPR-2023 one) the
+field exists to prevent. Before the successor's `valid_from`, the predecessor is still
+served on its own window. Authors who want two corpora genuinely co-active should use
+overlapping windows *without* `superseded_by`.
 
 #### Response fields
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -664,14 +664,25 @@ manifests:
 own root-level `temporal.recorded_at` already covers when the hub recorded its federation list.
 
 **Resolution behaviour (Level 2):**
-- The effective date is `as_of` if set, else today (§15.13).
+- The effective date is `as_of` if set, else today. "Today" MUST be computed in **UTC**, so
+  implementations agree at a timezone boundary (v0.21; was unspecified).
 - A sub-manifest is *temporally included* iff it has no `temporal` block, OR
   (`valid_from` is null or `valid_from <= effective_date`) AND
   (`valid_until` is null or `valid_until >= effective_date`).
+- **Supersession (v0.21):** a sub-manifest whose `temporal.superseded_by` references another
+  `manifests[]` entry that is *itself temporally included* on the effective date is **excluded**,
+  even if its own window is still open. Once a successor is live, the superseded source is
+  dropped rather than co-served — the two are not both active. (Before its successor's
+  `valid_from`, the superseded source is still included on its own window.)
+- The filter MUST be applied on **every retrieval path**, not only search: a unit whose source
+  is excluded (or whose own unit-level window is invalid) on the effective date MUST NOT be
+  served by point lookups or resource enumeration either. Bare retrieval paths have no `as_of`
+  and use today (UTC); point-in-time access is via the query path's `as_of`.
 - Sub-manifests that fail this filter MUST NOT be fetched: the bridge skips them entirely — no
   HTTP request, no unit loading, no unit-level temporal evaluation.
 - `include_all_temporal: true` (§15.13) bypasses manifest-level filtering and traverses all
-  sub-manifests, consistent with its unit-level semantics.
+  sub-manifests, consistent with its unit-level semantics; query results returned through the
+  bypass SHOULD carry a `caution` marker so the bypass is observable.
 - Manifest-level temporal applies *before* unit-level temporal. The full federated filter order
   is: manifest-level temporal filter → fetch sub-manifest → score → `not_for` → unit-level
   temporal → top-N cut. A skipped sub-manifest simply produces no results — invisible to the
@@ -3325,10 +3336,14 @@ A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18)
   values. A signature over the composing file does not authenticate the bytes its includes
   resolve to.
 - **C18** (v0.21): Bridges that implement federated temporal evaluation (§3.6
-  `manifests[].temporal`) MUST: (a) compute the effective date as `as_of` if set, else today;
-  (b) skip — never fetch — sub-manifests outside their validity window; (c) bypass
-  manifest-level filtering when `include_all_temporal: true`; (d) apply manifest-level temporal
-  before unit-level temporal. Parsers MUST detect `superseded_by` cycles among `manifests[]`
+  `manifests[].temporal`) MUST: (a) compute the effective date as `as_of` if set, else today
+  **in UTC**; (b) skip — never fetch — sub-manifests outside their validity window, *including*
+  a source superseded by a temporally-included successor; (c) bypass manifest-level filtering
+  when `include_all_temporal: true`; (d) apply manifest-level temporal before unit-level
+  temporal; (e) enforce the filter on **every retrieval path** — point lookups and resource
+  enumeration, not only search — so an excluded source's units are unreadable, not merely
+  unsearchable; (f) reject an `as_of` that is not a valid ISO-8601 date/datetime rather than
+  comparing it lexically. Parsers MUST detect `superseded_by` cycles among `manifests[]`
   entries as a manifest error.
 
 The reference implementation is `kcp render` in [`cli/`](./cli/); the render validation corpus

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.21.0</version>
+    <version>0.21.1</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
+++ b/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.*;
 
 /**
@@ -41,6 +42,8 @@ public final class KcpServer {
         // for units from a sub-manifest associated with a manifests[] entry via local_mirror.
         // Primary units and unassociated sub-manifests have no entry (always included).
         Map<String, Temporal> sourceTemporals,
+        // manifests[].id -> temporal, for supersession resolution (issue #98 F4).
+        Map<String, Temporal> refTemporals,
         KnowledgeManifest primaryManifest,
         int totalUnits,
         int manifestTokenTotal
@@ -96,13 +99,19 @@ public final class KcpServer {
             dirMap.put(unit.id(), manifestDir);
         }
 
-        // Associate each federation entry's local_mirror (resolved against the primary dir)
-        // with its manifests[] declaration so a sub-manifest loaded from disk inherits its
-        // source temporal window (§3.6 / C18). Keyed by the resolved absolute mirror path.
+        // manifests[].id -> temporal, for supersession resolution (issue #98 F4).
+        Map<String, Temporal> refTemporalById = new LinkedHashMap<>();
+        for (ManifestRef ref : manifest.manifests()) {
+            refTemporalById.put(ref.id(), ref.temporal());
+        }
+
+        // Associate each federation entry's local_mirror with its manifests[] declaration so a
+        // sub-manifest loaded from disk inherits its source temporal window (§3.6 / C18).
+        // Keyed by the canonical (symlink-resolved) absolute mirror path (issue #98 F2).
         Map<Path, ManifestRef> mirrorToRef = new LinkedHashMap<>();
         for (ManifestRef ref : manifest.manifests()) {
             if (ref.localMirror() != null && !ref.localMirror().isEmpty() && manifestDir != null) {
-                mirrorToRef.put(manifestDir.resolve(ref.localMirror()).normalize().toAbsolutePath(), ref);
+                mirrorToRef.put(canonical(manifestDir.resolve(ref.localMirror())), ref);
             }
         }
 
@@ -110,7 +119,13 @@ public final class KcpServer {
         for (Path subPath : subManifestPaths) {
             Path resolvedSub = subPath.toAbsolutePath();
             Path subDir = resolvedSub.getParent();
-            ManifestRef sourceRef = mirrorToRef.get(resolvedSub.normalize());
+            ManifestRef sourceRef = mirrorToRef.get(canonical(resolvedSub));
+            // A federation that declares mirrors but loads a sub-manifest matching none means
+            // that sub-manifest's units would bypass temporal filtering — surface it (F2).
+            if (sourceRef == null && !mirrorToRef.isEmpty()) {
+                System.err.printf("  [kcp-mcp] warning: sub-manifest %s matched no manifests[].local_mirror"
+                    + " — its units are not subject to federation temporal filtering (§3.6 / C18)%n", resolvedSub);
+            }
             KnowledgeManifest subManifest;
             try {
                 subManifest = KcpParser.parse(resolvedSub);
@@ -139,11 +154,17 @@ public final class KcpServer {
         }
 
         // ── build unit resources from merged context ──────────────────────────────
+        // Resources are registered statically with the SDK, so temporally-excluded units are
+        // filtered here (effective date = today, UTC): they are neither listed nor readable —
+        // not just hidden from search (issue #98 F1). Historical access remains via
+        // search_knowledge's as_of, which reads rs.units() directly.
+        String resourceToday = effectiveToday();
         for (Map.Entry<String, KnowledgeUnit> entry : unitMap.entrySet()) {
             KnowledgeUnit unit    = entry.getValue();
             Path          unitDir = dirMap.get(entry.getKey());
 
             if (agentOnly && !unit.audience().contains("agent")) continue;
+            if (!isUnitServable(unit, srcTempMap.get(entry.getKey()), resourceToday, refTemporalById)) continue;
 
             resources.add(KcpMapper.buildUnitResource(slug, unit));
 
@@ -179,7 +200,7 @@ public final class KcpServer {
                 if (te instanceof Number n) manifestTokenTotal += n.intValue();
             }
         }
-        return new ResourceSet(resources, handlers, unitMap, dirMap, srcTempMap, manifest, unitMap.size(), manifestTokenTotal);
+        return new ResourceSet(resources, handlers, unitMap, dirMap, srcTempMap, refTemporalById, manifest, unitMap.size(), manifestTokenTotal);
     }
 
     // ── Search scoring (package-private for tests) ─────────────────────────────
@@ -256,28 +277,67 @@ public final class KcpServer {
     }
 
     /**
-     * Returns true if the unit is active on the given ISO 8601 date (§15.13).
-     * Units without a temporal block are always active.
+     * Unified bi-temporal inclusion check (§4.22 unit / §3.6 source, §15.13). True when a
+     * {@code temporal} block is valid on {@code asOf}; a null block is always included. One
+     * predicate for both unit and source temporal (issue #98 F7).
      */
-    static boolean isTemporallyActive(KnowledgeUnit unit, String asOf) {
-        var t = unit.temporal();
+    static boolean isTemporallyIncluded(Temporal t, String asOf) {
         if (t == null) return true;
         if (t.validFrom()  != null && t.validFrom().compareTo(asOf)  > 0) return false;
         if (t.validUntil() != null && t.validUntil().compareTo(asOf) < 0) return false;
         return true;
     }
 
+    /** UTC effective date (YYYY-MM-DD). Pinned to UTC so all three bridges agree at a
+     *  timezone boundary (issue #98 F6). */
+    static String effectiveToday() {
+        return LocalDate.now(ZoneOffset.UTC).toString();
+    }
+
+    private static final java.util.regex.Pattern AS_OF_RE =
+        java.util.regex.Pattern.compile("^\\d{4}-\\d{2}-\\d{2}([T ][0-9:.+\\-Z]*)?$");
+
+    /** Validate an {@code as_of} value as an ISO-8601 date or datetime (issue #98 F3). */
+    static boolean isValidAsOf(String s) {
+        return s != null && AS_OF_RE.matcher(s).matches();
+    }
+
     /**
-     * §3.6 / C18 manifest-level (federation source) temporal check. Returns true when a
-     * sub-manifest is relevant as a knowledge source on the effective date. A source with no
-     * temporal block is always included. Applied <em>before</em> unit-level temporal: a source
-     * filtered out here contributes no units at all — the bridge skips it entirely.
+     * §3.6 / C18 manifest-level inclusion with supersession (issue #98 F4). A source is included
+     * iff its window is valid on {@code asOf} AND it is not superseded by another manifests[]
+     * entry whose own window is active — once a successor is live, the superseded source is
+     * dropped, not co-served. {@code refTemporalById} maps manifests[].id → that entry's temporal.
      */
-    static boolean isSourceTemporallyIncluded(Temporal t, String effectiveDate) {
-        if (t == null) return true;
-        if (t.validFrom()  != null && t.validFrom().compareTo(effectiveDate)  > 0) return false;
-        if (t.validUntil() != null && t.validUntil().compareTo(effectiveDate) < 0) return false;
+    static boolean isSourceServable(Temporal t, String asOf, Map<String, Temporal> refTemporalById) {
+        if (!isTemporallyIncluded(t, asOf)) return false;
+        String succ = t != null ? t.supersededBy() : null;
+        if (succ != null && refTemporalById.containsKey(succ)
+                && isTemporallyIncluded(refTemporalById.get(succ), asOf)) {
+            return false;
+        }
         return true;
+    }
+
+    /**
+     * A unit is servable on a date iff its federation source is servable (window valid AND not
+     * superseded) AND its own unit-level window is valid. Every retrieval path gates on this so
+     * get_unit / read_resource / list_resources can't leak temporally excluded content (F1).
+     */
+    static boolean isUnitServable(KnowledgeUnit unit, Temporal sourceT, String asOf,
+                                  Map<String, Temporal> refTemporalById) {
+        return isSourceServable(sourceT, asOf, refTemporalById)
+            && isTemporallyIncluded(unit.temporal(), asOf);
+    }
+
+    /** Canonical absolute path for matching a local_mirror to a loaded sub-manifest. Follows
+     *  symlinks when the file exists so the association can't fail open on a symlinked or
+     *  non-canonical path (issue #98 F2); falls back to lexical normalisation otherwise. */
+    static Path canonical(Path p) {
+        try {
+            return p.toRealPath();
+        } catch (IOException e) {
+            return p.toAbsolutePath().normalize();
+        }
     }
 
     // ── Public factories ──────────────────────────────────────────────────────
@@ -442,14 +502,17 @@ public final class KcpServer {
 
         // Tool: list_manifests
         McpSchema.JsonSchema listManifestsSchema = new McpSchema.JsonSchema(
-            "object", Map.of(), List.of(), null, null, null
+            "object",
+            Map.of("as_of", Map.of("type", "string", "description",
+                "ISO 8601 date (YYYY-MM-DD) to evaluate temporally_active against (§3.6). Default: today (UTC).")),
+            List.of(), null, null, null
         );
 
         server.addTool(new McpServerFeatures.SyncToolSpecification(
             new McpSchema.Tool("list_manifests", null,
                 "List the sub-manifests declared in this knowledge.yaml federation block.",
                 listManifestsSchema, null, null, null),
-            (exchange, request) -> handleListManifests(rs.primaryManifest())
+            (exchange, request) -> handleListManifests(request, rs)
         ));
     }
 
@@ -483,7 +546,14 @@ public final class KcpServer {
                     "{\"error\":\"temporal_query_conflict\",\"message\":\"as_of and include_all_temporal are mutually exclusive.\"}")),
                 true, null, null);
         }
-        String temporalDate = asOf != null ? asOf : LocalDate.now().toString();
+        // F3: reject an unparseable as_of rather than feeding it to lexicographic comparison.
+        if (asOf != null && !isValidAsOf(asOf)) {
+            return new McpSchema.CallToolResult(
+                List.of(new McpSchema.TextContent(
+                    "{\"error\":\"invalid_as_of\",\"message\":\"as_of must be an ISO-8601 date (YYYY-MM-DD)\"}")),
+                true, null, null);
+        }
+        String temporalDate = asOf != null ? asOf : effectiveToday();
 
         if (query.isBlank()) {
             return new McpSchema.CallToolResult(
@@ -501,8 +571,8 @@ public final class KcpServer {
             // scoring and before unit-level temporal. A source outside its validity window is
             // skipped entirely — none of its units are scored or returned. Bypassed by
             // include_all_temporal, consistent with the unit-level semantics below.
-            if (!includeAllTemporal && !isSourceTemporallyIncluded(
-                    rs.sourceTemporals().get(entry.getKey()), temporalDate)) {
+            if (!includeAllTemporal && !isSourceServable(
+                    rs.sourceTemporals().get(entry.getKey()), temporalDate, rs.refTemporals())) {
                 continue;
             }
 
@@ -548,7 +618,16 @@ public final class KcpServer {
         if (!includeAllTemporal) {
             finalResults.removeIf(r -> {
                 KnowledgeUnit u = rs.units().get(r.id());
-                return u != null && !isTemporallyActive(u, temporalDate);
+                return u != null && !isTemporallyIncluded(u.temporal(), temporalDate);
+            });
+        } else {
+            // F5: mark every result so a bypassed (possibly out-of-window) result is observable.
+            finalResults.replaceAll(r -> {
+                String note = r.caution() != null
+                    ? r.caution() + "; temporal filtering bypassed"
+                    : "temporal filtering bypassed (include_all_temporal)";
+                return new SearchResult(r.id(), r.intent(), r.path(), r.uri(), r.score(),
+                    r.matchReason(), r.tokenEstimate(), r.summaryUnit(), note);
             });
         }
 
@@ -629,6 +708,16 @@ public final class KcpServer {
                     "Unit not found: \"" + unitId + "\". Available units: " + ids)),
                 true, null, null);
         }
+        // F1: refuse a temporally-excluded unit by id, matching search / resource paths.
+        // Default effective date is today (UTC); historical access is via search's as_of.
+        String guToday = effectiveToday();
+        if (!isUnitServable(unit, rs.sourceTemporals().get(unitId), guToday, rs.refTemporals())) {
+            return new McpSchema.CallToolResult(
+                List.of(new McpSchema.TextContent(
+                    "{\"error\":\"temporally_unavailable\",\"message\":\"Unit '" + escapeJson(unitId)
+                        + "' is outside its temporal validity window as of " + guToday + "\"}")),
+                true, null, null);
+        }
 
         Path unitDir = rs.unitDirs().get(unitId);
         String mime = KcpMapper.resolveMime(unit);
@@ -694,7 +783,18 @@ public final class KcpServer {
             false, null, null);
     }
 
-    static McpSchema.CallToolResult handleListManifests(KnowledgeManifest manifest) {
+    static McpSchema.CallToolResult handleListManifests(McpSchema.CallToolRequest request, ResourceSet rs) {
+        KnowledgeManifest manifest = rs.primaryManifest();
+        Map<String, Object> args = request.arguments();
+        String asOf = args != null && args.get("as_of") != null ? String.valueOf(args.get("as_of")) : null;
+        // F3: validate as_of here too. F9: temporally_active reflects as_of (else today, UTC).
+        if (asOf != null && !isValidAsOf(asOf)) {
+            return new McpSchema.CallToolResult(
+                List.of(new McpSchema.TextContent(
+                    "{\"error\":\"invalid_as_of\",\"message\":\"as_of must be an ISO-8601 date (YYYY-MM-DD)\"}")),
+                true, null, null);
+        }
+        String lmDate = asOf != null ? asOf : effectiveToday();
         StringBuilder sb = new StringBuilder("[\n");
         List<ManifestRef> refs = manifest.manifests();
         for (int i = 0; i < refs.size(); i++) {
@@ -711,7 +811,7 @@ public final class KcpServer {
             sb.append("\"version_policy\":").append(m.versionPolicy() != null ? "\"" + escapeJson(m.versionPolicy()) + "\"" : "null").append(",");
             sb.append("\"temporal\":").append(temporalJson(m.temporal())).append(",");
             sb.append("\"temporally_active\":").append(
-                isSourceTemporallyIncluded(m.temporal(), LocalDate.now().toString()));
+                isSourceServable(m.temporal(), lmDate, rs.refTemporals()));
             sb.append("}");
         }
         sb.append("\n]");

--- a/bridge/java/src/test/java/no/cantara/kcp/mcp/KcpServerToolsTest.java
+++ b/bridge/java/src/test/java/no/cantara/kcp/mcp/KcpServerToolsTest.java
@@ -266,7 +266,8 @@ class KcpServerToolsTest {
 
     @Test void listManifestsReturnsEmptyArrayWhenNoFederationBlock() throws Exception {
         // "full" fixture has no manifests block
-        McpSchema.CallToolResult result = KcpServer.handleListManifests(fullRs.primaryManifest());
+        McpSchema.CallToolResult result = KcpServer.handleListManifests(
+            new McpSchema.CallToolRequest("list_manifests", Map.of()), fullRs);
 
         assertFalse(result.isError());
         String text = ((McpSchema.TextContent) result.content().get(0)).text();
@@ -278,7 +279,8 @@ class KcpServerToolsTest {
     @Test void listManifestsReturnsManifestEntriesFromFederationBlock() throws Exception {
         KcpServer.ResourceSet fedRs = KcpServer.buildResources(fixture("federation"), false);
 
-        McpSchema.CallToolResult result = KcpServer.handleListManifests(fedRs.primaryManifest());
+        McpSchema.CallToolResult result = KcpServer.handleListManifests(
+            new McpSchema.CallToolRequest("list_manifests", Map.of()), fedRs);
 
         assertFalse(result.isError());
         String text = ((McpSchema.TextContent) result.content().get(0)).text();
@@ -470,11 +472,84 @@ class KcpServerToolsTest {
     }
 
     @Test void fedTemporalListManifestsExposesTemporalAndActivity() throws Exception {
-        McpSchema.CallToolResult result = KcpServer.handleListManifests(fedRs().primaryManifest());
+        KcpServer.ResourceSet rs = fedRs();
+        McpSchema.CallToolResult result = KcpServer.handleListManifests(
+            new McpSchema.CallToolRequest("list_manifests", Map.of()), rs);
         String text = ((McpSchema.TextContent) result.content().get(0)).text();
         assertTrue(text.contains("\"valid_until\":\"2023-09-01\""), text);
         // gdpr-2018 expired as of today; gdpr-2023 active. Both flags present.
         assertTrue(text.contains("\"temporally_active\":false"), text);
         assertTrue(text.contains("\"temporally_active\":true"), text);
+    }
+
+    // ── C18 hardening (issue #98) ─────────────────────────────────────────────
+    private static String toolText(McpSchema.CallToolResult r) {
+        return ((McpSchema.TextContent) r.content().get(0)).text();
+    }
+
+    @Test void hF1_getUnitRefusesExpiredSource() throws Exception {
+        McpSchema.CallToolResult r = KcpServer.handleGetUnit(
+            new McpSchema.CallToolRequest("get_unit", Map.of("unit_id", "gdpr-2018-consent")),
+            fedRs(), "fed-temporal-hub");
+        assertTrue(r.isError());
+        assertTrue(toolText(r).contains("temporally_unavailable"), toolText(r));
+    }
+
+    @Test void hF1_buildResourcesOmitsExpiredKeepsActive() throws Exception {
+        KcpServer.ResourceSet rs = fedRs();
+        java.util.Set<String> uris = new java.util.HashSet<>();
+        for (McpSchema.Resource res : rs.resources()) uris.add(res.uri());
+        assertTrue(uris.contains(KcpMapper.unitUri("fed-temporal-hub", "gdpr-2023-consent")), uris.toString());
+        assertFalse(uris.contains(KcpMapper.unitUri("fed-temporal-hub", "gdpr-2018-consent")), uris.toString());
+        // and no read handler exists for the excluded unit
+        assertFalse(rs.handlers().containsKey(KcpMapper.unitUri("fed-temporal-hub", "gdpr-2018-consent")));
+    }
+
+    @Test void hF2_bindsThroughSymlinkedSubManifest() throws Exception {
+        Path tmp = java.nio.file.Files.createTempDirectory("kcp-fed-");
+        try {
+            Path link = tmp.resolve("mirror-old-link");
+            java.nio.file.Files.createSymbolicLink(link,
+                fixture("fed-temporal").getParent().resolve("mirror-old"));
+            KcpServer.ResourceSet rs = KcpServer.buildResources(fixture("fed-temporal"), false,
+                List.of(link.resolve("knowledge.yaml"), subFixture("fed-temporal", "mirror-new")));
+            McpSchema.CallToolResult r = KcpServer.handleGetUnit(
+                new McpSchema.CallToolRequest("get_unit", Map.of("unit_id", "gdpr-2018-consent")),
+                rs, "fed-temporal-hub");
+            assertTrue(toolText(r).contains("temporally_unavailable"), toolText(r));
+        } finally {
+            try { java.nio.file.Files.walk(tmp).sorted(java.util.Comparator.reverseOrder())
+                .forEach(p -> p.toFile().delete()); } catch (Exception ignore) {}
+        }
+    }
+
+    @Test void hF3_invalidAsOfRejected() throws Exception {
+        McpSchema.CallToolResult r = KcpServer.handleSearchKnowledge(
+            new McpSchema.CallToolRequest("search_knowledge", Map.of("query", "consent gdpr", "as_of", "not-a-date")),
+            fedRs(), "fed-temporal-hub");
+        assertTrue(r.isError());
+        assertTrue(toolText(r).contains("invalid_as_of"), toolText(r));
+    }
+
+    @Test void hF4_supersessionDropsSupersededOnBoundary() throws Exception {
+        String text = fedSearch(fedRs(), Map.of("query", "consent gdpr", "as_of", "2023-09-01"));
+        assertTrue(text.contains("\"id\":\"gdpr-2023-consent\""), text);
+        assertFalse(text.contains("\"id\":\"gdpr-2018-consent\""), text);
+    }
+
+    @Test void hF5_includeAllTemporalMarksCaution() throws Exception {
+        String text = fedSearch(fedRs(), Map.of("query", "consent gdpr", "include_all_temporal", true));
+        assertTrue(text.contains("temporal filtering bypassed"), text);
+    }
+
+    @Test void hF9_listManifestsHonoursAsOf() throws Exception {
+        McpSchema.CallToolResult r = KcpServer.handleListManifests(
+            new McpSchema.CallToolRequest("list_manifests", Map.of("as_of", "2020-01-01")), fedRs());
+        String text = toolText(r);
+        // 2018 active in 2020, 2023 not yet valid: expect at least one true and one false,
+        // and specifically the 2018 entry present with its window.
+        assertTrue(text.contains("\"id\":\"gdpr-2018\""), text);
+        assertTrue(text.contains("\"temporally_active\":true"), text);
+        assertTrue(text.contains("\"temporally_active\":false"), text);
     }
 }

--- a/bridge/python/kcp_mcp/server.py
+++ b/bridge/python/kcp_mcp/server.py
@@ -3,7 +3,10 @@ KCP MCP server — low-level Server API matching the TypeScript bridge pattern.
 """
 import json
 import sys
+import re
 from datetime import date as _date
+from datetime import datetime as _datetime
+from datetime import timezone as _timezone
 from pathlib import Path
 
 from mcp.server import Server
@@ -21,7 +24,7 @@ from mcp.types import (
 from pydantic import AnyUrl
 
 from kcp import parse
-from kcp.model import KnowledgeManifest
+from kcp.model import KnowledgeManifest, Temporal
 
 from .commands import (
     CommandManifest,
@@ -93,11 +96,16 @@ def create_server(
     # Maps unit_id → the federation source's temporal window (manifests[].temporal, §3.6),
     # for units that came from a sub-manifest associated with a manifests[] entry. Primary
     # units and sub-manifests not declared as a local_mirror have no entry (always included).
-    source_temporal: dict[str, object] = {}
+    source_temporal: dict[str, Temporal] = {}
 
-    # Associate each federation entry's local_mirror (resolved against the primary dir) with
-    # its manifests[] declaration, so a sub-manifest loaded from disk inherits its source
-    # temporal window (§3.6 / C18). Keyed by the resolved absolute mirror path.
+    # manifests[].id → temporal, for supersession resolution (issue #98 F4).
+    ref_temporal_by_id: dict[str, Temporal] = {
+        ref.id: ref.temporal for ref in manifest.manifests
+    }
+
+    # Associate each federation entry's local_mirror with its manifests[] declaration so a
+    # sub-manifest loaded from disk inherits its source temporal window (§3.6 / C18). Path.resolve()
+    # canonicalises (follows symlinks), so the association can't fail open on a symlinked path.
     mirror_to_ref: dict[Path, object] = {}
     for ref in manifest.manifests:
         if ref.local_mirror:
@@ -109,6 +117,13 @@ def create_server(
         sub_path = Path(sub_path).resolve()
         sub_dir = sub_path.parent
         source_ref = mirror_to_ref.get(sub_path)
+        # A federation that declares mirrors but loads a sub-manifest matching none means that
+        # sub-manifest's units would bypass temporal filtering — surface it (issue #98 F2).
+        if source_ref is None and mirror_to_ref:
+            sys.stderr.write(
+                f"  [kcp-mcp] warning: sub-manifest {sub_path} matched no manifests[].local_mirror — "
+                f"its units are not subject to federation temporal filtering (§3.6 / C18)\n"
+            )
         try:
             sub_manifest: KnowledgeManifest = parse(sub_path)
         except Exception as e:
@@ -139,14 +154,8 @@ def create_server(
     if commands_dir is not None:
         command_manifests = load_command_manifests(commands_dir)
 
-    # Build static resource list
-    resource_list: list[Resource] = [
-        _build_resource(manifest_resource_dict(slug, manifest))
-    ]
-    for unit, _ in unit_context.values():
-        if agent_only and "agent" not in unit.audience:
-            continue
-        resource_list.append(_build_resource(unit_resource_dict(slug, unit)))
+    # The resource list is built per request in list_resources() so it can omit temporally
+    # excluded units against the current date (issue #98 F1) — not cached statically here.
 
     # Log startup info
     agent_note = " [agent-only]" if agent_only else ""
@@ -163,7 +172,17 @@ def create_server(
 
     @server.list_resources()
     async def list_resources() -> list[Resource]:
-        return resource_list
+        # F1: omit temporally-excluded units (source window closed/superseded, or unit window
+        # invalid) as of today — not just hidden from search.
+        today = _effective_today()
+        out: list[Resource] = [_build_resource(manifest_resource_dict(slug, manifest))]
+        for uid, (unit, _d) in unit_context.items():
+            if agent_only and "agent" not in unit.audience:
+                continue
+            if not _unit_servable(unit, source_temporal.get(uid), today, ref_temporal_by_id):
+                continue
+            out.append(_build_resource(unit_resource_dict(slug, unit)))
+        return out
 
     @server.read_resource()
     async def read_resource(uri: AnyUrl):
@@ -187,6 +206,12 @@ def create_server(
             raise ValueError(f"No unit with id '{unit_id}'")
 
         unit, unit_dir = ctx
+        # F1: refuse a temporally-excluded unit here too, not just in search.
+        today = _effective_today()
+        if not _unit_servable(unit, source_temporal.get(unit_id), today, ref_temporal_by_id):
+            raise ValueError(
+                f"Unit '{unit_id}' is outside its temporal validity window as of {today}"
+            )
         mime = resolve_mime(unit)
         try:
             content, is_binary = read_resource_content(unit_dir, unit.path, mime)
@@ -282,7 +307,12 @@ def create_server(
                 ),
                 inputSchema={
                     "type": "object",
-                    "properties": {},
+                    "properties": {
+                        "as_of": {
+                            "type": "string",
+                            "description": "ISO 8601 date (YYYY-MM-DD) to evaluate temporally_active against (§3.6). Default: today (UTC).",
+                        },
+                    },
                     "required": [],
                 },
             ),
@@ -292,13 +322,13 @@ def create_server(
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         if name == "search_knowledge":
-            return _handle_search_knowledge(unit_context, slug, arguments or {}, source_temporal)
+            return _handle_search_knowledge(unit_context, slug, arguments or {}, source_temporal, ref_temporal_by_id)
         if name == "get_unit":
-            return _handle_get_unit(unit_context, arguments or {})
+            return _handle_get_unit(unit_context, arguments or {}, source_temporal, ref_temporal_by_id)
         if name == "get_command_syntax":
             return _handle_get_command_syntax(command_manifests, arguments or {})
         if name == "list_manifests":
-            return _handle_list_manifests(manifest)
+            return _handle_list_manifests(manifest, arguments or {}, ref_temporal_by_id)
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
     # ── Prompts ──────────────────────────────────────────────────────────────
@@ -396,9 +426,10 @@ def _score_unit(unit, terms: list[str], slug: str) -> dict:
     }
 
 
-def _is_temporally_active(unit, as_of: str) -> bool:
-    """Return True if unit is active on as_of (§15.13). Units without temporal block are always active."""
-    t = getattr(unit, "temporal", None)
+def _is_temporally_included(t, as_of: str) -> bool:
+    """Unified bi-temporal inclusion check (§4.22 unit / §3.6 source, §15.13). True when the
+    `temporal` block is valid on as_of; a None block is always included. One predicate for both
+    unit and source temporal — callers pass unit.temporal or ref.temporal (issue #98 F7)."""
     if t is None:
         return True
     if t.valid_from is not None and t.valid_from > as_of:
@@ -408,18 +439,47 @@ def _is_temporally_active(unit, as_of: str) -> bool:
     return True
 
 
-def _is_source_temporally_included(temporal, effective_date: str) -> bool:
-    """§3.6 / C18 manifest-level (federation source) temporal check. Returns True when a
-    sub-manifest is relevant as a knowledge source on the effective date. A source with no
-    temporal block is always included. Applied *before* unit-level temporal: a source filtered
-    out here contributes no units at all — the bridge skips it entirely."""
-    if temporal is None:
-        return True
-    if temporal.valid_from is not None and temporal.valid_from > effective_date:
+def _effective_today() -> str:
+    """UTC effective date (YYYY-MM-DD). Pinned to UTC so all three bridges agree at a
+    timezone boundary (issue #98 F6)."""
+    return _datetime.now(_timezone.utc).date().isoformat()
+
+
+_AS_OF_RE = re.compile(r"^\d{4}-\d{2}-\d{2}([T ][0-9:.+\-Z]*)?$")
+
+
+def _is_valid_as_of(s: str) -> bool:
+    """Validate as_of as an ISO-8601 date or datetime; reject unparseable values rather than
+    feeding them to lexicographic comparison (issue #98 F3)."""
+    if not _AS_OF_RE.match(s):
         return False
-    if temporal.valid_until is not None and temporal.valid_until < effective_date:
+    try:
+        _datetime.fromisoformat(s.replace("Z", "+00:00") if len(s) > 10 else s)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_source_servable(temporal, as_of: str, ref_temporal_by_id: dict) -> bool:
+    """§3.6 / C18 manifest-level inclusion with supersession (issue #98 F4). A source is included
+    iff its window is valid on as_of AND it is not superseded by another manifests[] entry whose
+    own window is active — once a successor is live, the superseded source is dropped, not co-served."""
+    if not _is_temporally_included(temporal, as_of):
+        return False
+    succ = getattr(temporal, "superseded_by", None) if temporal is not None else None
+    if succ is not None and succ in ref_temporal_by_id and _is_temporally_included(ref_temporal_by_id[succ], as_of):
         return False
     return True
+
+
+def _unit_servable(unit, source_t, as_of: str, ref_temporal_by_id: dict) -> bool:
+    """A unit is servable on a date iff its federation source is servable (window valid AND not
+    superseded by an active successor) AND its own unit-level window is valid. Every retrieval
+    path gates on this so get_unit / read_resource / list_resources can't leak temporally
+    excluded content that search_knowledge already hides (issue #98 F1)."""
+    return _is_source_servable(source_t, as_of, ref_temporal_by_id) and _is_temporally_included(
+        getattr(unit, "temporal", None), as_of
+    )
 
 
 def _match_not_for(unit, terms: list[str]) -> str | None:
@@ -438,6 +498,7 @@ def _handle_search_knowledge(
     slug: str,
     arguments: dict,
     source_temporal: dict | None = None,
+    ref_temporal_by_id: dict | None = None,
 ) -> list[TextContent]:
     """Search knowledge units by query (RFC-0007 query baseline)."""
     query = arguments.get("query", "").strip()
@@ -455,19 +516,25 @@ def _handle_search_knowledge(
             "error": "temporal_query_conflict",
             "message": "as_of and include_all_temporal are mutually exclusive.",
         }))]
-    temporal_date = as_of if as_of is not None else _date.today().isoformat()
+    # F3: reject an unparseable as_of rather than feeding it to lexicographic comparison.
+    if as_of is not None and not _is_valid_as_of(as_of):
+        return [TextContent(type="text", text=json.dumps({
+            "error": "invalid_as_of",
+            "message": f"as_of must be an ISO-8601 date (YYYY-MM-DD); got {as_of!r}",
+        }))]
+    temporal_date = as_of if as_of is not None else _effective_today()
 
     source_temporal = source_temporal or {}
+    ref_temporal_by_id = ref_temporal_by_id or {}
     terms = query.split()
     results = []
 
     for unit_id, (unit, _unit_dir) in unit_context.items():
         # §3.6 / C18: manifest-level (federation source) temporal filter, applied before
-        # scoring and before unit-level temporal. A source outside its validity window is
-        # skipped entirely — none of its units are scored or returned. Bypassed by
-        # include_all_temporal, consistent with the unit-level semantics below.
-        if not include_all_temporal and not _is_source_temporally_included(
-            source_temporal.get(unit_id), temporal_date
+        # scoring and before unit-level temporal. A source outside its window (or superseded
+        # by an active successor, F4) is skipped entirely. Bypassed by include_all_temporal.
+        if not include_all_temporal and not _is_source_servable(
+            source_temporal.get(unit_id), temporal_date, ref_temporal_by_id
         ):
             continue
         # Filter: audience
@@ -507,8 +574,18 @@ def _handle_search_knowledge(
     if not include_all_temporal:
         final_results = [
             r for r in final_results
-            if _is_temporally_active(unit_context.get(r["id"], (None, None))[0], temporal_date)
+            if _is_temporally_included(
+                getattr(unit_context.get(r["id"], (None, None))[0], "temporal", None), temporal_date
+            )
         ]
+    else:
+        # F5: mark every result so a bypassed (possibly out-of-window) result is observable.
+        marked = []
+        for r in final_results:
+            existing = r.get("caution")
+            note = f"{existing}; temporal filtering bypassed" if existing else "temporal filtering bypassed (include_all_temporal)"
+            marked.append({**r, "caution": note})
+        final_results = marked
 
     if not final_results:
         ids = ", ".join(unit_context.keys())
@@ -523,8 +600,12 @@ def _handle_search_knowledge(
 def _handle_get_unit(
     unit_context: dict,
     arguments: dict,
+    source_temporal: dict | None = None,
+    ref_temporal_by_id: dict | None = None,
 ) -> list[TextContent]:
     """Fetch the content of a specific knowledge unit by id."""
+    source_temporal = source_temporal or {}
+    ref_temporal_by_id = ref_temporal_by_id or {}
     unit_id = arguments.get("unit_id", "").strip()
     ctx = unit_context.get(unit_id)
     if ctx is None:
@@ -532,6 +613,14 @@ def _handle_get_unit(
         return [TextContent(type="text", text=f'Unit not found: "{unit_id}". Available units: {ids}')]
 
     unit, unit_dir = ctx
+    # F1: refuse a temporally-excluded unit by id, matching search / read_resource. Default
+    # effective date is today (UTC); historical access is via search_knowledge's as_of.
+    today = _effective_today()
+    if not _unit_servable(unit, source_temporal.get(unit_id), today, ref_temporal_by_id):
+        return [TextContent(type="text", text=json.dumps({
+            "error": "temporally_unavailable",
+            "message": f"Unit '{unit_id}' is outside its temporal validity window as of {today}",
+        }))]
     mime = resolve_mime(unit)
     try:
         content, is_binary = read_resource_content(unit_dir, unit.path, mime)
@@ -572,8 +661,23 @@ def _temporal_to_dict(temporal) -> dict | None:
     return out
 
 
-def _handle_list_manifests(manifest: KnowledgeManifest) -> list[TextContent]:
+def _handle_list_manifests(
+    manifest: KnowledgeManifest,
+    arguments: dict | None = None,
+    ref_temporal_by_id: dict | None = None,
+) -> list[TextContent]:
     """Return JSON array of declared sub-manifests."""
+    arguments = arguments or {}
+    ref_temporal_by_id = ref_temporal_by_id or {r.id: r.temporal for r in manifest.manifests}
+    # F9: temporally_active reflects as_of (else today, UTC), so it can't contradict a
+    # search_knowledge call made with the same historical as_of. F4: supersession-aware.
+    as_of = arguments.get("as_of")
+    if as_of is not None and not _is_valid_as_of(as_of):
+        return [TextContent(type="text", text=json.dumps({
+            "error": "invalid_as_of",
+            "message": f"as_of must be an ISO-8601 date (YYYY-MM-DD); got {as_of!r}",
+        }))]
+    lm_date = as_of if as_of is not None else _effective_today()
     entries = []
     for m in manifest.manifests:
         entry: dict = {
@@ -586,9 +690,7 @@ def _handle_list_manifests(manifest: KnowledgeManifest) -> list[TextContent]:
             "version_pin": m.version_pin,
             "version_policy": m.version_policy,
             "temporal": _temporal_to_dict(m.temporal),
-            "temporally_active": _is_source_temporally_included(
-                m.temporal, _date.today().isoformat()
-            ),
+            "temporally_active": _is_source_servable(m.temporal, lm_date, ref_temporal_by_id),
         }
         entries.append(entry)
     return [TextContent(type="text", text=json.dumps(entries, indent=2))]

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.21.0"
+version = "0.21.1"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/python/tests/test_server.py
+++ b/bridge/python/tests/test_server.py
@@ -1103,3 +1103,88 @@ async def test_fed_temporal_list_manifests_exposes_temporal_and_activity():
     assert old["temporal"]["valid_until"] == "2023-09-01"
     assert old["temporally_active"] is False  # expired as of today
     assert cur["temporally_active"] is True
+
+
+# ── C18 hardening (issue #98) ─────────────────────────────────────────────────
+# The temporal filter must hold on every retrieval path, bind through symlinks, validate
+# as_of, enforce supersession, and be observable when bypassed. Same fed-temporal hub.
+import os as _os
+import tempfile as _tempfile
+
+
+def _fed_text(result):
+    return result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_h_f1_get_unit_refuses_expired_source():
+    server = _fed_server()
+    result = await call_tool(server, "get_unit", {"unit_id": "gdpr-2018-consent"})
+    assert json.loads(_fed_text(result))["error"] == "temporally_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_h_f1_list_resources_hides_expired_keeps_active():
+    server = _fed_server()
+    resources = await call_list_resources(server)
+    names = [r.name for r in resources]
+    assert "gdpr-2023-consent" in names
+    assert "gdpr-2018-consent" not in names
+
+
+@pytest.mark.asyncio
+async def test_h_f1_read_resource_raises_for_expired():
+    server = _fed_server()
+    with pytest.raises(Exception, match="temporal validity window"):
+        await call_read_resource(server, "knowledge://fed-temporal-hub/gdpr-2018-consent")
+
+
+@pytest.mark.asyncio
+async def test_h_f2_binds_through_symlinked_sub_manifest():
+    tmp = _tempfile.mkdtemp(prefix="kcp-fed-")
+    try:
+        link = _os.path.join(tmp, "mirror-old-link")
+        _os.symlink(str(FED_TEMPORAL_DIR / "mirror-old"), link)
+        server = create_server(
+            FED_TEMPORAL_DIR / "knowledge.yaml",
+            warn_on_validation=False,
+            sub_manifests=[Path(link) / "knowledge.yaml", FED_TEMPORAL_DIR / "mirror-new" / "knowledge.yaml"],
+        )
+        result = await call_tool(server, "get_unit", {"unit_id": "gdpr-2018-consent"})
+        assert json.loads(_fed_text(result))["error"] == "temporally_unavailable"
+    finally:
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_h_f3_invalid_as_of_rejected():
+    server = _fed_server()
+    result = await call_tool(server, "search_knowledge", {"query": "consent gdpr", "as_of": "not-a-date"})
+    assert json.loads(_fed_text(result))["error"] == "invalid_as_of"
+
+
+@pytest.mark.asyncio
+async def test_h_f4_supersession_drops_superseded_on_boundary():
+    server = _fed_server()
+    result = await call_tool(server, "search_knowledge", {"query": "consent gdpr", "as_of": "2023-09-01"})
+    ids = [r["id"] for r in json.loads(_fed_text(result))]
+    assert "gdpr-2023-consent" in ids
+    assert "gdpr-2018-consent" not in ids
+
+
+@pytest.mark.asyncio
+async def test_h_f5_include_all_temporal_marks_caution():
+    server = _fed_server()
+    result = await call_tool(server, "search_knowledge", {"query": "consent gdpr", "include_all_temporal": True})
+    rows = json.loads(_fed_text(result))
+    assert rows and all("temporal filtering bypassed" in (r.get("caution") or "") for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_h_f9_list_manifests_honours_as_of():
+    server = _fed_server()
+    result = await call_tool(server, "list_manifests", {"as_of": "2020-01-01"})
+    entries = {e["id"]: e for e in json.loads(_fed_text(result))}
+    assert entries["gdpr-2018"]["temporally_active"] is True
+    assert entries["gdpr-2023"]["temporally_active"] is False

--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "MCP bridge for the Knowledge Context Protocol — exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/bridge/typescript/src/server.ts
+++ b/bridge/typescript/src/server.ts
@@ -2,6 +2,7 @@
 // Reads a knowledge.yaml and exposes its units as MCP resources, tools, and prompts.
 
 import { dirname, resolve } from "node:path";
+import { realpathSync } from "node:fs";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   ListResourcesRequestSchema,
@@ -132,30 +133,57 @@ function scoreUnit(
 }
 
 /**
- * §15.12 / §15.13 temporal activity check.
- * Returns true when the unit should be included for the given date string (YYYY-MM-DD).
- * A unit with no temporal block is always active.
+ * Unified bi-temporal inclusion check (§4.22 unit-level / §3.6 source-level, §15.13).
+ * Returns true when a `temporal` block is valid on the effective date (YYYY-MM-DD).
+ * A null/absent block is always included. One predicate for both unit and source temporal —
+ * callers pass `unit.temporal` or `ref.temporal` (was two body-identical twins; issue #98 F7).
  */
-function isTemporallyActive(unit: KnowledgeUnit, asOf: string): boolean {
-  const t = unit.temporal;
+function isTemporallyIncluded(t: Temporal | undefined, asOf: string): boolean {
   if (!t) return true;
   if (t.valid_from && t.valid_from > asOf) return false;
   if (t.valid_until && t.valid_until < asOf) return false;
   return true;
 }
 
+/** UTC effective date (YYYY-MM-DD). Pinned to UTC so all three bridges agree at a
+ *  timezone boundary (issue #98 F6; RFC-0021 §"Resolution behaviour"). */
+function effectiveToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Validate an `as_of` value as an ISO-8601 date or datetime (issue #98 F3).
+ *  Unparseable values are rejected rather than fed into lexicographic comparison. */
+function isValidAsOf(s: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}([T ][0-9:.+\-Z]*)?$/.test(s)) return false;
+  const d = new Date(s.length === 10 ? s + "T00:00:00Z" : s);
+  return !Number.isNaN(d.getTime());
+}
+
 /**
- * §3.6 / C18 manifest-level (federation source) temporal check. Returns true when a
- * sub-manifest is relevant *as a knowledge source* on the effective date. A source with no
- * `manifests[].temporal` block is always included. This applies *before* unit-level temporal
- * (§4.22): a source filtered out here contributes no units at all — the bridge skips it
- * entirely, equivalent to never fetching it.
+ * §3.6 / C18 manifest-level (federation source) inclusion, with supersession (issue #98 F4).
+ * A source is included iff its window is valid on `asOf` AND it is not superseded by another
+ * `manifests[]` entry whose own window is active on `asOf` — once a successor is live, the
+ * superseded source is dropped, not co-served. `refTemporalById` maps `manifests[].id` →
+ * that entry's temporal block.
  */
-function isSourceTemporallyIncluded(t: Temporal | undefined, effectiveDate: string): boolean {
-  if (!t) return true;
-  if (t.valid_from && t.valid_from > effectiveDate) return false;
-  if (t.valid_until && t.valid_until < effectiveDate) return false;
+function isSourceServable(
+  t: Temporal | undefined,
+  asOf: string,
+  refTemporalById: Map<string, Temporal | undefined>
+): boolean {
+  if (!isTemporallyIncluded(t, asOf)) return false;
+  const succ = t?.superseded_by;
+  if (succ && refTemporalById.has(succ) && isTemporallyIncluded(refTemporalById.get(succ), asOf)) {
+    return false;
+  }
   return true;
+}
+
+/** Canonical absolute path for matching a `local_mirror` to a loaded sub-manifest. Follows
+ *  symlinks and normalises when the file exists, so the association can't silently fail open
+ *  on a symlinked or non-canonical path (issue #98 F2). Falls back to a lexical resolve. */
+function canonicalPath(p: string): string {
+  try { return realpathSync(p); } catch { return resolve(p); }
 }
 
 /** Returns the first not_for phrase matched by any query term, or null (§15.11). */
@@ -225,7 +253,7 @@ export function createKcpServer(
   const mirrorToRef = new Map<string, { id: string; temporal?: Temporal }>();
   for (const ref of manifest.manifests) {
     if (ref.local_mirror) {
-      mirrorToRef.set(resolve(primaryDir, ref.local_mirror), { id: ref.id, temporal: ref.temporal });
+      mirrorToRef.set(canonicalPath(resolve(primaryDir, ref.local_mirror)), { id: ref.id, temporal: ref.temporal });
     }
   }
 
@@ -233,7 +261,15 @@ export function createKcpServer(
   for (const subPath of subManifests) {
     const resolvedSub = resolve(subPath);
     const subDir = dirname(resolvedSub);
-    const sourceRef = mirrorToRef.get(resolvedSub);
+    const sourceRef = mirrorToRef.get(canonicalPath(resolvedSub));
+    // A federation that declares mirrors but loads a sub-manifest matching none means that
+    // sub-manifest's units would bypass temporal filtering — surface it (issue #98 F2).
+    if (!sourceRef && mirrorToRef.size > 0) {
+      process.stderr.write(
+        `  [kcp-mcp] warning: sub-manifest ${resolvedSub} matched no manifests[].local_mirror — ` +
+        `its units are not subject to federation temporal filtering (§3.6 / C18)\n`
+      );
+    }
 
     let subManifest: KnowledgeManifest;
     try {
@@ -283,14 +319,29 @@ export function createKcpServer(
     }
   }
 
-  // ── Build static resource list ────────────────────────────────────────────
-  const resourceList: McpResourceMeta[] = [
-    buildManifestResource(manifest, projectSlug),
-  ];
-  for (const { unit } of unitContextMap.values()) {
-    const r = buildUnitResource(unit, projectSlug, agentOnly);
-    if (r !== null) resourceList.push(r);
-  }
+  // manifests[].id → temporal, for supersession resolution at query time (issue #98 F4).
+  const refTemporalById = new Map<string, Temporal | undefined>(
+    manifest.manifests.map((r) => [r.id, r.temporal])
+  );
+
+  // A unit is *servable* on a date iff its federation source is servable (window valid AND not
+  // superseded by an active successor) AND its own unit-level window is valid. Every retrieval
+  // path gates on this, so get_unit / read_resource / list_resources cannot leak temporally
+  // excluded content that search_knowledge already hides (issue #98 F1).
+  const isUnitServable = (ctx: UnitContext, asOf: string): boolean =>
+    isSourceServable(ctx.sourceTemporal, asOf, refTemporalById) &&
+    isTemporallyIncluded(ctx.unit.temporal, asOf);
+
+  // Build the resource list for a given effective date, omitting non-servable units (F1).
+  const buildResourceList = (asOf: string): McpResourceMeta[] => {
+    const list: McpResourceMeta[] = [buildManifestResource(manifest, projectSlug)];
+    for (const ctx of unitContextMap.values()) {
+      if (!isUnitServable(ctx, asOf)) continue;
+      const r = buildUnitResource(ctx.unit, projectSlug, agentOnly);
+      if (r !== null) list.push(r);
+    }
+    return list;
+  };
 
   const totalUnits = unitContextMap.size;
 
@@ -313,7 +364,7 @@ export function createKcpServer(
   // ── Resource handlers ──────────────────────────────────────────────────────
 
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-    resources: resourceList,
+    resources: buildResourceList(effectiveToday()),
   }));
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
@@ -341,6 +392,12 @@ export function createKcpServer(
     const ctx = unitContextMap.get(unitId);
     if (!ctx) {
       throw new Error(`No unit with id '${unitId}'`);
+    }
+    // C18: a unit outside its (source or unit) temporal window is not served here either —
+    // not just hidden from search (issue #98 F1).
+    const today = effectiveToday();
+    if (!isUnitServable(ctx, today)) {
+      throw new Error(`Unit '${unitId}' is outside its temporal validity window as of ${today}`);
     }
 
     const content = readUnitContent(ctx.manifestDir, ctx.unit, uri);
@@ -441,7 +498,13 @@ export function createKcpServer(
         "List the sub-manifests declared in this knowledge.yaml federation block.",
       inputSchema: {
         type: "object" as const,
-        properties: {},
+        properties: {
+          as_of: {
+            type: "string",
+            description:
+              "ISO 8601 date (YYYY-MM-DD) to evaluate temporally_active against (§3.6). Default: today (UTC).",
+          },
+        },
         required: [],
       },
     },
@@ -471,7 +534,14 @@ export function createKcpServer(
             isError: true,
           };
         }
-        const temporalDate = asOf ?? new Date().toISOString().slice(0, 10);
+        // F3: reject an unparseable as_of rather than feeding it to lexicographic comparison.
+        if (asOf !== undefined && !isValidAsOf(asOf)) {
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ error: "invalid_as_of", message: `as_of must be an ISO-8601 date (YYYY-MM-DD); got ${JSON.stringify(asOf)}` }) }],
+            isError: true,
+          };
+        }
+        const temporalDate = asOf ?? effectiveToday();
 
         if (!query.trim()) {
           return {
@@ -494,7 +564,7 @@ export function createKcpServer(
           // scoring and before unit-level temporal. A source outside its validity window is
           // skipped entirely — none of its units are scored or returned. Bypassed by
           // include_all_temporal, consistent with the unit-level semantics below.
-          if (!includeAllTemporal && !isSourceTemporallyIncluded(ctx.sourceTemporal, temporalDate)) {
+          if (!includeAllTemporal && !isSourceServable(ctx.sourceTemporal, temporalDate, refTemporalById)) {
             continue;
           }
 
@@ -524,7 +594,7 @@ export function createKcpServer(
           ? results
           : results.filter((r) => {
               const uctx = unitContextMap.get(r.id);
-              return uctx ? isTemporallyActive(uctx.unit, temporalDate) : true;
+              return uctx ? isTemporallyIncluded(uctx.unit.temporal, temporalDate) : true;
             });
 
         // §15.11 not_for filter: strict exclusion, soft demotion (score → not_for → top-N per §15.12)
@@ -537,7 +607,18 @@ export function createKcpServer(
           finalResults.push({ ...r, score: Math.max(1, Math.floor(r.score / 2)), caution: `not_for match: '${matched}'` });
         }
 
-        if (finalResults.length === 0) {
+        // F5: when include_all_temporal bypasses the filter, stamp every result with a caution
+        // so a bypassed (potentially expired/out-of-window) result is observable, not silent.
+        const cautioned = includeAllTemporal
+          ? finalResults.map((r) => ({
+              ...r,
+              caution: r.caution
+                ? `${r.caution}; temporal filtering bypassed`
+                : "temporal filtering bypassed (include_all_temporal)",
+            }))
+          : finalResults;
+
+        if (cautioned.length === 0) {
           const ids = [...unitContextMap.keys()].join(", ");
           return {
             content: [
@@ -550,8 +631,8 @@ export function createKcpServer(
         }
 
         // Sort by score descending, take top 5
-        finalResults.sort((a, b) => b.score - a.score);
-        const top5 = finalResults.slice(0, 5);
+        cautioned.sort((a, b) => b.score - a.score);
+        const top5 = cautioned.slice(0, 5);
 
         return {
           content: [
@@ -574,6 +655,24 @@ export function createKcpServer(
               {
                 type: "text" as const,
                 text: `Unit not found: "${unitId}". Available units: ${ids}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        // C18: refuse to serve a temporally-excluded unit by id, matching search/read_resource
+        // (issue #98 F1). The default effective date is today (UTC); historical access is via
+        // search_knowledge's as_of, not a bare get_unit.
+        const todayGu = effectiveToday();
+        if (!isUnitServable(ctx, todayGu)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: "temporally_unavailable",
+                  message: `Unit '${unitId}' is outside its temporal validity window as of ${todayGu}`,
+                }),
               },
             ],
             isError: true,
@@ -605,6 +704,16 @@ export function createKcpServer(
       }
 
       case "list_manifests": {
+        // F9: temporally_active reflects as_of (else today, UTC), so it can't contradict a
+        // search_knowledge call made with the same historical as_of. F4: supersession-aware.
+        const lmAsOf = args?.["as_of"] as string | undefined;
+        if (lmAsOf !== undefined && !isValidAsOf(lmAsOf)) {
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ error: "invalid_as_of", message: `as_of must be an ISO-8601 date (YYYY-MM-DD); got ${JSON.stringify(lmAsOf)}` }) }],
+            isError: true,
+          };
+        }
+        const lmDate = lmAsOf ?? effectiveToday();
         const manifestsList = manifest.manifests.map((m) => ({
           id: m.id,
           url: m.url,
@@ -615,10 +724,7 @@ export function createKcpServer(
           version_pin: m.version_pin ?? null,
           version_policy: m.version_policy ?? null,
           temporal: m.temporal ?? null,
-          temporally_active: isSourceTemporallyIncluded(
-            m.temporal,
-            new Date().toISOString().slice(0, 10)
-          ),
+          temporally_active: isSourceServable(m.temporal, lmDate, refTemporalById),
         }));
         return {
           content: [

--- a/bridge/typescript/tests/tools.test.ts
+++ b/bridge/typescript/tests/tools.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { join } from "node:path";
+import { mkdtempSync, symlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { createKcpServer } from "../src/server.js";
 import { loadCommandManifests } from "../src/commands.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -529,6 +531,107 @@ describe("federation temporal (C18)", () => {
     expect(old.temporal?.valid_until).toBe("2023-09-01");
     expect(old.temporally_active).toBe(false); // expired as of today
     expect(cur.temporally_active).toBe(true);
+  });
+});
+
+// Issue #98 — C18 hardening: the temporal filter must hold on every retrieval path (not just
+// search_knowledge), bind robustly, validate input, enforce supersession, and be observable
+// when bypassed. Same fed-temporal hub: gdpr-2018 (valid_until 2023-09-01, superseded_by
+// gdpr-2023) and gdpr-2023 (valid_from 2023-09-01). "Today" in tests is well after 2023.
+describe("C18 hardening (issue #98)", () => {
+  const FED = join(import.meta.dirname, "fixtures/fed-temporal");
+  const HUB = join(FED, "knowledge.yaml");
+  const MIRRORS = [join(FED, "mirror-old/knowledge.yaml"), join(FED, "mirror-new/knowledge.yaml")];
+
+  async function connect(subManifests = MIRRORS) {
+    const { server } = createKcpServer(HUB, { warnOnValidation: false, subManifests });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    const client = new Client({ name: "t", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(ct);
+    return client;
+  }
+  const txt = (r: unknown) => ((r as { content: Array<{ text: string }> }).content[0].text);
+
+  // ── F1: the filter holds on get_unit / read_resource / list_resources, not just search ──
+  it("F1: get_unit refuses a unit from an expired source (today)", async () => {
+    const c = await connect();
+    const r = await c.callTool({ name: "get_unit", arguments: { unit_id: "gdpr-2018-consent" } });
+    await c.close();
+    expect(r.isError).toBe(true);
+    expect(JSON.parse(txt(r)).error).toBe("temporally_unavailable");
+  });
+
+  it("F1: list_resources hides expired-source units, keeps active ones", async () => {
+    const c = await connect();
+    const { resources } = await c.listResources();
+    await c.close();
+    const names = resources.map((x) => x.name);
+    expect(names).toContain("gdpr-2023-consent");
+    expect(names).not.toContain("gdpr-2018-consent");
+  });
+
+  it("F1: read_resource throws for an expired-source unit", async () => {
+    const c = await connect();
+    await expect(
+      c.readResource({ uri: "knowledge://fed-temporal-hub/gdpr-2018-consent" })
+    ).rejects.toThrow(/temporal validity window/);
+    await c.close();
+  });
+
+  // ── F2: association binds through a symlinked sub-manifest path (no lexical fail-open) ──
+  it("F2: source temporal binds through a symlinked sub-manifest path", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "kcp-fed-"));
+    try {
+      symlinkSync(join(FED, "mirror-old"), join(tmp, "mirror-old-link"), "dir");
+      // Pass the expired mirror via a symlink whose lexical path differs from the hub's
+      // ./mirror-old — only realpath canonicalisation makes the window bind.
+      const c = await connect([join(tmp, "mirror-old-link/knowledge.yaml"), MIRRORS[1]]);
+      const r = await c.callTool({ name: "get_unit", arguments: { unit_id: "gdpr-2018-consent" } });
+      await c.close();
+      expect(JSON.parse(txt(r)).error).toBe("temporally_unavailable");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  // ── F3: as_of is validated, not fed raw into string comparison ──
+  it("F3: an unparseable as_of is rejected", async () => {
+    const c = await connect();
+    const r = await c.callTool({ name: "search_knowledge", arguments: { query: "consent gdpr", as_of: "not-a-date" } });
+    await c.close();
+    expect(r.isError).toBe(true);
+    expect(JSON.parse(txt(r)).error).toBe("invalid_as_of");
+  });
+
+  // ── F4/F8: supersession hard-excludes on the boundary day once the successor is active ──
+  it("F4: on the supersession boundary, the superseded source is dropped", async () => {
+    const c = await connect();
+    const r = await c.callTool({ name: "search_knowledge", arguments: { query: "consent gdpr", as_of: "2023-09-01" } });
+    await c.close();
+    const ids = (JSON.parse(txt(r)) as Array<{ id: string }>).map((x) => x.id);
+    expect(ids).toContain("gdpr-2023-consent");
+    expect(ids).not.toContain("gdpr-2018-consent"); // superseded by an active successor
+  });
+
+  // ── F5: include_all_temporal bypass is marked on results ──
+  it("F5: include_all_temporal stamps a caution on results", async () => {
+    const c = await connect();
+    const r = await c.callTool({ name: "search_knowledge", arguments: { query: "consent gdpr", include_all_temporal: true } });
+    await c.close();
+    const rows = JSON.parse(txt(r)) as Array<{ caution: string | null }>;
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((x) => (x.caution ?? "").includes("temporal filtering bypassed"))).toBe(true);
+  });
+
+  // ── F9: list_manifests honours as_of so it can't contradict a historical search ──
+  it("F9: list_manifests temporally_active reflects as_of", async () => {
+    const c = await connect();
+    const r = await c.callTool({ name: "list_manifests", arguments: { as_of: "2020-01-01" } });
+    await c.close();
+    const entries = JSON.parse(txt(r)) as Array<{ id: string; temporally_active: boolean }>;
+    expect(entries.find((e) => e.id === "gdpr-2018")!.temporally_active).toBe(true);
+    expect(entries.find((e) => e.id === "gdpr-2023")!.temporally_active).toBe(false);
   });
 });
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.21.0 (all three bridges — aligned with KCP spec version)
+**Current version:** 0.21.1 (all three bridges — aligned with KCP spec version)
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -39,8 +39,9 @@ When adding any MCP capability:
 | `search_knowledge`: `summary_unit` field | ✅ | ✅ | ✅ | from hints.summary_unit |
 | `search_knowledge`: `not_for` filter (§15.11) | ✅ | ✅ | ✅ | strict exclusion + soft demotion with `caution` field |
 | `search_knowledge`: temporal query `as_of` / `include_all_temporal` (§15.13) | ✅ | ✅ | ✅ | point-in-time filtering, conflict error on mutual exclusion |
-| `get_unit` tool | ✅ | ✅ | ✅ | fetch unit file content by id |
-| `list_manifests` tool | ✅ | ✅ | ✅ | lists declared sub-manifests (federation §3.6) |
+| Federated temporal filtering, all retrieval paths (§3.6 / C18) | ✅ | ✅ | ✅ | `manifests[].temporal` enforced in search **and** `get_unit` / resources; UTC effective date; supersession-aware; `as_of` validated; `include_all_temporal` marks `caution` (issue #98) |
+| `get_unit` tool | ✅ | ✅ | ✅ | fetch unit file content by id; refuses temporally-excluded units |
+| `list_manifests` tool | ✅ | ✅ | ✅ | lists declared sub-manifests (federation §3.6); optional `as_of`, supersession-aware `temporally_active` |
 | `get_command_syntax` tool | ✅ | ✅ | ✅ | requires `--commands-dir` |
 | `sdd-review` prompt | ✅ | ✅ | ✅ | |
 | `kcp-explore` prompt | ✅ | ✅ | ✅ | |
@@ -104,6 +105,7 @@ No known gaps — all three bridges are at full parity.
 | 0.20.0 | 2026-06-12 | §15.13 temporal query: `as_of` + `include_all_temporal` parameters, `temporal_query_conflict` error — all three bridges. Bridge versions now aligned with KCP spec version. |
 | 0.20.1 | 2026-06-13 | Python bridge: added `sdd-review` and `kcp-explore` MCP prompts — closes last Tier 1 parity gaps. |
 | 0.21.0 | 2026-06-13 | Spec v0.21: parsers expose `manifests[].temporal` (RFC-0021) and `discovery.verified_by`/`evidence`; temporal validation (`superseded_by` cycle detection, validity-window §7 warnings) implemented in all four parser/validator implementations. Bridge skip-before-fetch federation temporal filtering deferred. |
+| 0.21.1 | 2026-06-13 | C18 hardening (issue #98): federated temporal filtering now enforced on **every** retrieval path (`get_unit`, `read_resource`, `list_resources`), not just `search_knowledge`; effective date pinned to UTC; supersession-aware exclusion (`superseded_by` + active successor → drop); `as_of` ISO-8601 validation; `local_mirror` association canonicalised (symlink-safe) with a warning on no match; `include_all_temporal` results carry a `caution`; `list_manifests` gains optional `as_of`. All three bridges. |
 
 > **Note:** v0.7.0--v0.9.0 were internal development milestones that shipped combined as v0.10.0.
 > v0.11.0--v0.13.0 were bridge feature additions that culminated in v0.14.0.


### PR DESCRIPTION
Fixes the findings in #98 — an adversarial-panel review of PR #95 that correctly found the C18 temporal filter was enforced only in `search_knowledge`. I verified the headline claims against source (the CRITICAL and the TS resolve mismatch are real) before fixing. Test-driven, across all three bridges.

## Fixes

| # | Sev | Fix |
|---|-----|-----|
| **F1** | 🔴 CRITICAL | Filter now holds on **every** retrieval path — `get_unit`, `read_resource`, `list_resources` — not just search. `get_unit` → `temporally_unavailable` error; resource paths omit/refuse excluded units. |
| **F2** | 🟠 HIGH | `local_mirror` ↔ sub-manifest association canonicalised (symlink-resolved) so it can't fail open; warns when a loaded sub-manifest matches no declared mirror. |
| **F3** | 🟠 HIGH | `as_of` validated as ISO-8601 → `invalid_as_of`, instead of raw lexicographic comparison. |
| **F4** | 🟡 MED *(semantic)* | **Supersession enforced** — a source whose `superseded_by` references a temporally-active successor is excluded, not co-served. |
| **F5** | 🟡 MED | `include_all_temporal` results carry a `caution`. |
| **F6** | 🟡 MED | Effective "today" pinned to **UTC** in all three bridges + spec/RFC. |
| **F9** | 🟢 | `list_manifests` accepts optional `as_of`; `temporally_active` reflects it. |
| **F7/F10** | 🟢 | Duplicate unit/source temporal predicates collapsed to one per bridge; Python maps typed `Temporal`. |

## ⚠️ One decision for your explicit review — F4

F4 was flagged in the issue as *"worth an RFC decision,"* not a code bug. I implemented supersession-exclusion (the compliance-correct behaviour for the motivating GDPR example) **and updated the normative text** — SPEC §3.6 and RFC-0021 now say a superseded source is dropped once its successor is active, narrowing the previous "overlap = both active" wording to the non-supersession case. If you'd rather keep both-active and only warn, that's the one commit to revert; everything else is pure hardening.

## Spec/RFC

- SPEC §3.6 resolution behaviour: UTC effective date, supersession rule, every-path enforcement, `as_of` validation.
- SPEC §16.5 **C18** expanded with clauses (e) every-path and (f) `as_of` validation, plus UTC + supersession in (a)/(b).
- RFC-0021 resolution-behaviour + a new "supersession ≠ overlap" subsection.

## Validation

Each fix is **mutation-verified**. New discriminating tests run on the resource paths (not just search), including a symlink test for F2 and a boundary test for F4. Full suites green: **TS 216, Python 161, Java 161**, version-drift guard 13. Bridges bumped to **0.21.1** (parity rule); `PARITY.md` + `CHANGELOG` updated.

## Deferred (transparent)

- **F11** (Java `temporalJson` hand-rolled vs. mapper) — left as-is; cosmetic, low-risk.
- **F12** (language-neutral conformance runner over shared `{as_of, window} → expected` vectors) — real infrastructure value, but a separate change; the per-bridge fixtures + mutation tests stand for now. Happy to do it as a follow-up.

Closes #98 (modulo F11/F12, which I can split into a tracking issue if you prefer).

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_