### PR TITLE
feat(v0.22): Trust & Attestation — agent_requirements + extended auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Spec — v0.22 "Trust & Attestation" foundation (RFC-0004 + RFC-0002 promotion)
+
+The consumer-identity half of the security model, promoted to the spec (implementation lands in
+subsequent phases across parsers, renderer, and bridges):
+
+- **`trust.agent_requirements` (SPEC §3.2)** — `require_attestation`, `trusted_providers`
+  (identity), `attestation_url` + `attestation_jwks` (credential), and `propagate_to_governed`.
+  Declares what an agent must prove about *itself* before a source serves `access: restricted`
+  units — the counterpart to `content_integrity`, which authenticates the producer. **KCP
+  declares; agents attest** — the renderer never dereferences `attestation_url` (stays
+  deterministic/network-free).
+- **Extended `auth.methods` types (SPEC §3.3)** — `bearer_token`, `spiffe`, `did`,
+  `http_signature` (RFC 9421) promoted from RFC-0002; `type` values beyond the now-seven defined
+  remain silently ignored.
+- **`governs` attestation propagation (#47)** — resolved via `agent_requirements.propagate_to_governed`:
+  a governing manifest's attestation requirements become a floor on its governed sources.
+- **Conformance C19–C21 (SPEC §16.5)** — C19 renderer surfaces `agent_requirements` and never
+  attests; C20 bridges refuse restricted-unit content on every retrieval path unless the declared
+  credential is presented (never calling `attestation_url` themselves); C21 `governs` propagation.
+- RFC-0004 and RFC-0002 headers updated to mark these Accepted → v0.22.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,57 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Spec — v0.22 "Trust & Attestation" foundation (RFC-0004 + RFC-0002 promotion)
+_Nothing yet._
 
-The consumer-identity half of the security model, promoted to the spec (implementation lands in
-subsequent phases across parsers, renderer, and bridges):
+---
 
-- **`trust.agent_requirements` (SPEC §3.2)** — `require_attestation`, `trusted_providers`
-  (identity), `attestation_url` + `attestation_jwks` (credential), and `propagate_to_governed`.
-  Declares what an agent must prove about *itself* before a source serves `access: restricted`
-  units — the counterpart to `content_integrity`, which authenticates the producer. **KCP
-  declares; agents attest** — the renderer never dereferences `attestation_url` (stays
-  deterministic/network-free).
-- **Extended `auth.methods` types (SPEC §3.3)** — `bearer_token`, `spiffe`, `did`,
-  `http_signature` (RFC 9421) promoted from RFC-0002; `type` values beyond the now-seven defined
-  remain silently ignored.
-- **`governs` attestation propagation (#47)** — resolved via `agent_requirements.propagate_to_governed`:
-  a governing manifest's attestation requirements become a floor on its governed sources.
-- **Conformance C19–C21 (SPEC §16.5)** — C19 renderer surfaces `agent_requirements` and never
-  attests; C20 bridges refuse restricted-unit content on every retrieval path unless the declared
-  credential is presented (never calling `attestation_url` themselves); C21 `governs` propagation.
-- RFC-0004 and RFC-0002 headers updated to mark these Accepted → v0.22.
+## [0.22.0] — 2026-07-04 — Trust & Attestation
+
+**Spec version:** `"0.22"` | **Prior:** `"0.21"` (v0.21.0, 2026-06-13)
+
+The consumer-identity half of the security model. Where v0.16–v0.21 answered "is this knowledge
+intact and current?", v0.22 answers "who may consume it, and how do they prove it?" — promoting
+the attestation half of RFC-0004 and the extended-auth remainder of RFC-0002.
+
+**Load-bearing principle: KCP *declares* trust requirements; it never *performs* auth.** The
+renderer never dereferences `attestation_url` (deterministic/network-free, C1/C7); the bridge
+gates restricted-unit content on a *presented* credential but never verifies it. Agents attest.
+
+### Spec — RFC-0004 + RFC-0002 promotion
+
+- **`trust.agent_requirements` (§3.2)** — `require_attestation`, `trusted_providers` (identity),
+  `attestation_url` + `attestation_jwks` (credential), and `propagate_to_governed`. Declares what
+  an agent must prove about *itself* before a source serves `access: restricted` units — the
+  consumer counterpart to `content_integrity`, which authenticates the producer.
+- **Extended `auth.methods` types (§3.3)** — `bearer_token`, `spiffe`, `did`, `http_signature`
+  (RFC 9421) promoted; `type` values beyond the now-seven defined remain silently ignored.
+- **`governs` attestation propagation (closes #47)** — `agent_requirements.propagate_to_governed`:
+  a governing manifest's attestation requirements become a floor on its governed sources (C21).
+- **Conformance C19–C21 (§16.5).**
+
+### Parsers (Level 1)
+
+- All four implementations parse, expose, and validate `trust.agent_requirements` and the
+  extended `auth.methods` sub-fields (`trust_domain`, `supported_methods`, `key_id`, `algorithm`).
+- Validator warnings: non-HTTPS `attestation_url`/`jwks`; unsatisfiable `require_attestation`
+  (no providers/url); `propagate_to_governed` with no `governs` relationship.
+- `knowledge-schema.json` gains `trust_agent_requirements` + the new auth sub-fields.
+
+### Renderer (C19)
+
+- `kcp render` surfaces `trust.agent_requirements` as data and marks `access: restricted` units
+  `requires_attestation: true` when the manifest requires it — copying declared strings verbatim,
+  never dereferencing them. Load-eligibility is **not** gated on attestation (flag, not gate — the
+  renderer can't attest; the bridge does the real gate). `render-schema.json` whitelists the block.
+
+### Bridges (C20)
+
+- All three MCP bridges refuse restricted-unit *content* on every retrieval path (`get_unit`,
+  `read_resource`, `list_resources`) unless the client presents an `attestation` argument, which
+  the bridge checks for presence only — it never calls `attestation_url`. `get_unit` returns
+  `attestation_required` (surfacing the declared providers/url); `search_knowledge` marks restricted
+  units `requires_attestation`. New `attestation` argument on `get_unit` + `search_knowledge`.
+- Bridges bumped to 0.22.0 (parity rule).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ project or documentation site. It adds the metadata layer that llms.txt cannot e
 - **Trust & integrity** (v0.16+): signed manifests, per-unit content hashes, and a trusted render pipeline so execution-capable agents never ingest unauthenticated prose
 - **Temporal validity** (v0.19+): validity windows (`valid_from`/`valid_until`), supersession chains, and point-in-time (`as_of`) queries for audit and future-dated policy
 - **Composition** (v0.19+): compose manifests from other manifests — include, override, exclude — without forking
+- **Trust & attestation** (v0.22+): `trust.agent_requirements` declares what an agent must prove about *itself* before restricted units are served — extended `auth.methods` (SPIFFE, DID, HTTP Message Signatures) and attestation gating enforced by the bridge. KCP *declares* the requirement; the agent *attests*
 
 ---
 
@@ -423,9 +424,9 @@ The format is intentionally minimal and builds incrementally through promoted RF
 - **[SPEC.md](./SPEC.md)** — Normative specification (field definitions, validation rules, conformance levels)
 - **[PROPOSAL.md](./PROPOSAL.md)** — The case for a knowledge architecture standard
 - **[RFC-0001](./RFC-0001-KCP-Extended.md)** — Extended capabilities (overview of all proposals; F/H/I/J/K/L/N promoted to v0.3–v0.4 core)
-- **[RFC-0002](./RFC-0002-Auth-and-Delegation.md)** — Auth and delegation metadata (`access`, `auth_scope`, `auth` promoted to core in v0.5–v0.6; `delegation` promoted to core in v0.7)
+- **[RFC-0002](./RFC-0002-Auth-and-Delegation.md)** — Auth and delegation metadata (`access`, `auth_scope`, `auth` promoted to core in v0.5–v0.6; `delegation` promoted to core in v0.7; extended `auth.methods` types `bearer_token`/`spiffe`/`did`/`http_signature` promoted in v0.22)
 - **[RFC-0003](./RFC-0003-Federation.md)** — Cross-manifest federation proposal (`manifests`, `external_depends_on`, `external_relationships` — promoted to core in v0.9 as DAG with local authority)
-- **[RFC-0004](./RFC-0004-Trust-and-Compliance.md)** — Trust, provenance, and compliance metadata (`trust.provenance`, `sensitivity` promoted in v0.5; `trust.audit` promoted in v0.6; `compliance` promoted to core in v0.7)
+- **[RFC-0004](./RFC-0004-Trust-and-Compliance.md)** — Trust, provenance, and compliance metadata (`trust.provenance`, `sensitivity` promoted in v0.5; `trust.audit` promoted in v0.6; `compliance` promoted to core in v0.7; `content_integrity` in v0.16; `trust.agent_requirements` attestation promoted in v0.22 — conformance C19–C21)
 - **[RFC-0005](./RFC-0005-Payment-and-Rate-Limits.md)** — Payment and rate-limit metadata proposal (`payment.default_tier` promoted to core in v0.5; `rate_limits` promoted to core in v0.8; payment methods and x402 remain RFC)
 - **[RFC-0006](./RFC-0006-Context-Window-Hints.md)** — Context window hints (accepted; promoted to SPEC.md §4.10 in v0.4)
 - **[RFC-0007](./RFC-0007-Query-Vocabulary.md)** — Query vocabulary (accepted; promoted to SPEC.md §15 in v0.14): `terms`, `audience`, `max_token_budget`, `has_capabilities`, `exclude_stale`, `federation_scope`

--- a/RFC-0002-Auth-and-Delegation.md
+++ b/RFC-0002-Auth-and-Delegation.md
@@ -22,7 +22,7 @@ The following proposals from this RFC have been promoted to the core specificati
 | `delegation` (root-level) | v0.7 | Level 3 | Proposal 3. `max_depth`, `require_capability_attenuation`, `audit_chain`, `human_in_the_loop`. |
 
 **Still RFC-only (not yet promoted):**
-- `auth.methods` types beyond the core three: `bearer_token`, `spiffe`, `did`, `http_signature` — awaiting implementation feedback.
+- ~~`auth.methods` types beyond the core three: `bearer_token`, `spiffe`, `did`, `http_signature`~~ — **promoted to SPEC.md §3.3 in v0.22**. Parsers MUST parse and expose them; `type` values beyond the now-seven defined types are still silently ignored for forward compatibility.
 - `auth` at unit level (per-unit auth override) — awaiting real-world use cases.
 - `delegation` at unit level (per-unit delegation override) — promoted at root level in v0.7; per-unit override awaiting real-world use cases.
 - `require_delegation_proof` — awaiting XAA / OIDC-A stabilization.

--- a/RFC-0004-Trust-and-Compliance.md
+++ b/RFC-0004-Trust-and-Compliance.md
@@ -30,7 +30,7 @@ The following proposals from this RFC have been promoted to the core specificati
 **Still RFC-only (not yet promoted):**
 - ~~`trust.content_integrity`~~ — **promoted to SPEC.md §3.2 in v0.16**, activated by the trusted render pipeline (RFC-0018), with `EdDSA` (Ed25519, RFC 8037) profiled as the mandatory-to-implement JWS algorithm.
 - `trust.audit.provides_access_receipts` / `receipt_format` — awaiting implementation feedback on receipt formats.
-- `trust.agent_requirements` — `require_attestation`, `trusted_providers`, `attestation_url`, `attestation_jwks` awaiting OIDC-A ratification and community input.
+- ~~`trust.agent_requirements`~~ — **promoted to SPEC.md §3.2 in v0.22** (`require_attestation`, `trusted_providers`, `attestation_url`, `attestation_jwks`, plus `propagate_to_governed` for `governs`-edge policy propagation, resolving [#47](https://github.com/Cantara/knowledge-context-protocol/issues/47)). Conformance C19 (renderer surfaces, never attests), C20 (bridge gates restricted-unit content on presented credential), C21 (`governs` propagation). KCP declares; agents attest.
 - `trust.provenance.publisher_did` — W3C DID resolution not yet common enough for core.
 - `compliance` at unit level (per-unit compliance override) — promoted at root level in v0.7; per-unit override awaiting real-world validation.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -283,8 +283,43 @@ Tier semantics are defined in §16.2.
 All sub-fields of `trust` are OPTIONAL. An empty `trust` block (no sub-fields) is valid and
 SHOULD be silently accepted. Unknown sub-fields MUST be silently ignored.
 
-Access receipts and agent attestation requirements remain in
-[RFC-0004](./RFC-0004-Trust-and-Compliance.md) and may be promoted in a future version.
+#### `trust.agent_requirements` sub-fields (v0.22)
+
+Promoted from [RFC-0004](./RFC-0004-Trust-and-Compliance.md). Where `content_integrity`
+authenticates *who published* a manifest, `agent_requirements` declares what an agent must
+prove about *itself* before the source serves its `access: restricted` units — the
+consumer-identity counterpart to the producer-integrity block above.
+
+**KCP declares these requirements; it does not perform authentication.** The verification
+mechanism — an on-chain token check, a W3C Verifiable Credential, an OIDC-A claim, a SPIFFE
+assertion — is outside KCP's scope. The agent runtime attests; the manifest only declares what
+attestation is expected, so agents can plan before attempting access. A conforming renderer
+never calls `attestation_url` (it stays deterministic and network-free, §16.5 C19).
+
+```yaml
+trust:
+  agent_requirements:
+    require_attestation: true
+    # Satisfied by EITHER trusted_providers (identity-based) OR attestation_url
+    # (credential-based) — either is sufficient.
+    trusted_providers: ["internal-agents.acme.com"]
+    attestation_url: "https://acme.com/v1/attest"
+    attestation_jwks: "https://acme.com/.well-known/jwks.json"
+    propagate_to_governed: false
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `require_attestation` | OPTIONAL | boolean | If `true`, agents MUST present attestation before accessing `access: restricted` units. Satisfied by `trusted_providers` OR `attestation_url` — either is sufficient. Default: `false`. |
+| `trusted_providers` | OPTIONAL | list of strings | Trusted agent-provider domain names (identity-based). Matched against the OIDC-A `agent_provider` claim or equivalent. Agents not matching SHOULD be refused access to restricted units. |
+| `attestation_url` | OPTIONAL | string | HTTPS endpoint that verifies agent credentials (credential-based). MUST use HTTPS. If present, `require_attestation` SHOULD be `true`. The verification mechanism is out of scope. |
+| `attestation_jwks` | OPTIONAL | string | JWKS endpoint URL for verifying signed responses from `attestation_url`. If absent, agents MUST use the TLS certificate of `attestation_url` as the trust anchor. |
+| `propagate_to_governed` | OPTIONAL | boolean | If `true`, a manifest that `governs` another (§3.6) declares that its governed manifests MUST satisfy at least these attestation requirements. Agents resolving a `governs` edge SHOULD enforce the governing manifest's requirements on the governed source, or surface a §7 warning when the governed manifest declares weaker requirements. Default: `false`. |
+
+Attestation and payment ([RFC-0005](./RFC-0005-Payment-and-Rate-Limits.md)) are independent
+axes that compose as **token-gated access**: an agent calls `attestation_url` first; on success
+access is granted, on failure it falls through to `payment.methods`. Access-by-proof lives in
+`trust`; access-by-transaction lives in `payment`.
 
 ### 3.3 `auth`
 
@@ -331,10 +366,15 @@ specification:
 | `none` | No credentials required. | None. |
 | `oauth2` | OAuth 2.1 authentication. | `issuer`, `scopes`, `registration_url` |
 | `api_key` | API key passed in a named HTTP header. | `header`, `registration_url` |
+| `bearer_token` | Opaque bearer token in the `Authorization` header (v0.22). | `registration_url` |
+| `spiffe` | SPIFFE/SPIRE workload identity — the agent presents an SVID (v0.22). | `trust_domain` |
+| `did` | Decentralized Identifier authentication (v0.22). | `supported_methods` (e.g. `did:web`, `did:key`) |
+| `http_signature` | HTTP Message Signatures, [RFC 9421](https://datatracker.ietf.org/doc/html/rfc9421) — used by Visa TAP and Mastercard Agent Pay (v0.22). | `key_id`, `algorithm` |
 
-Unknown `type` values MUST be silently ignored by parsers. This enables forward compatibility
-with additional auth types defined in [RFC-0002](./RFC-0002-Auth-and-Delegation.md) (e.g.
-`spiffe`, `did`, `bearer_token`, `http_signature`) without requiring core spec changes.
+The `bearer_token`, `spiffe`, `did`, and `http_signature` types are promoted from
+[RFC-0002](./RFC-0002-Auth-and-Delegation.md) in v0.22. Parsers MUST parse and expose them.
+`type` values beyond those in the table above MUST still be silently ignored, preserving
+forward compatibility for auth types defined in future versions.
 
 ##### `type: none`
 
@@ -372,6 +412,47 @@ authorization.
 |-----------|----------|-------------|
 | `header` | REQUIRED | Name of the HTTP header that carries the API key (e.g. `"X-API-Key"`, `"Authorization"`). |
 | `registration_url` | OPTIONAL | URL where agents or operators can register for an API key. |
+
+##### `type: bearer_token` (v0.22)
+
+Declares that the source accepts an opaque bearer token in the `Authorization: Bearer <token>`
+header. Unlike `oauth2`, no issuer/discovery flow is implied — the token is obtained
+out-of-band.
+
+| Sub-field | Required | Description |
+|-----------|----------|-------------|
+| `registration_url` | OPTIONAL | URL where agents or operators can obtain a token. |
+
+##### `type: spiffe` (v0.22)
+
+Declares that the source authenticates agents by [SPIFFE](https://spiffe.io/) workload
+identity — the agent presents an SVID (X.509 or JWT) proving membership in a trust domain.
+Suited to non-human / agentic workloads.
+
+| Sub-field | Required | Description |
+|-----------|----------|-------------|
+| `trust_domain` | REQUIRED | The SPIFFE trust domain the source accepts (e.g. `"acme.internal"`). |
+
+##### `type: did` (v0.22)
+
+Declares that the source authenticates agents via a [Decentralized Identifier](https://www.w3.org/TR/did-core/).
+The agent proves control of a DID; the source resolves it to verify.
+
+| Sub-field | Required | Description |
+|-----------|----------|-------------|
+| `supported_methods` | OPTIONAL | List of accepted DID methods (e.g. `["did:web", "did:key"]`). Absent = any resolvable method. |
+
+##### `type: http_signature` (v0.22)
+
+Declares that the source authenticates requests with [HTTP Message Signatures (RFC 9421)](https://datatracker.ietf.org/doc/html/rfc9421) —
+the emerging agent-payments authentication standard (Visa TAP, Mastercard Agent Pay). Note this
+is the same mechanism `trust.content_integrity.signing.method: http_signature` names for
+transport integrity (§3.2); here it authenticates the *consumer*.
+
+| Sub-field | Required | Description |
+|-----------|----------|-------------|
+| `key_id` | RECOMMENDED | Identifier of the key the agent signs with, echoed in the signature's `keyid` parameter. |
+| `algorithm` | OPTIONAL | Signature algorithm (e.g. `"ed25519"`, `"ecdsa-p256-sha256"`). |
 
 #### `auth` block conformance
 
@@ -3301,7 +3382,7 @@ minimum trigger `on_failure: warn` (§3.6). Pinning applies per-edge.
 
 ### 16.5 Renderer conformance
 
-A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18), C15 (RFC-0020, v0.19), C16 (v0.20), C17 (RFC-0022, v0.21), and C18 (RFC-0021, v0.21):
+A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18), C15 (RFC-0020, v0.19), C16 (v0.20), C17 (RFC-0022, v0.21), C18 (RFC-0021, v0.21), and C19–C21 (RFC-0004/0002, v0.22):
 
 - **C1–C10** (RFC-0018): determinism (C1), fail-closed emission (C2), schema-only output (C3),
   no `load_eligible: true` on executable/service/unknown kinds (C4), no auto-traversal below
@@ -3345,6 +3426,26 @@ A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18)
   unsearchable; (f) reject an `as_of` that is not a valid ISO-8601 date/datetime rather than
   comparing it lexically. Parsers MUST detect `superseded_by` cycles among `manifests[]`
   entries as a manifest error.
+- **C19** (v0.22): The renderer surfaces `trust.agent_requirements` (§3.2) as data and **never
+  performs attestation** — it MUST NOT dereference `attestation_url`, `attestation_jwks`, or
+  `trusted_providers`, keeping the render deterministic (C1) and network-free (C7). A unit whose
+  `access` is `restricted` under a manifest declaring `require_attestation: true` is rendered
+  with a `requires_attestation: true` marker; the renderer does **not** on that basis alone set
+  `load_eligible: false` (attestation is the agent's runtime act, not the renderer's — gating it
+  at render time would be theater). Trust-tier and integrity gating (C4/C11/C17) still apply
+  independently.
+- **C20** (v0.22): Bridges that implement attestation gating MUST refuse to serve the *content*
+  of an `access: restricted` unit — on every retrieval path (search, point lookup, resource
+  read) — unless the client has presented the credential type the manifest declares in
+  `trust.agent_requirements` (identity via `trusted_providers`, or a credential accepted by
+  `attestation_url`). The bridge MUST NOT itself call `attestation_url`; it verifies that a
+  declared credential was presented, surfacing the requirement (and refusal reason) as data. A
+  restricted unit served to an unattested client is a C20 violation.
+- **C21** (v0.22): When a manifest `governs` another (§3.6) and its `agent_requirements` sets
+  `propagate_to_governed: true`, an agent resolving the `governs` edge MUST treat the governing
+  manifest's attestation requirements as a floor on the governed source, emitting a §7 warning
+  when the governed manifest declares weaker requirements (or none). Parsers expose
+  `propagate_to_governed`; enforcement is a resolution-time (Level 2) behaviour.
 
 The reference implementation is `kcp render` in [`cli/`](./cli/); the render validation corpus
 lives in [`experiments/rfc-0018-render/`](./experiments/rfc-0018-render/) (cases A10–A12, B17–B20

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knowledge Context Protocol (KCP) Specification
 
-**Version:** 0.21
+**Version:** 0.22
 **Status:** Draft
 **Date:** 2026-06-12
 **Repository:** github.com/cantara/knowledge-context-protocol

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.21.1</version>
+    <version>0.22.0</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
+++ b/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
@@ -158,6 +158,11 @@ public final class KcpServer {
         // filtered here (effective date = today, UTC): they are neither listed nor readable —
         // not just hidden from search (issue #98 F1). Historical access remains via
         // search_knowledge's as_of, which reads rs.units() directly.
+        // §3.2 / C20 (v0.22): does the primary manifest require agent attestation?
+        boolean requireAttestation = manifest.trust() != null
+                && manifest.trust().agentRequirements() != null
+                && Boolean.TRUE.equals(manifest.trust().agentRequirements().requireAttestation());
+
         String resourceToday = effectiveToday();
         for (Map.Entry<String, KnowledgeUnit> entry : unitMap.entrySet()) {
             KnowledgeUnit unit    = entry.getValue();
@@ -172,8 +177,16 @@ public final class KcpServer {
             final String mime     = KcpMapper.resolveMime(unit);
             final String unitPath = unit.path();
             final Path finalUnitDir = unitDir;
+            // C20: a resource read carries no attestation channel — restricted units under a
+            // manifest requiring attestation are fetched via get_unit with an attestation argument.
+            final boolean needsAttestation = requireAttestation && "restricted".equals(unit.access());
+            final String uid = unit.id();
 
             handlers.put(unitUri, uri -> {
+                if (needsAttestation) {
+                    throw new IllegalStateException("Unit '" + uid + "' requires agent attestation (§3.2); "
+                            + "fetch it via the get_unit tool with an 'attestation' argument");
+                }
                 try {
                     KcpContent.ContentResult content = KcpContent.read(finalUnitDir, unitPath, mime);
                     if (content.binary()) {
@@ -292,6 +305,20 @@ public final class KcpServer {
      *  timezone boundary (issue #98 F6). */
     static String effectiveToday() {
         return LocalDate.now(ZoneOffset.UTC).toString();
+    }
+
+    /** §3.2 / C20: a restricted unit under a manifest requiring attestation must not be served
+     *  unless a credential is presented. The bridge checks presence only — never verifies. */
+    static boolean unitNeedsAttestation(KnowledgeManifest manifest, KnowledgeUnit unit) {
+        var t = manifest.trust();
+        return t != null && t.agentRequirements() != null
+                && Boolean.TRUE.equals(t.agentRequirements().requireAttestation())
+                && "restricted".equals(unit.access());
+    }
+
+    static boolean attestationPresented(Map<String, Object> args) {
+        Object a = args != null ? args.get("attestation") : null;
+        return a != null && !"".equals(a);
     }
 
     private static final java.util.regex.Pattern AS_OF_RE =
@@ -453,6 +480,8 @@ public final class KcpServer {
             "ISO 8601 date for point-in-time temporal query (§15.13). Default: today."));
         searchProps.put("include_all_temporal", Map.of("type", "boolean", "description",
             "If true, skip temporal filtering and return all units regardless of valid_from/valid_until (§15.13). Mutually exclusive with as_of."));
+        searchProps.put("attestation", Map.of("type", "string", "description",
+            "Agent attestation credential (§3.2). When presented, restricted units are not marked requires_attestation. Presence is checked; the credential is not verified."));
         McpSchema.JsonSchema searchSchema = new McpSchema.JsonSchema(
             "object", searchProps, List.of("query"), null, null, null
         );
@@ -469,7 +498,9 @@ public final class KcpServer {
             "object",
             Map.of(
                 "unit_id", Map.of("type", "string", "description",
-                    "The unit id from search_knowledge results")
+                    "The unit id from search_knowledge results"),
+                "attestation", Map.of("type", "string", "description",
+                    "Agent attestation credential (§3.2). Required to fetch access: restricted units when the manifest sets require_attestation. Presence is checked; the credential is not verified.")
             ),
             List.of("unit_id"), null, null, null
         );
@@ -643,6 +674,9 @@ public final class KcpServer {
         finalResults.sort((a, b) -> Integer.compare(b.score(), a.score()));
         List<SearchResult> top5 = finalResults.subList(0, Math.min(5, finalResults.size()));
 
+        // C20: mark restricted units needing attestation (dropped if a credential was presented).
+        boolean attested = attestationPresented(args);
+
         // Build JSON array manually (no Jackson in production)
         StringBuilder sb = new StringBuilder("[\n");
         for (int i = 0; i < top5.size(); i++) {
@@ -680,6 +714,11 @@ public final class KcpServer {
             } else {
                 sb.append("\"caution\":null");
             }
+            // C20: requires_attestation marker
+            KnowledgeUnit ru = rs.units().get(r.id());
+            if (!attested && ru != null && unitNeedsAttestation(rs.primaryManifest(), ru)) {
+                sb.append(",\"requires_attestation\":true");
+            }
             sb.append("}");
         }
         sb.append("\n]");
@@ -716,6 +755,29 @@ public final class KcpServer {
                 List.of(new McpSchema.TextContent(
                     "{\"error\":\"temporally_unavailable\",\"message\":\"Unit '" + escapeJson(unitId)
                         + "' is outside its temporal validity window as of " + guToday + "\"}")),
+                true, null, null);
+        }
+        // C20: refuse restricted-unit content unless an attestation credential is presented.
+        if (unitNeedsAttestation(rs.primaryManifest(), unit) && !attestationPresented(request.arguments())) {
+            var arReq = rs.primaryManifest().trust().agentRequirements();
+            StringBuilder ar = new StringBuilder("{\"require_attestation\":true");
+            if (arReq.trustedProviders() != null && !arReq.trustedProviders().isEmpty()) {
+                ar.append(",\"trusted_providers\":[");
+                for (int i = 0; i < arReq.trustedProviders().size(); i++) {
+                    if (i > 0) ar.append(",");
+                    ar.append("\"").append(escapeJson(arReq.trustedProviders().get(i))).append("\"");
+                }
+                ar.append("]");
+            }
+            if (arReq.attestationUrl() != null) {
+                ar.append(",\"attestation_url\":\"").append(escapeJson(arReq.attestationUrl())).append("\"");
+            }
+            ar.append("}");
+            return new McpSchema.CallToolResult(
+                List.of(new McpSchema.TextContent(
+                    "{\"error\":\"attestation_required\",\"message\":\"Unit '" + escapeJson(unitId)
+                        + "' is access: restricted and this manifest requires attestation (§3.2). "
+                        + "Re-call get_unit with an 'attestation' argument.\",\"agent_requirements\":" + ar + "}")),
                 true, null, null);
         }
 

--- a/bridge/java/src/test/java/no/cantara/kcp/mcp/KcpAttestationGatingTest.java
+++ b/bridge/java/src/test/java/no/cantara/kcp/mcp/KcpAttestationGatingTest.java
@@ -1,0 +1,73 @@
+package no.cantara.kcp.mcp;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** C20 (v0.22): attestation gating. attest-hub sets require_attestation with a restricted
+ *  ("secret") and a public ("public-doc") unit. The bridge refuses restricted content unless
+ *  a credential is presented — it never verifies the credential. */
+class KcpAttestationGatingTest {
+
+    private static Path fixture(String name) {
+        URL url = KcpAttestationGatingTest.class.getClassLoader().getResource("fixtures/" + name + "/knowledge.yaml");
+        assertNotNull(url, "fixture not found: " + name);
+        return Paths.get(url.getPath());
+    }
+
+    private static KcpServer.ResourceSet rs() throws Exception {
+        return KcpServer.buildResources(fixture("attestation"), false);
+    }
+
+    private static String toolText(McpSchema.CallToolResult r) {
+        return ((McpSchema.TextContent) r.content().get(0)).text();
+    }
+
+    @Test void getUnitRefusesRestrictedWithoutAttestation() throws Exception {
+        McpSchema.CallToolResult r = KcpServer.handleGetUnit(
+            new McpSchema.CallToolRequest("get_unit", Map.of("unit_id", "secret")), rs(), "attest-hub");
+        assertTrue(r.isError());
+        String t = toolText(r);
+        assertTrue(t.contains("attestation_required"), t);
+        assertTrue(t.contains("https://acme.com/v1/attest"), t);
+    }
+
+    @Test void getUnitServesRestrictedWithAttestation() throws Exception {
+        McpSchema.CallToolResult r = KcpServer.handleGetUnit(
+            new McpSchema.CallToolRequest("get_unit", Map.of("unit_id", "secret", "attestation", "spiffe://acme.internal/agent")),
+            rs(), "attest-hub");
+        assertTrue(toolText(r).contains("Restricted design notes"), toolText(r));
+    }
+
+    @Test void getUnitServesPublicWithoutAttestation() throws Exception {
+        McpSchema.CallToolResult r = KcpServer.handleGetUnit(
+            new McpSchema.CallToolRequest("get_unit", Map.of("unit_id", "public-doc")), rs(), "attest-hub");
+        assertTrue(toolText(r).contains("Anyone may read this"), toolText(r));
+    }
+
+    @Test void resourceReadRefusesRestricted() throws Exception {
+        KcpServer.ResourceSet rs = rs();
+        String uri = KcpMapper.unitUri("attest-hub", "secret");
+        KcpServer.ResourceHandler h = rs.handlers().get(uri);
+        assertNotNull(h, "handler should exist for restricted unit");
+        Exception ex = assertThrows(Exception.class, () -> h.handle(uri));
+        assertTrue(ex.getMessage().contains("requires agent attestation"), ex.getMessage());
+    }
+
+    @Test void searchMarksRestrictedDroppedWhenAttested() throws Exception {
+        String unmarked = toolText(KcpServer.handleSearchKnowledge(
+            new McpSchema.CallToolRequest("search_knowledge", Map.of("query", "secret design")), rs(), "attest-hub"));
+        String attested = toolText(KcpServer.handleSearchKnowledge(
+            new McpSchema.CallToolRequest("search_knowledge", Map.of("query", "secret design", "attestation", "spiffe://acme.internal/agent")),
+            rs(), "attest-hub"));
+        assertTrue(unmarked.contains("\"requires_attestation\":true"), unmarked);
+        assertFalse(attested.contains("\"requires_attestation\":true"), attested);
+    }
+}

--- a/bridge/java/src/test/resources/fixtures/attestation/knowledge.yaml
+++ b/bridge/java/src/test/resources/fixtures/attestation/knowledge.yaml
@@ -1,0 +1,27 @@
+kcp_version: "0.21"
+project: attest-hub
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    trusted_providers: [internal-agents.acme.com]
+    attestation_url: https://acme.com/v1/attest
+auth:
+  methods:
+    - type: spiffe
+      trust_domain: acme.internal
+units:
+  - id: public-doc
+    path: public.md
+    intent: "Public project overview"
+    scope: project
+    audience: [agent]
+    triggers: [overview, public]
+    access: public
+  - id: secret
+    path: secret.md
+    intent: "Restricted design secrets"
+    scope: project
+    audience: [agent]
+    triggers: [secret, design]
+    access: restricted

--- a/bridge/java/src/test/resources/fixtures/attestation/public.md
+++ b/bridge/java/src/test/resources/fixtures/attestation/public.md
@@ -1,0 +1,2 @@
+# Public
+Anyone may read this.

--- a/bridge/java/src/test/resources/fixtures/attestation/secret.md
+++ b/bridge/java/src/test/resources/fixtures/attestation/secret.md
@@ -1,0 +1,2 @@
+# Secret
+Restricted design notes.

--- a/bridge/python/kcp_mcp/server.py
+++ b/bridge/python/kcp_mcp/server.py
@@ -98,6 +98,11 @@ def create_server(
     # units and sub-manifests not declared as a local_mirror have no entry (always included).
     source_temporal: dict[str, Temporal] = {}
 
+    # §3.2 / C20 (v0.22): attestation policy from the primary manifest. The bridge checks a
+    # credential was presented before serving restricted units; it never calls attestation_url.
+    agent_req = manifest.trust.agent_requirements if manifest.trust else None
+    require_attestation = bool(agent_req and agent_req.require_attestation)
+
     # manifests[].id → temporal, for supersession resolution (issue #98 F4).
     ref_temporal_by_id: dict[str, Temporal] = {
         ref.id: ref.temporal for ref in manifest.manifests
@@ -212,6 +217,12 @@ def create_server(
             raise ValueError(
                 f"Unit '{unit_id}' is outside its temporal validity window as of {today}"
             )
+        # C20: a resource read carries no attestation channel — a restricted unit under a
+        # manifest requiring attestation is fetched via get_unit with an attestation argument.
+        if _unit_needs_attestation(unit, require_attestation):
+            raise ValueError(
+                f"Unit '{unit_id}' requires agent attestation (§3.2); fetch it via the get_unit tool with an 'attestation' argument"
+            )
         mime = resolve_mime(unit)
         try:
             content, is_binary = read_resource_content(unit_dir, unit.path, mime)
@@ -268,6 +279,10 @@ def create_server(
                             "type": "boolean",
                             "description": "If true, skip temporal filtering and return all units regardless of valid_from/valid_until (§15.13). Mutually exclusive with as_of.",
                         },
+                        "attestation": {
+                            "type": "string",
+                            "description": "Agent attestation credential (§3.2). When presented, restricted units are not marked requires_attestation. Presence is checked; the credential is not verified.",
+                        },
                     },
                     "required": ["query"],
                 },
@@ -281,6 +296,10 @@ def create_server(
                         "unit_id": {
                             "type": "string",
                             "description": "The unit id from search_knowledge results",
+                        },
+                        "attestation": {
+                            "type": "string",
+                            "description": "Agent attestation credential (§3.2). Required to fetch access: restricted units when the manifest sets require_attestation. Presence is checked; the credential is not verified.",
                         },
                     },
                     "required": ["unit_id"],
@@ -322,9 +341,9 @@ def create_server(
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         if name == "search_knowledge":
-            return _handle_search_knowledge(unit_context, slug, arguments or {}, source_temporal, ref_temporal_by_id)
+            return _handle_search_knowledge(unit_context, slug, arguments or {}, source_temporal, ref_temporal_by_id, require_attestation)
         if name == "get_unit":
-            return _handle_get_unit(unit_context, arguments or {}, source_temporal, ref_temporal_by_id)
+            return _handle_get_unit(unit_context, arguments or {}, source_temporal, ref_temporal_by_id, require_attestation, agent_req)
         if name == "get_command_syntax":
             return _handle_get_command_syntax(command_manifests, arguments or {})
         if name == "list_manifests":
@@ -482,6 +501,28 @@ def _unit_servable(unit, source_t, as_of: str, ref_temporal_by_id: dict) -> bool
     )
 
 
+def _unit_needs_attestation(unit, require_attestation: bool) -> bool:
+    """§3.2 / C20: a restricted unit under a manifest requiring attestation must not be served
+    unless the client presents a credential. The bridge checks presence only — it never calls
+    attestation_url (verification is the agent's job)."""
+    return require_attestation and getattr(unit, "access", None) == "restricted"
+
+
+def _attestation_presented(arguments: dict) -> bool:
+    a = arguments.get("attestation")
+    return a is not None and a != ""
+
+
+def _attestation_requirement_data(agent_req) -> dict:
+    out = {"require_attestation": True}
+    if agent_req is not None:
+        if getattr(agent_req, "trusted_providers", None):
+            out["trusted_providers"] = agent_req.trusted_providers
+        if getattr(agent_req, "attestation_url", None):
+            out["attestation_url"] = agent_req.attestation_url
+    return out
+
+
 def _match_not_for(unit, terms: list[str]) -> str | None:
     """Return the first not_for phrase matched by any query term, or None (§15.11)."""
     not_for = getattr(unit, "not_for", None) or []
@@ -499,6 +540,7 @@ def _handle_search_knowledge(
     arguments: dict,
     source_temporal: dict | None = None,
     ref_temporal_by_id: dict | None = None,
+    require_attestation: bool = False,
 ) -> list[TextContent]:
     """Search knowledge units by query (RFC-0007 query baseline)."""
     query = arguments.get("query", "").strip()
@@ -591,6 +633,14 @@ def _handle_search_knowledge(
         ids = ", ".join(unit_context.keys())
         return [TextContent(type="text", text=f'No units matched query "{query}". Available units: {ids}')]
 
+    # C20: mark restricted units needing attestation (dropped if a credential was presented).
+    attested = _attestation_presented(arguments)
+    if require_attestation and not attested:
+        for r in final_results:
+            u = unit_context.get(r["id"], (None, None))[0]
+            if u is not None and getattr(u, "access", None) == "restricted":
+                r["requires_attestation"] = True
+
     final_results.sort(key=lambda r: r["score"], reverse=True)
     top5 = final_results[:5]
 
@@ -602,6 +652,8 @@ def _handle_get_unit(
     arguments: dict,
     source_temporal: dict | None = None,
     ref_temporal_by_id: dict | None = None,
+    require_attestation: bool = False,
+    agent_req=None,
 ) -> list[TextContent]:
     """Fetch the content of a specific knowledge unit by id."""
     source_temporal = source_temporal or {}
@@ -620,6 +672,13 @@ def _handle_get_unit(
         return [TextContent(type="text", text=json.dumps({
             "error": "temporally_unavailable",
             "message": f"Unit '{unit_id}' is outside its temporal validity window as of {today}",
+        }))]
+    # C20: refuse restricted-unit content unless an attestation credential is presented.
+    if _unit_needs_attestation(unit, require_attestation) and not _attestation_presented(arguments):
+        return [TextContent(type="text", text=json.dumps({
+            "error": "attestation_required",
+            "message": f"Unit '{unit_id}' is access: restricted and this manifest requires attestation (§3.2). Re-call get_unit with an 'attestation' argument.",
+            "agent_requirements": _attestation_requirement_data(agent_req),
         }))]
     mime = resolve_mime(unit)
     try:

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.21.1"
+version = "0.22.0"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/python/tests/fixtures/attestation/knowledge.yaml
+++ b/bridge/python/tests/fixtures/attestation/knowledge.yaml
@@ -1,0 +1,27 @@
+kcp_version: "0.21"
+project: attest-hub
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    trusted_providers: [internal-agents.acme.com]
+    attestation_url: https://acme.com/v1/attest
+auth:
+  methods:
+    - type: spiffe
+      trust_domain: acme.internal
+units:
+  - id: public-doc
+    path: public.md
+    intent: "Public project overview"
+    scope: project
+    audience: [agent]
+    triggers: [overview, public]
+    access: public
+  - id: secret
+    path: secret.md
+    intent: "Restricted design secrets"
+    scope: project
+    audience: [agent]
+    triggers: [secret, design]
+    access: restricted

--- a/bridge/python/tests/fixtures/attestation/public.md
+++ b/bridge/python/tests/fixtures/attestation/public.md
@@ -1,0 +1,2 @@
+# Public
+Anyone may read this.

--- a/bridge/python/tests/fixtures/attestation/secret.md
+++ b/bridge/python/tests/fixtures/attestation/secret.md
@@ -1,0 +1,2 @@
+# Secret
+Restricted design notes.

--- a/bridge/python/tests/test_server.py
+++ b/bridge/python/tests/test_server.py
@@ -1188,3 +1188,47 @@ async def test_h_f9_list_manifests_honours_as_of():
     entries = {e["id"]: e for e in json.loads(_fed_text(result))}
     assert entries["gdpr-2018"]["temporally_active"] is True
     assert entries["gdpr-2023"]["temporally_active"] is False
+
+
+# ── Attestation gating (C20, v0.22) ───────────────────────────────────────────
+ATTEST_DIR = Path(__file__).parent / "fixtures" / "attestation"
+
+
+def _attest_server():
+    return create_server(ATTEST_DIR / "knowledge.yaml", warn_on_validation=False)
+
+
+@pytest.mark.asyncio
+async def test_c20_get_unit_refuses_restricted_without_attestation():
+    result = await call_tool(_attest_server(), "get_unit", {"unit_id": "secret"})
+    e = json.loads(result.content[0].text)
+    assert e["error"] == "attestation_required"
+    assert e["agent_requirements"]["attestation_url"] == "https://acme.com/v1/attest"
+
+
+@pytest.mark.asyncio
+async def test_c20_get_unit_serves_restricted_with_attestation():
+    result = await call_tool(_attest_server(), "get_unit", {"unit_id": "secret", "attestation": "spiffe://acme.internal/agent"})
+    assert "Restricted design notes" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_c20_get_unit_serves_public_without_attestation():
+    result = await call_tool(_attest_server(), "get_unit", {"unit_id": "public-doc"})
+    assert "Anyone may read this" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_c20_read_resource_refuses_restricted():
+    with pytest.raises(Exception, match="requires agent attestation"):
+        await call_read_resource(_attest_server(), "knowledge://attest-hub/secret")
+
+
+@pytest.mark.asyncio
+async def test_c20_search_marks_restricted_dropped_when_attested():
+    unmarked = await call_tool(_attest_server(), "search_knowledge", {"query": "secret design"})
+    attested = await call_tool(_attest_server(), "search_knowledge", {"query": "secret design", "attestation": "spiffe://acme.internal/agent"})
+    row_a = next(r for r in json.loads(unmarked.content[0].text) if r["id"] == "secret")
+    row_b = next(r for r in json.loads(attested.content[0].text) if r["id"] == "secret")
+    assert row_a.get("requires_attestation") is True
+    assert "requires_attestation" not in row_b

--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "MCP bridge for the Knowledge Context Protocol — exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/bridge/typescript/src/server.ts
+++ b/bridge/typescript/src/server.ts
@@ -75,6 +75,7 @@ interface SearchResult {
   token_estimate: number | null;
   summary_unit: string | null;
   caution: string | null;
+  requires_attestation?: boolean;
 }
 
 /**
@@ -332,6 +333,23 @@ export function createKcpServer(
     isSourceServable(ctx.sourceTemporal, asOf, refTemporalById) &&
     isTemporallyIncluded(ctx.unit.temporal, asOf);
 
+  // §3.2 / C20 (v0.22): attestation gating. The primary manifest may require agents to attest
+  // before restricted units are served. The bridge checks that a credential was *presented*
+  // (the `attestation` argument); it never calls attestation_url — verification is the agent's.
+  const agentReq = manifest.trust?.agent_requirements;
+  const requireAttestation = agentReq?.require_attestation === true;
+  const unitNeedsAttestation = (unit: KnowledgeUnit): boolean =>
+    requireAttestation && unit.access === "restricted";
+  const attestationPresented = (args: Record<string, unknown> | undefined): boolean => {
+    const a = args?.["attestation"];
+    return a !== undefined && a !== null && a !== "";
+  };
+  const attestationRequirementData = () => ({
+    require_attestation: true,
+    ...(agentReq?.trusted_providers?.length ? { trusted_providers: agentReq.trusted_providers } : {}),
+    ...(agentReq?.attestation_url ? { attestation_url: agentReq.attestation_url } : {}),
+  });
+
   // Build the resource list for a given effective date, omitting non-servable units (F1).
   const buildResourceList = (asOf: string): McpResourceMeta[] => {
     const list: McpResourceMeta[] = [buildManifestResource(manifest, projectSlug)];
@@ -399,6 +417,11 @@ export function createKcpServer(
     if (!isUnitServable(ctx, today)) {
       throw new Error(`Unit '${unitId}' is outside its temporal validity window as of ${today}`);
     }
+    // C20: a resource read carries no attestation channel — a restricted unit under a manifest
+    // requiring attestation is not served here; agents use get_unit with an attestation argument.
+    if (unitNeedsAttestation(ctx.unit)) {
+      throw new Error(`Unit '${unitId}' requires agent attestation (§3.2); fetch it via the get_unit tool with an 'attestation' argument`);
+    }
 
     const content = readUnitContent(ctx.manifestDir, ctx.unit, uri);
 
@@ -457,6 +480,10 @@ export function createKcpServer(
             type: "boolean",
             description: "When true, bypass temporal filtering and return all units regardless of validity window (§15.13). Mutually exclusive with as_of.",
           },
+          attestation: {
+            type: "string",
+            description: "Agent attestation credential (§3.2). When presented, restricted units are not marked requires_attestation. The bridge checks presence only; it does not verify.",
+          },
         },
         required: ["query"],
       },
@@ -471,6 +498,10 @@ export function createKcpServer(
           unit_id: {
             type: "string",
             description: "The unit id from search_knowledge results",
+          },
+          attestation: {
+            type: "string",
+            description: "Agent attestation credential (§3.2). Required to fetch access: restricted units when the manifest sets trust.agent_requirements.require_attestation. The bridge checks it is presented; it does not verify it.",
           },
         },
         required: ["unit_id"],
@@ -630,9 +661,20 @@ export function createKcpServer(
           };
         }
 
+        // C20: mark restricted units that need attestation, so an agent knows to attest before
+        // fetching their content via get_unit. The marker is dropped if attestation was presented.
+        const attested = attestationPresented(args as Record<string, unknown> | undefined);
+        const marked = cautioned.map((r) => {
+          const uctx = unitContextMap.get(r.id);
+          if (!attested && uctx && unitNeedsAttestation(uctx.unit)) {
+            return { ...r, requires_attestation: true };
+          }
+          return r;
+        });
+
         // Sort by score descending, take top 5
-        cautioned.sort((a, b) => b.score - a.score);
-        const top5 = cautioned.slice(0, 5);
+        marked.sort((a, b) => b.score - a.score);
+        const top5 = marked.slice(0, 5);
 
         return {
           content: [
@@ -672,6 +714,23 @@ export function createKcpServer(
                 text: JSON.stringify({
                   error: "temporally_unavailable",
                   message: `Unit '${unitId}' is outside its temporal validity window as of ${todayGu}`,
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        // C20: refuse restricted-unit content unless the client presented an attestation
+        // (the declared credential). The bridge does not verify it — never calls attestation_url.
+        if (unitNeedsAttestation(ctx.unit) && !attestationPresented(args)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  error: "attestation_required",
+                  message: `Unit '${unitId}' is access: restricted and this manifest requires attestation (§3.2). Re-call get_unit with an 'attestation' argument.`,
+                  agent_requirements: attestationRequirementData(),
                 }),
               },
             ],

--- a/bridge/typescript/tests/fixtures/attestation/knowledge.yaml
+++ b/bridge/typescript/tests/fixtures/attestation/knowledge.yaml
@@ -1,0 +1,27 @@
+kcp_version: "0.21"
+project: attest-hub
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    trusted_providers: [internal-agents.acme.com]
+    attestation_url: https://acme.com/v1/attest
+auth:
+  methods:
+    - type: spiffe
+      trust_domain: acme.internal
+units:
+  - id: public-doc
+    path: public.md
+    intent: "Public project overview"
+    scope: project
+    audience: [agent]
+    triggers: [overview, public]
+    access: public
+  - id: secret
+    path: secret.md
+    intent: "Restricted design secrets"
+    scope: project
+    audience: [agent]
+    triggers: [secret, design]
+    access: restricted

--- a/bridge/typescript/tests/fixtures/attestation/public.md
+++ b/bridge/typescript/tests/fixtures/attestation/public.md
@@ -1,0 +1,2 @@
+# Public
+Anyone may read this.

--- a/bridge/typescript/tests/fixtures/attestation/secret.md
+++ b/bridge/typescript/tests/fixtures/attestation/secret.md
@@ -1,0 +1,2 @@
+# Secret
+Restricted design notes.

--- a/bridge/typescript/tests/parser.test.ts
+++ b/bridge/typescript/tests/parser.test.ts
@@ -664,3 +664,92 @@ describe("parseFile", () => {
     expect(api?.depends_on).toEqual(["spec"]);
   });
 });
+
+// v0.22 Trust & Attestation: trust.agent_requirements + extended auth.methods (RFC-0004/0002)
+import { validate } from "../src/validator.js";
+
+const ATTEST_YAML = `
+kcp_version: "0.21"
+project: attest-demo
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    trusted_providers: [internal-agents.acme.com]
+    attestation_url: https://acme.com/v1/attest
+    attestation_jwks: https://acme.com/.well-known/jwks.json
+    propagate_to_governed: true
+auth:
+  methods:
+    - type: spiffe
+      trust_domain: acme.internal
+    - type: did
+      supported_methods: [did:web, did:key]
+    - type: http_signature
+      key_id: k1
+      algorithm: ed25519
+    - type: bearer_token
+      registration_url: https://acme.com/token
+relationships:
+  - from: overview
+    to: overview
+    type: governs
+units:
+  - id: overview
+    path: README.md
+    intent: "restricted overview"
+    scope: project
+    audience: [agent]
+    access: restricted
+`;
+
+describe("trust.agent_requirements + extended auth (v0.22)", () => {
+  it("parses agent_requirements fields", () => {
+    const m = parseDict((require("js-yaml") as typeof import("js-yaml")).load(ATTEST_YAML) as Record<string, unknown>);
+    const ar = m.trust!.agent_requirements!;
+    expect(ar.require_attestation).toBe(true);
+    expect(ar.trusted_providers).toEqual(["internal-agents.acme.com"]);
+    expect(ar.attestation_url).toBe("https://acme.com/v1/attest");
+    expect(ar.propagate_to_governed).toBe(true);
+  });
+
+  it("parses the extended auth method sub-fields", () => {
+    const m = parseDict((require("js-yaml") as typeof import("js-yaml")).load(ATTEST_YAML) as Record<string, unknown>);
+    const byType = Object.fromEntries(m.auth!.methods.map((x) => [x.type, x]));
+    expect(byType["spiffe"].trust_domain).toBe("acme.internal");
+    expect(byType["did"].supported_methods).toEqual(["did:web", "did:key"]);
+    expect(byType["http_signature"].key_id).toBe("k1");
+    expect(byType["http_signature"].algorithm).toBe("ed25519");
+  });
+
+  it("warns on non-HTTPS attestation_url and unsatisfiable require_attestation", () => {
+    const m = parseDict((require("js-yaml") as typeof import("js-yaml")).load(`
+kcp_version: "0.21"
+project: bad
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    attestation_url: http://insecure.example/attest
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+`) as Record<string, unknown>);
+    const r = validate(m, ".");
+    expect(r.warnings.some((w) => w.includes("attestation_url SHOULD use HTTPS"))).toBe(true);
+  });
+
+  it("warns when propagate_to_governed is set but no governs relationship exists", () => {
+    const m = parseDict((require("js-yaml") as typeof import("js-yaml")).load(`
+kcp_version: "0.21"
+project: nogov
+version: 1.0.0
+trust:
+  agent_requirements:
+    propagate_to_governed: true
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+`) as Record<string, unknown>);
+    const r = validate(m, ".");
+    expect(r.warnings.some((w) => w.includes("propagate_to_governed"))).toBe(true);
+  });
+});

--- a/bridge/typescript/tests/tools.test.ts
+++ b/bridge/typescript/tests/tools.test.ts
@@ -721,3 +721,63 @@ describe("prompts/get", () => {
     await client.close();
   });
 });
+
+// C20 (v0.22): attestation gating. The attest-hub manifest sets require_attestation and has a
+// restricted unit ("secret") and a public unit ("public-doc"). The bridge refuses restricted
+// content unless an attestation credential is presented — it never verifies the credential.
+describe("attestation gating (C20)", () => {
+  const ATTEST = join(import.meta.dirname, "fixtures/attestation/knowledge.yaml");
+  async function connectA() {
+    const { server } = createKcpServer(ATTEST, { warnOnValidation: false });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    const client = new Client({ name: "t", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(ct);
+    return client;
+  }
+  const txt = (r: unknown) => ((r as { content: Array<{ text: string }> }).content[0].text);
+
+  it("get_unit refuses a restricted unit with no attestation", async () => {
+    const c = await connectA();
+    const r = await c.callTool({ name: "get_unit", arguments: { unit_id: "secret" } });
+    await c.close();
+    expect(r.isError).toBe(true);
+    const e = JSON.parse(txt(r));
+    expect(e.error).toBe("attestation_required");
+    expect(e.agent_requirements.attestation_url).toBe("https://acme.com/v1/attest");
+  });
+
+  it("get_unit serves the restricted unit once attestation is presented", async () => {
+    const c = await connectA();
+    const r = await c.callTool({ name: "get_unit", arguments: { unit_id: "secret", attestation: "spiffe://acme.internal/agent" } });
+    await c.close();
+    expect(r.isError).toBeFalsy();
+    expect(txt(r)).toContain("Restricted design notes");
+  });
+
+  it("get_unit serves a public unit with no attestation", async () => {
+    const c = await connectA();
+    const r = await c.callTool({ name: "get_unit", arguments: { unit_id: "public-doc" } });
+    await c.close();
+    expect(txt(r)).toContain("Anyone may read this");
+  });
+
+  it("read_resource refuses restricted content (no attestation channel)", async () => {
+    const c = await connectA();
+    await expect(
+      c.readResource({ uri: "knowledge://attest-hub/secret" })
+    ).rejects.toThrow(/requires agent attestation/);
+    await c.close();
+  });
+
+  it("search marks a restricted unit requires_attestation, dropped when attested", async () => {
+    const c = await connectA();
+    const unmarked = await c.callTool({ name: "search_knowledge", arguments: { query: "secret design" } });
+    const withAttest = await c.callTool({ name: "search_knowledge", arguments: { query: "secret design", attestation: "spiffe://acme.internal/agent" } });
+    await c.close();
+    const rowA = (JSON.parse(txt(unmarked)) as Array<{ id: string; requires_attestation?: boolean }>).find((x) => x.id === "secret")!;
+    const rowB = (JSON.parse(txt(withAttest)) as Array<{ id: string; requires_attestation?: boolean }>).find((x) => x.id === "secret")!;
+    expect(rowA.requires_attestation).toBe(true);
+    expect(rowB.requires_attestation).toBeUndefined();
+  });
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.21.0
+    `\nKCP Developer CLI — v0.22.0
 
 Usage: kcp <command> [options]
 

--- a/cli/src/consistency.test.ts
+++ b/cli/src/consistency.test.ts
@@ -145,6 +145,7 @@ describe("render-schema.json guards", () => {
     relationship: { fields: string[] };
     federation: { fields: string[] };
     provenance: { fields: string[] };
+    agent_requirements: { fields: string[] };
   };
   const ks = JSON.parse(readFileSync(r("schema/knowledge-schema.json"), "utf8")) as {
     properties: Record<string, unknown>;
@@ -204,6 +205,13 @@ describe("render-schema.json guards", () => {
     const knownProv = Object.keys(ks.definitions.trust_provenance.properties ?? {});
     for (const f of rs.provenance.fields) {
       expect(knownProv, `provenance field '${f}' absent from knowledge-schema trust_provenance`).toContain(f);
+    }
+  });
+
+  it("agent_requirements fields are a subset of knowledge-schema trust_agent_requirements properties", () => {
+    const knownAr = Object.keys(ks.definitions.trust_agent_requirements.properties ?? {});
+    for (const f of rs.agent_requirements.fields) {
+      expect(knownAr, `agent_requirements field '${f}' absent from knowledge-schema trust_agent_requirements`).toContain(f);
     }
   });
 });

--- a/cli/src/render.test.ts
+++ b/cli/src/render.test.ts
@@ -99,6 +99,70 @@ describe("kcp render", () => {
     expect(doc.sanitization.quarantined).toEqual([]);
   });
 
+  it("surfaces trust.agent_requirements and marks restricted units (C19, v0.22)", () => {
+    const manifestPath = writeManifest(`project: attest
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    trusted_providers: [internal-agents.acme.com]
+    attestation_url: https://acme.com/v1/attest
+    propagate_to_governed: false
+units:
+  - id: secret
+    path: secret.md
+    intent: "Restricted design notes"
+    scope: project
+    audience: [agent]
+    access: restricted
+  - id: public-doc
+    path: public.md
+    intent: "Public overview"
+    scope: project
+    audience: [agent]
+    access: public
+`);
+    const { doc } = renderOk(manifestPath);
+
+    // agent_requirements surfaced as data (never dereferenced — C19)
+    expect(doc.trust.agent_requirements.require_attestation).toBe(true);
+    expect(doc.trust.agent_requirements.attestation_url).toBe("https://acme.com/v1/attest");
+    expect(doc.trust.agent_requirements.trusted_providers).toEqual(["internal-agents.acme.com"]);
+
+    // restricted unit flagged; public unit not
+    const secret = doc.units.find((u: { id: string }) => u.id === "secret");
+    const pub = doc.units.find((u: { id: string }) => u.id === "public-doc");
+    expect(secret.requires_attestation).toBe(true);
+    expect(pub.requires_attestation).toBeUndefined();
+  });
+
+  it("does not gate load_eligible on attestation at trusted tier (C19: flag, not gate)", () => {
+    const manifestPath = writeManifest(`project: lib-pcb
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    attestation_url: https://acme.com/v1/attest
+units:
+  - id: secret
+    path: secret.md
+    intent: "Restricted but load-eligible once attested"
+    scope: project
+    audience: [agent]
+    access: restricted
+`);
+    const pub = signManifest(manifestPath, "cantara-org-2026");
+    const keysPath = writeAllowlist([
+      { key_id: "cantara-org-2026", method: "jws", algorithm: "EdDSA", public_key: pub,
+        scope: { domains: ["github.com/testorg"] } },
+    ]);
+    const { doc } = renderOk(manifestPath, { keysPath, origin: "github.com/testorg/lib-pcb" });
+    const unit = doc.units.find((u: { id: string }) => u.id === "secret");
+    expect(doc.trust.tier).toBe("trusted");
+    expect(unit.requires_attestation).toBe(true);
+    expect(unit.load_eligible).toBe(true); // attestation is the agent's gate (C20), not the renderer's
+  });
+
   it("quarantines imperative intent (T1) and keeps the rest", () => {
     const manifestPath = writeManifest(`project: hostile
 version: 1.0.0

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.21.0";
+export const RENDERER_VERSION = "kcp-cli 0.22.0";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -52,6 +52,7 @@ interface RenderSchemaFile {
   relationship: { fields: string[] };
   federation: { fields: string[] };
   provenance: { fields: string[] };
+  agent_requirements: { fields: string[] };
 }
 const _rs = JSON.parse(
   readFileSync(new URL("../schema/render-schema.json", import.meta.url), "utf8")
@@ -68,6 +69,9 @@ const CONTENT_STRUCTURE_FIELDS = _rs.content_structure.fields;
 const RELATIONSHIP_FIELDS = _rs.relationship.fields;
 const FEDERATION_FIELDS = _rs.federation.fields;
 const PROVENANCE_FIELDS = _rs.provenance.fields;
+// §3.2 trust.agent_requirements passthrough (v0.22). Surfaced as data only — the
+// renderer never dereferences attestation_url/jwks (C19; deterministic + network-free).
+const AGENT_REQ_FIELDS = _rs.agent_requirements.fields;
 
 // §5.1: default tier→confidence mapping, monotone in tier.
 const TIER_CONFIDENCE: Record<string, number> = { trusted: 0.7, known: 0.6, unsigned: 0.5 };
@@ -669,6 +673,13 @@ export function renderManifest(options: RenderOptions): RenderResult {
           (options.requireUnitHashes || escalationByCorroboration));
     }
     out.content_verified = contentVerified;
+    // C19 (v0.22): mark a restricted unit when the manifest declares require_attestation.
+    // The renderer *declares* the requirement as data; it never performs attestation and does
+    // not, on this basis alone, set load_eligible: false — that gate is the bridge's (C20).
+    const arBlock = (doc.trust as RawMap | undefined)?.["agent_requirements"] as RawMap | undefined;
+    if (arBlock?.["require_attestation"] === true && String(unit.access ?? "") === "restricted") {
+      out.requires_attestation = true;
+    }
     units.push(out);
   });
 
@@ -691,6 +702,7 @@ export function renderManifest(options: RenderOptions): RenderResult {
 
   // --- trust passthrough -------------------------------------------------------
   let provenance: RawMap | undefined;
+  let agentRequirements: RawMap | undefined;
   if (doc.trust && typeof doc.trust === "object" && !Array.isArray(doc.trust)) {
     for (const [k, v] of Object.entries(doc.trust as RawMap)) {
       const leafCount = countLeaves(v);
@@ -704,6 +716,19 @@ export function renderManifest(options: RenderOptions): RenderResult {
           } else {
             dropped.push({ path: `trust.provenance.${pk}`, reason: "not_in_schema" });
             fieldsDropped += countLeaves(pv);
+          }
+        }
+      } else if (k === "agent_requirements" && v && typeof v === "object" && !Array.isArray(v)) {
+        // C19: surface agent_requirements as data; whitelist its fields. The renderer never
+        // dereferences attestation_url/jwks — it only copies the declared strings through.
+        agentRequirements = {};
+        for (const [ak, av] of Object.entries(v as RawMap)) {
+          if (AGENT_REQ_FIELDS.includes(ak)) {
+            agentRequirements[ak] = av;
+            fieldsRendered += countLeaves(av);
+          } else {
+            dropped.push({ path: `trust.agent_requirements.${ak}`, reason: "not_in_schema" });
+            fieldsDropped += countLeaves(av);
           }
         }
       } else if (k === "content_integrity") {
@@ -757,6 +782,7 @@ export function renderManifest(options: RenderOptions): RenderResult {
         status: trust.status,
       },
       ...(provenance && Object.keys(provenance).length ? { provenance } : {}),
+      ...(agentRequirements && Object.keys(agentRequirements).length ? { agent_requirements: agentRequirements } : {}),
     },
     discovery: {
       verification_status: "declared", // §5.1

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.21.1 (all three bridges — aligned with KCP spec version)
+**Current version:** 0.22.0 (all three bridges — aligned with KCP spec version)
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -40,6 +40,7 @@ When adding any MCP capability:
 | `search_knowledge`: `not_for` filter (§15.11) | ✅ | ✅ | ✅ | strict exclusion + soft demotion with `caution` field |
 | `search_knowledge`: temporal query `as_of` / `include_all_temporal` (§15.13) | ✅ | ✅ | ✅ | point-in-time filtering, conflict error on mutual exclusion |
 | Federated temporal filtering, all retrieval paths (§3.6 / C18) | ✅ | ✅ | ✅ | `manifests[].temporal` enforced in search **and** `get_unit` / resources; UTC effective date; supersession-aware; `as_of` validated; `include_all_temporal` marks `caution` (issue #98) |
+| Attestation gating (§3.2 / C20) | ✅ | ✅ | ✅ | restricted-unit content refused on every retrieval path unless an `attestation` argument is presented; `get_unit` → `attestation_required`; `search` marks `requires_attestation`; bridge never calls `attestation_url` (v0.22) |
 | `get_unit` tool | ✅ | ✅ | ✅ | fetch unit file content by id; refuses temporally-excluded units |
 | `list_manifests` tool | ✅ | ✅ | ✅ | lists declared sub-manifests (federation §3.6); optional `as_of`, supersession-aware `temporally_active` |
 | `get_command_syntax` tool | ✅ | ✅ | ✅ | requires `--commands-dir` |
@@ -106,6 +107,7 @@ No known gaps — all three bridges are at full parity.
 | 0.20.1 | 2026-06-13 | Python bridge: added `sdd-review` and `kcp-explore` MCP prompts — closes last Tier 1 parity gaps. |
 | 0.21.0 | 2026-06-13 | Spec v0.21: parsers expose `manifests[].temporal` (RFC-0021) and `discovery.verified_by`/`evidence`; temporal validation (`superseded_by` cycle detection, validity-window §7 warnings) implemented in all four parser/validator implementations. Bridge skip-before-fetch federation temporal filtering deferred. |
 | 0.21.1 | 2026-06-13 | C18 hardening (issue #98): federated temporal filtering now enforced on **every** retrieval path (`get_unit`, `read_resource`, `list_resources`), not just `search_knowledge`; effective date pinned to UTC; supersession-aware exclusion (`superseded_by` + active successor → drop); `as_of` ISO-8601 validation; `local_mirror` association canonicalised (symlink-safe) with a warning on no match; `include_all_temporal` results carry a `caution`; `list_manifests` gains optional `as_of`. All three bridges. |
+| 0.22.0 | 2026-07-04 | Trust & Attestation (RFC-0004/0002): `trust.agent_requirements` + extended `auth.methods` types (`bearer_token`, `spiffe`, `did`, `http_signature`) parsed/exposed; C20 attestation gating — restricted-unit content refused unless an `attestation` argument is presented, on every retrieval path; `search` marks `requires_attestation`; new `attestation` argument on `get_unit` + `search_knowledge`. Bridge never calls `attestation_url`. All three bridges. |
 
 > **Note:** v0.7.0--v0.9.0 were internal development milestones that shipped combined as v0.10.0.
 > v0.11.0--v0.13.0 were bridge feature additions that culminated in v0.14.0.

--- a/docs/index.html
+++ b/docs/index.html
@@ -2407,7 +2407,7 @@ relationships:
 
       <div class="roadmap-core reveal">
         <div class="roadmap-core__info">
-          <span class="roadmap-core__badge">v0.21 — Current</span>
+          <span class="roadmap-core__badge">v0.21 — Shipped</span>
           <h3>Federation Temporal &amp; Composition Integrity</h3>
           <p><code>manifests[].temporal</code> (SPEC §3.6) lets a hub declare when a federated source is relevant, so bridges skip out-of-window sub-manifests before fetching. Composition <code>integrity</code> becomes enforcing at <code>trusted</code> tier (SPEC §3.11 / C17): an unverified or substituted include can't reach an agent's standing context — closing the composition-substitution attack (T10). Promoted from RFC-0021 and RFC-0022.</p>
         </div>
@@ -2416,6 +2416,20 @@ relationships:
           <span class="roadmap-field-pill">integrity</span>
           <span class="roadmap-field-pill">RFC-0021</span>
           <span class="roadmap-field-pill">RFC-0022</span>
+        </div>
+      </div>
+
+      <div class="roadmap-core reveal">
+        <div class="roadmap-core__info">
+          <span class="roadmap-core__badge">v0.22 — Current</span>
+          <h3>Trust &amp; Attestation</h3>
+          <p><code>trust.agent_requirements</code> (SPEC §3.2) declares what an agent must prove about <em>itself</em> before <code>access: restricted</code> units are served — the consumer-identity counterpart to producer integrity. Extended <code>auth.methods</code> add SPIFFE, DID, and HTTP Message Signatures (RFC 9421). The renderer surfaces the requirement (C19) and the bridge refuses restricted content on every retrieval path unless a credential is presented (C20) — but <strong>KCP declares; agents attest</strong>: nothing ever calls <code>attestation_url</code>. Promoted from RFC-0004 and RFC-0002.</p>
+        </div>
+        <div class="roadmap-core__fields">
+          <span class="roadmap-field-pill">agent_requirements</span>
+          <span class="roadmap-field-pill">auth.methods</span>
+          <span class="roadmap-field-pill">RFC-0004</span>
+          <span class="roadmap-field-pill">RFC-0002</span>
         </div>
       </div>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,6 +105,24 @@ Validates clean: `kcp validate examples/temporal-validity/knowledge.yaml`.
 
 ---
 
+## [attestation/](./attestation/)
+
+**Trust & Attestation. Restricted units gated behind agent attestation (v0.22).**
+
+An internal-knowledge manifest that requires agents to prove who they are before it serves its
+restricted units (RFC-0004/0002, SPEC §3.2/§3.3, v0.22):
+- `trust.agent_requirements` — `require_attestation`, `trusted_providers` (identity), `attestation_url` (credential)
+- A public `onboarding` unit (served to anyone) and a restricted `incident-runbook` (gated)
+- Extended `auth.methods`: `spiffe` (workload SVID) and `http_signature` (RFC 9421)
+- **KCP declares; agents attest** — the renderer flags `requires_attestation` and never
+  dereferences `attestation_url`; the bridge refuses restricted content until an `attestation`
+  argument is presented (C19/C20)
+
+Walkthrough: [guides/gating-restricted-knowledge-with-attestation.md](../guides/gating-restricted-knowledge-with-attestation.md).
+Validates clean: `kcp validate examples/attestation/knowledge.yaml`.
+
+---
+
 ## [trusted-render-demo/](./trusted-render-demo/)
 
 **Interactive walk-through of the trusted render pipeline (RFC-0018/0019/0022, SPEC §16).**

--- a/examples/attestation/README.md
+++ b/examples/attestation/README.md
@@ -1,0 +1,22 @@
+# Attestation example (v0.22)
+
+An internal-knowledge manifest that requires agents to **attest who they are** before it will
+serve its restricted units — the consumer-identity half of KCP's security model
+([Trust & Attestation](../../guides/gating-restricted-knowledge-with-attestation.md), RFC-0004/0002).
+
+- **`onboarding`** — `access: public`, served to anyone.
+- **`incident-runbook`** — `access: restricted`, gated behind `trust.agent_requirements`.
+
+The load-bearing idea: **KCP declares the requirement; it never performs the auth.** The renderer
+surfaces `agent_requirements` and marks the restricted unit `requires_attestation`, but never
+calls `attestation_url`. The bridge refuses restricted content until an `attestation` argument is
+presented — and checks only that it *was* presented, never verifying it. The agent runtime does
+the real attesting (SPIFFE SVID, RFC 9421 signature, OIDC-A claim, …).
+
+```bash
+kcp validate examples/attestation/knowledge.yaml   # ✓ Valid
+kcp render   examples/attestation/knowledge.yaml   # surfaces agent_requirements + requires_attestation
+```
+
+Full walkthrough (validate → render → bridge gating → governance propagation):
+[**guides/gating-restricted-knowledge-with-attestation.md**](../../guides/gating-restricted-knowledge-with-attestation.md).

--- a/examples/attestation/incident-runbook.md
+++ b/examples/attestation/incident-runbook.md
@@ -1,0 +1,2 @@
+# Incident Runbook
+Restricted: escalation contacts and procedures.

--- a/examples/attestation/knowledge.yaml
+++ b/examples/attestation/knowledge.yaml
@@ -1,0 +1,50 @@
+kcp_version: "0.22"
+project: acme-internal-knowledge
+version: 1.0.0
+
+# Trust & Attestation (v0.22). This manifest requires agents to attest before it will serve
+# its restricted units. KCP DECLARES the requirement; the agent runtime performs the attestation.
+# The bridge refuses restricted content until an attestation credential is presented; the renderer
+# surfaces the requirement as data and never dereferences attestation_url.
+trust:
+  provenance:
+    publisher: "Acme Corp"
+    contact: "knowledge-team@acme.com"
+  agent_requirements:
+    require_attestation: true
+    # Satisfied by EITHER an allowlisted provider identity OR a credential the endpoint accepts.
+    trusted_providers: ["internal-agents.acme.com"]
+    attestation_url: "https://acme.com/v1/attest"
+    attestation_jwks: "https://acme.com/.well-known/jwks.json"
+
+auth:
+  methods:
+    # Workload identity for non-human agents (SPIFFE SVID).
+    - type: spiffe
+      trust_domain: acme.internal
+    # RFC 9421 HTTP Message Signatures — the agent-payments authentication standard.
+    - type: http_signature
+      key_id: acme-agent-2026
+      algorithm: ed25519
+    # Public fallback for the public units.
+    - type: none
+
+units:
+  - id: onboarding
+    path: onboarding.md
+    intent: "How do I get started as a new engineer here?"
+    scope: project
+    audience: [developer, agent]
+    triggers: [onboarding, getting started]
+    access: public
+
+  - id: incident-runbook
+    path: incident-runbook.md
+    intent: "Production incident response runbook with escalation contacts"
+    scope: project
+    audience: [operator, agent]
+    triggers: [incident, runbook, escalation, oncall]
+    access: restricted
+    auth_scope: "read:incident-runbook"
+
+relationships: []

--- a/examples/attestation/onboarding.md
+++ b/examples/attestation/onboarding.md
@@ -1,0 +1,2 @@
+# Onboarding
+Public getting-started guide.

--- a/experiments/rfc-0018-render/run.js
+++ b/experiments/rfc-0018-render/run.js
@@ -196,7 +196,7 @@ const ALLOWED_TOP = ['render', 'trust', 'discovery', 'project', 'units',
 const ALLOWED_UNIT = ['id', 'kind', 'path', 'intent', 'format', 'content_type',
   'language', 'scope', 'audience', 'license', 'validated', 'update_frequency',
   'triggers', 'not_for', 'content_structure', 'load_eligible', 'invocation',
-  'content_verified'];
+  'content_verified', 'requires_attestation'];
 
 function checkCase(c, r) {
   const problems = [];

--- a/guides/gating-restricted-knowledge-with-attestation.md
+++ b/guides/gating-restricted-knowledge-with-attestation.md
@@ -1,0 +1,149 @@
+# Tutorial: Gating restricted knowledge with attestation
+
+A hands-on walkthrough of **Trust & Attestation** (v0.22): declaring that an agent must
+prove *who it is* before a knowledge source will serve its restricted units — and seeing
+that gate enforced by the renderer and the MCP bridge.
+
+The one principle to hold onto: **KCP declares trust requirements; it never performs auth.**
+The manifest says *what* attestation is expected; the agent runtime does the attesting. The
+renderer never dereferences `attestation_url`; the bridge checks a credential was *presented*
+but never verifies it. This keeps the render pipeline deterministic and keeps KCP out of the
+business of being an identity provider.
+
+Everything here runs against the shipped example at
+[`examples/attestation/`](../examples/attestation/).
+
+## 1. The manifest
+
+`trust.agent_requirements` (SPEC §3.2) declares the requirement; a unit opts in by being
+`access: restricted`:
+
+```yaml
+trust:
+  agent_requirements:
+    require_attestation: true
+    # Satisfied by EITHER an allowlisted provider identity OR a credential the endpoint accepts.
+    trusted_providers: ["internal-agents.acme.com"]   # identity-based (OIDC-A agent_provider)
+    attestation_url: "https://acme.com/v1/attest"      # credential-based (HTTPS)
+    attestation_jwks: "https://acme.com/.well-known/jwks.json"
+
+units:
+  - id: onboarding
+    intent: "How do I get started?"
+    access: public               # served to anyone
+  - id: incident-runbook
+    intent: "Production incident runbook with escalation contacts"
+    access: restricted           # gated behind attestation
+```
+
+The extended `auth.methods` types (v0.22) declare *how* an agent presents identity —
+`spiffe` (workload SVID), `http_signature` (RFC 9421), `did`, `bearer_token`:
+
+```yaml
+auth:
+  methods:
+    - type: spiffe
+      trust_domain: acme.internal
+    - type: http_signature
+      key_id: acme-agent-2026
+      algorithm: ed25519
+    - type: none        # public fallback
+```
+
+Validate it:
+
+```bash
+kcp validate examples/attestation/knowledge.yaml
+# ✓ Valid — no errors or warnings
+```
+
+The validator will warn if you make the requirement unsatisfiable (`require_attestation: true`
+with no `trusted_providers` or `attestation_url`), if `attestation_url` isn't HTTPS, or if you
+set `propagate_to_governed: true` without a `governs` relationship.
+
+## 2. Render it — the requirement is surfaced, not enforced
+
+```bash
+kcp render examples/attestation/knowledge.yaml
+```
+
+The rendered artifact surfaces `agent_requirements` as data and flags the restricted unit:
+
+```yaml
+trust:
+  tier: unsigned
+  agent_requirements:
+    require_attestation: true
+    trusted_providers: ["internal-agents.acme.com"]
+    attestation_url: "https://acme.com/v1/attest"
+units:
+  - id: incident-runbook
+    requires_attestation: true      # ← the C19 marker
+```
+
+Two things the renderer deliberately does **not** do (conformance C19):
+
+- It never calls `attestation_url` — the strings are copied through verbatim. The render stays
+  deterministic and network-free.
+- It does **not** set `load_eligible: false` on the restricted unit just because attestation is
+  required. Gating there would be theater — the renderer can't attest. The *bridge* is the real
+  gate (C20). A restricted unit at `trusted` tier is still `load_eligible: true` **with** the
+  `requires_attestation` marker: "you may load this once you've attested."
+
+## 3. Serve it through the bridge — the gate fires
+
+Point an MCP bridge at the manifest (any of the three — TypeScript, Python, Java):
+
+```bash
+npx kcp-mcp examples/attestation/knowledge.yaml      # TypeScript
+# or:  python -m kcp_mcp examples/attestation/knowledge.yaml
+```
+
+Now the gate is live on **every retrieval path** (C20):
+
+| Call | Result |
+|------|--------|
+| `get_unit(unit_id: "onboarding")` | ✅ served — the unit is `access: public` |
+| `get_unit(unit_id: "incident-runbook")` | ❌ `{"error": "attestation_required", "agent_requirements": {…}}` |
+| `get_unit(unit_id: "incident-runbook", attestation: "spiffe://acme.internal/agent")` | ✅ served — a credential was presented |
+| `read_resource("knowledge://…/incident-runbook")` | ❌ refused — resource reads carry no attestation channel; use `get_unit` |
+| `search_knowledge(query: "incident")` | returns the unit **marked** `requires_attestation: true` so the agent knows to attest first |
+
+The bridge checks that an `attestation` argument was *presented*. It does **not** verify the
+credential — it never calls `attestation_url`. Verification is the agent runtime's job (and the
+mechanism — on-chain token, Verifiable Credential, OIDC-A claim, SPIFFE assertion — is out of
+KCP's scope). KCP's contribution is the *declaration layer* so an agent can plan before it acts.
+
+## 4. Governance propagation (optional)
+
+A governing manifest can push its attestation floor onto the sources it `governs`:
+
+```yaml
+trust:
+  agent_requirements:
+    require_attestation: true
+    propagate_to_governed: true    # governed sources MUST meet at least this bar
+relationships:
+  - from: security-policy
+    to: some-team-manifest
+    type: governs
+```
+
+An agent resolving the `governs` edge treats the governing manifest's requirements as a floor
+on the governed source, warning if the governed manifest declares weaker requirements (C21).
+This resolves [#47](https://github.com/Cantara/knowledge-context-protocol/issues/47).
+
+## Where this sits in the trust model
+
+v0.16–v0.21 answered *"is this knowledge intact and current?"* — signatures, per-unit content
+hashes, origin evidence, composition integrity, temporal validity. v0.22 answers the
+complementary question: *"who may consume it, and how do they prove it?"* Producer integrity
+(`content_integrity`) and consumer identity (`agent_requirements`) are the two halves of the
+same story, and they compose cleanly with payment (RFC-0005) for token-gated access — attest to
+get free access, fall through to `payment.methods` if you can't.
+
+## See also
+
+- [SPEC §3.2 `trust.agent_requirements`](../SPEC.md#32-trust) · [§3.3 extended `auth.methods`](../SPEC.md#33-auth) · [§16.5 C19–C21](../SPEC.md#165-renderer-conformance)
+- [RFC-0004 Trust & Compliance](../RFC-0004-Trust-and-Compliance.md) · [RFC-0002 Auth & Delegation](../RFC-0002-Auth-and-Delegation.md)
+- [`examples/attestation/`](../examples/attestation/)

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -19,6 +19,7 @@ import no.cantara.kcp.model.RateLimit;
 import no.cantara.kcp.model.RateLimits;
 import no.cantara.kcp.model.Relationship;
 import no.cantara.kcp.model.Trust;
+import no.cantara.kcp.model.TrustAgentRequirements;
 import no.cantara.kcp.model.TrustAudit;
 import no.cantara.kcp.model.TrustProvenance;
 import no.cantara.kcp.model.Temporal;
@@ -193,7 +194,19 @@ public class KcpParser {
             );
         }
 
-        return new Trust(provenance, audit);
+        TrustAgentRequirements agentRequirements = null;
+        Map<String, Object> arMap = (Map<String, Object>) t.get("agent_requirements");
+        if (arMap != null) {
+            agentRequirements = new TrustAgentRequirements(
+                    (Boolean) arMap.get("require_attestation"),
+                    (List<String>) arMap.getOrDefault("trusted_providers", List.of()),
+                    (String) arMap.get("attestation_url"),
+                    (String) arMap.get("attestation_jwks"),
+                    (Boolean) arMap.get("propagate_to_governed")
+            );
+        }
+
+        return new Trust(provenance, audit, agentRequirements);
     }
 
     @SuppressWarnings("unchecked")
@@ -211,7 +224,11 @@ public class KcpParser {
                 (String) m.get("issuer"),
                 (List<String>) m.getOrDefault("scopes", List.of()),
                 (String) m.get("header"),
-                (String) m.get("registration_url")
+                (String) m.get("registration_url"),
+                (String) m.get("trust_domain"),
+                (List<String>) m.getOrDefault("supported_methods", List.of()),
+                (String) m.get("key_id"),
+                (String) m.get("algorithm")
         );
     }
 

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -54,7 +54,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -296,6 +296,30 @@ public class KcpValidator {
             warnings.add("manifest: units with access 'authenticated' or 'restricted' exist but no 'auth' block is declared");
         }
 
+        // Agent attestation requirements validation (§3.2, v0.22)
+        var ar = manifest.trust() != null ? manifest.trust().agentRequirements() : null;
+        if (ar != null) {
+            if (ar.attestationUrl() != null && !ar.attestationUrl().startsWith("https://")) {
+                warnings.add("manifest: trust.agent_requirements.attestation_url SHOULD use HTTPS, got '" + ar.attestationUrl() + "'");
+            }
+            if (ar.attestationJwks() != null && !ar.attestationJwks().startsWith("https://")) {
+                warnings.add("manifest: trust.agent_requirements.attestation_jwks SHOULD use HTTPS, got '" + ar.attestationJwks() + "'");
+            }
+            if (Boolean.TRUE.equals(ar.requireAttestation())
+                    && ar.trustedProviders().isEmpty() && ar.attestationUrl() == null) {
+                warnings.add("manifest: trust.agent_requirements.require_attestation is true but neither "
+                        + "trusted_providers nor attestation_url is declared — the requirement cannot be satisfied");
+            }
+            if (Boolean.TRUE.equals(ar.propagateToGoverned())) {
+                boolean hasGoverns = manifest.relationships().stream().anyMatch(r -> "governs".equals(r.type()))
+                        || manifest.manifests().stream().anyMatch(m -> "governs".equals(m.relationship()));
+                if (!hasGoverns) {
+                    warnings.add("manifest: trust.agent_requirements.propagate_to_governed is true but the "
+                            + "manifest declares no 'governs' relationship — nothing to propagate to");
+                }
+            }
+        }
+
         for (Relationship rel : manifest.relationships()) {
             String p = "relationship '" + rel.fromId() + "' -> '" + rel.toId() + "'";
             if (!unitIds.contains(rel.fromId())) {

--- a/parsers/java/src/main/java/no/cantara/kcp/model/AuthMethod.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/AuthMethod.java
@@ -5,7 +5,8 @@ import java.util.List;
 /**
  * A single authentication method declaration within the {@code auth.methods} list.
  *
- * <p>Core types defined by the spec: {@code none}, {@code oauth2}, {@code api_key}.
+ * <p>Types defined by the spec (v0.22): {@code none}, {@code oauth2}, {@code api_key},
+ * {@code bearer_token}, {@code spiffe}, {@code did}, {@code http_signature}.
  * Unknown types MUST be silently ignored per SPEC.md §7.
  */
 public record AuthMethod(
@@ -13,9 +14,14 @@ public record AuthMethod(
         String issuer,
         List<String> scopes,
         String header,
-        String registrationUrl
+        String registrationUrl,
+        String trustDomain,          // spiffe
+        List<String> supportedMethods, // did
+        String keyId,                // http_signature
+        String algorithm             // http_signature
 ) {
     public AuthMethod {
         scopes = scopes != null ? List.copyOf(scopes) : List.of();
+        supportedMethods = supportedMethods != null ? List.copyOf(supportedMethods) : List.of();
     }
 }

--- a/parsers/java/src/main/java/no/cantara/kcp/model/Trust.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/Trust.java
@@ -6,6 +6,7 @@ package no.cantara.kcp.model;
  */
 public record Trust(
         TrustProvenance provenance,
-        TrustAudit audit
+        TrustAudit audit,
+        TrustAgentRequirements agentRequirements
 ) {
 }

--- a/parsers/java/src/main/java/no/cantara/kcp/model/TrustAgentRequirements.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/TrustAgentRequirements.java
@@ -1,0 +1,21 @@
+package no.cantara.kcp.model;
+
+import java.util.List;
+
+/**
+ * Agent attestation requirements within the trust block. See SPEC.md §3.2 (v0.22).
+ *
+ * <p>Declares what an agent must prove about itself before {@code access: restricted} units are
+ * served. KCP declares these requirements; it does not perform authentication.
+ */
+public record TrustAgentRequirements(
+        Boolean requireAttestation,
+        List<String> trustedProviders,
+        String attestationUrl,
+        String attestationJwks,
+        Boolean propagateToGoverned
+) {
+    public TrustAgentRequirements {
+        trustedProviders = trustedProviders != null ? List.copyOf(trustedProviders) : List.of();
+    }
+}

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpAttestationTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpAttestationTest.java
@@ -1,0 +1,90 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.KnowledgeManifest;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** v0.22 Trust & Attestation: trust.agent_requirements + extended auth (RFC-0004/0002). */
+class KcpAttestationTest {
+
+    @SuppressWarnings("unchecked")
+    private static KnowledgeManifest parse(String yaml) {
+        return KcpParser.fromMap((Map<String, Object>) new Yaml().load(yaml));
+    }
+
+    private static final String ATTEST = """
+        kcp_version: "0.21"
+        project: attest-demo
+        version: 1.0.0
+        trust:
+          agent_requirements:
+            require_attestation: true
+            trusted_providers: [internal-agents.acme.com]
+            attestation_url: https://acme.com/v1/attest
+            propagate_to_governed: true
+        auth:
+          methods:
+            - {type: spiffe, trust_domain: acme.internal}
+            - {type: did, supported_methods: [did:web, did:key]}
+            - {type: http_signature, key_id: k1, algorithm: ed25519}
+        relationships:
+          - {from: overview, to: overview, type: governs}
+        units:
+          - {id: overview, path: README.md, intent: x, scope: project, audience: [agent], access: restricted}
+        """;
+
+    @Test void parsesAgentRequirements() {
+        var ar = parse(ATTEST).trust().agentRequirements();
+        assertEquals(Boolean.TRUE, ar.requireAttestation());
+        assertEquals(List.of("internal-agents.acme.com"), ar.trustedProviders());
+        assertEquals("https://acme.com/v1/attest", ar.attestationUrl());
+        assertEquals(Boolean.TRUE, ar.propagateToGoverned());
+    }
+
+    @Test void parsesExtendedAuthMethods() {
+        var methods = parse(ATTEST).auth().methods();
+        var spiffe = methods.stream().filter(m -> "spiffe".equals(m.type())).findFirst().orElseThrow();
+        var did = methods.stream().filter(m -> "did".equals(m.type())).findFirst().orElseThrow();
+        var sig = methods.stream().filter(m -> "http_signature".equals(m.type())).findFirst().orElseThrow();
+        assertEquals("acme.internal", spiffe.trustDomain());
+        assertEquals(List.of("did:web", "did:key"), did.supportedMethods());
+        assertEquals("k1", sig.keyId());
+        assertEquals("ed25519", sig.algorithm());
+    }
+
+    @Test void warnsNonHttpsAndUnsatisfiable() {
+        KnowledgeManifest m = parse("""
+            kcp_version: "0.21"
+            project: bad
+            version: 1.0.0
+            trust:
+              agent_requirements:
+                require_attestation: true
+                attestation_url: http://insecure.example/attest
+            units:
+              - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+            """);
+        var warnings = KcpValidator.validate(m).warnings();
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("attestation_url SHOULD use HTTPS")), warnings.toString());
+    }
+
+    @Test void warnsPropagateWithoutGoverns() {
+        KnowledgeManifest m = parse("""
+            kcp_version: "0.21"
+            project: nogov
+            version: 1.0.0
+            trust:
+              agent_requirements:
+                propagate_to_governed: true
+            units:
+              - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+            """);
+        assertTrue(KcpValidator.validate(m).warnings().stream()
+                .anyMatch(w -> w.contains("propagate_to_governed")));
+    }
+}

--- a/parsers/python/kcp/model.py
+++ b/parsers/python/kcp/model.py
@@ -219,6 +219,11 @@ class AuthMethod:
     scopes: list[str] = field(default_factory=list)
     header: Optional[str] = None
     registration_url: Optional[str] = None
+    # Extended method sub-fields (RFC-0002, v0.22):
+    trust_domain: Optional[str] = None       # spiffe
+    supported_methods: list[str] = field(default_factory=list)  # did
+    key_id: Optional[str] = None             # http_signature
+    algorithm: Optional[str] = None          # http_signature
 
 
 @dataclass
@@ -243,10 +248,21 @@ class TrustAudit:
 
 
 @dataclass
+class TrustAgentRequirements:
+    """Agent attestation requirements within the trust block. See SPEC.md section 3.2 (v0.22)."""
+    require_attestation: Optional[bool] = None
+    trusted_providers: list[str] = field(default_factory=list)
+    attestation_url: Optional[str] = None
+    attestation_jwks: Optional[str] = None
+    propagate_to_governed: Optional[bool] = None
+
+
+@dataclass
 class Trust:
     """Root-level trust block. See SPEC.md section 3.2."""
     provenance: Optional[TrustProvenance] = None
     audit: Optional[TrustAudit] = None
+    agent_requirements: Optional[TrustAgentRequirements] = None
 
 
 @dataclass

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -8,7 +8,7 @@ from .model import (
     Auth, AuthMethod, Authority, Compliance, ContentHash, ContentStructure, Delegation,
     Discovery, ExternalDependency, ExternalRelationship, FreshnessPolicy,
     KnowledgeManifest, KnowledgeUnit, ManifestRef, RateLimit, RateLimits, Relationship,
-    Trust, TrustAudit, TrustProvenance, Visibility,
+    Trust, TrustAudit, TrustAgentRequirements, TrustProvenance, Visibility,
 )
 
 
@@ -64,7 +64,17 @@ def _parse_trust(data: Optional[dict]) -> Optional[Trust]:
             agent_must_log=audit_data.get("agent_must_log"),
             require_trace_context=audit_data.get("require_trace_context"),
         )
-    return Trust(provenance=provenance, audit=audit)
+    agent_requirements = None
+    ar_data = data.get("agent_requirements")
+    if ar_data is not None:
+        agent_requirements = TrustAgentRequirements(
+            require_attestation=ar_data.get("require_attestation"),
+            trusted_providers=ar_data.get("trusted_providers", []),
+            attestation_url=ar_data.get("attestation_url"),
+            attestation_jwks=ar_data.get("attestation_jwks"),
+            propagate_to_governed=ar_data.get("propagate_to_governed"),
+        )
+    return Trust(provenance=provenance, audit=audit, agent_requirements=agent_requirements)
 
 
 def _parse_auth(data: Optional[dict]) -> Optional[Auth]:
@@ -78,6 +88,10 @@ def _parse_auth(data: Optional[dict]) -> Optional[Auth]:
             scopes=m.get("scopes", []),
             header=m.get("header"),
             registration_url=m.get("registration_url"),
+            trust_domain=m.get("trust_domain"),
+            supported_methods=m.get("supported_methods", []),
+            key_id=m.get("key_id"),
+            algorithm=m.get("algorithm"),
         )
         for m in data.get("methods", [])
     ]

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -94,7 +94,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -427,6 +427,32 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
             "but no 'auth' block is declared"
         )
 
+    # Agent attestation requirements validation (§3.2, v0.22)
+    ar = manifest.trust.agent_requirements if manifest.trust else None
+    if ar is not None:
+        if ar.attestation_url and not ar.attestation_url.startswith("https://"):
+            warnings.append(
+                f"manifest: trust.agent_requirements.attestation_url SHOULD use HTTPS, got '{ar.attestation_url}'"
+            )
+        if ar.attestation_jwks and not ar.attestation_jwks.startswith("https://"):
+            warnings.append(
+                f"manifest: trust.agent_requirements.attestation_jwks SHOULD use HTTPS, got '{ar.attestation_jwks}'"
+            )
+        if ar.require_attestation and not ar.trusted_providers and not ar.attestation_url:
+            warnings.append(
+                "manifest: trust.agent_requirements.require_attestation is true but neither "
+                "trusted_providers nor attestation_url is declared — the requirement cannot be satisfied"
+            )
+        if ar.propagate_to_governed:
+            has_governs = any(r.type == "governs" for r in manifest.relationships) or any(
+                m.relationship == "governs" for m in manifest.manifests
+            )
+            if not has_governs:
+                warnings.append(
+                    "manifest: trust.agent_requirements.propagate_to_governed is true but the "
+                    "manifest declares no 'governs' relationship — nothing to propagate to"
+                )
+
     for rel in manifest.relationships:
         p = f"relationship '{rel.from_id}' -> '{rel.to_id}'"
         if rel.from_id not in unit_ids:

--- a/parsers/python/tests/test_attestation.py
+++ b/parsers/python/tests/test_attestation.py
@@ -1,0 +1,71 @@
+"""v0.22 Trust & Attestation: trust.agent_requirements + extended auth (RFC-0004/0002)."""
+import yaml
+from kcp.parser import parse_dict
+from kcp.validator import validate
+
+ATTEST = yaml.safe_load("""
+kcp_version: "0.21"
+project: attest-demo
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    trusted_providers: [internal-agents.acme.com]
+    attestation_url: https://acme.com/v1/attest
+    propagate_to_governed: true
+auth:
+  methods:
+    - {type: spiffe, trust_domain: acme.internal}
+    - {type: did, supported_methods: [did:web, did:key]}
+    - {type: http_signature, key_id: k1, algorithm: ed25519}
+relationships:
+  - {from: overview, to: overview, type: governs}
+units:
+  - {id: overview, path: README.md, intent: x, scope: project, audience: [agent], access: restricted}
+""")
+
+
+def test_parses_agent_requirements():
+    ar = parse_dict(ATTEST).trust.agent_requirements
+    assert ar.require_attestation is True
+    assert ar.trusted_providers == ["internal-agents.acme.com"]
+    assert ar.attestation_url == "https://acme.com/v1/attest"
+    assert ar.propagate_to_governed is True
+
+
+def test_parses_extended_auth_methods():
+    methods = {m.type: m for m in parse_dict(ATTEST).auth.methods}
+    assert methods["spiffe"].trust_domain == "acme.internal"
+    assert methods["did"].supported_methods == ["did:web", "did:key"]
+    assert methods["http_signature"].key_id == "k1"
+    assert methods["http_signature"].algorithm == "ed25519"
+
+
+def test_warns_non_https_and_unsatisfiable():
+    m = parse_dict(yaml.safe_load("""
+kcp_version: "0.21"
+project: bad
+version: 1.0.0
+trust:
+  agent_requirements:
+    require_attestation: true
+    attestation_url: http://insecure.example/attest
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+"""))
+    warns = validate(m).warnings
+    assert any("attestation_url SHOULD use HTTPS" in w for w in warns)
+
+
+def test_warns_propagate_without_governs():
+    m = parse_dict(yaml.safe_load("""
+kcp_version: "0.21"
+project: nogov
+version: 1.0.0
+trust:
+  agent_requirements:
+    propagate_to_governed: true
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+"""))
+    assert any("propagate_to_governed" in w for w in validate(m).warnings)

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "kcp_version": {
       "type": "string",
-      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.21\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.20\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
-      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21"]
+      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.22\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.21\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
+      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22"]
     },
     "project": {
       "type": "string",

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -62,7 +62,8 @@
       "additionalProperties": true,
       "properties": {
         "provenance": { "$ref": "#/definitions/trust_provenance" },
-        "audit": { "$ref": "#/definitions/trust_audit" }
+        "audit": { "$ref": "#/definitions/trust_audit" },
+        "agent_requirements": { "$ref": "#/definitions/trust_agent_requirements" }
       }
     },
     "auth": { "$ref": "#/definitions/auth_object" },
@@ -474,6 +475,34 @@
         }
       }
     },
+    "trust_agent_requirements": {
+      "type": "object",
+      "description": "Agent attestation requirements within the trust block (v0.22). Declares what an agent must prove about itself before access: restricted units are served. KCP declares; agents attest. See SPEC.md §3.2.",
+      "additionalProperties": true,
+      "properties": {
+        "require_attestation": {
+          "type": "boolean",
+          "description": "If true, agents MUST present attestation before accessing access: restricted units. Satisfied by trusted_providers OR attestation_url. Default: false."
+        },
+        "trusted_providers": {
+          "type": "array",
+          "description": "Trusted agent-provider domain names (identity-based; matched against the OIDC-A agent_provider claim).",
+          "items": { "type": "string" }
+        },
+        "attestation_url": {
+          "type": "string",
+          "description": "HTTPS endpoint that verifies agent credentials (credential-based). The verification mechanism is out of KCP scope."
+        },
+        "attestation_jwks": {
+          "type": "string",
+          "description": "JWKS endpoint URL for verifying signed responses from attestation_url. If absent, agents use the attestation_url TLS certificate as trust anchor."
+        },
+        "propagate_to_governed": {
+          "type": "boolean",
+          "description": "If true, a manifest that governs another declares that its governed manifests MUST satisfy at least these attestation requirements. Default: false."
+        }
+      }
+    },
     "auth_object": {
       "type": "object",
       "description": "Root-level authentication methods available for accessing protected units. OPTIONAL. See SPEC.md §3.3.",
@@ -495,7 +524,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "Authentication method type. Core values: none (no authentication needed), oauth2 (OAuth 2.1 flow), api_key (static API key). Units with access: authenticated or access: restricted require a non-none method."
+          "description": "Authentication method type. Defined values (v0.22): none, oauth2, api_key, bearer_token, spiffe, did, http_signature. Units with access: authenticated or access: restricted require a non-none method. Unknown types are silently ignored."
         },
         "issuer": {
           "type": "string",
@@ -513,6 +542,23 @@
         "registration_url": {
           "type": "string",
           "description": "URL where agents or users can obtain credentials."
+        },
+        "trust_domain": {
+          "type": "string",
+          "description": "SPIFFE trust domain the source accepts. Relevant when type is spiffe (v0.22)."
+        },
+        "supported_methods": {
+          "type": "array",
+          "description": "Accepted DID methods (e.g. did:web, did:key). Relevant when type is did (v0.22).",
+          "items": { "type": "string" }
+        },
+        "key_id": {
+          "type": "string",
+          "description": "Identifier of the key the agent signs with. Relevant when type is http_signature (v0.22)."
+        },
+        "algorithm": {
+          "type": "string",
+          "description": "Signature algorithm (e.g. ed25519). Relevant when type is http_signature (v0.22)."
         }
       }
     },

--- a/schema/render-schema.json
+++ b/schema/render-schema.json
@@ -21,5 +21,8 @@
   },
   "provenance": {
     "fields": ["publisher", "publisher_url", "contact"]
+  },
+  "agent_requirements": {
+    "fields": ["require_attestation", "trusted_providers", "attestation_url", "attestation_jwks", "propagate_to_governed"]
   }
 }

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -149,11 +149,16 @@ export interface ExternalRelationship {
 
 /** A single authentication method declaration. See SPEC.md §3.3. */
 export interface AuthMethod {
-  type: string;            // "none" | "oauth2" | "api_key" (core types)
+  type: string;            // none | oauth2 | api_key | bearer_token | spiffe | did | http_signature
   issuer?: string;         // OAuth 2.1 issuer URL
   scopes?: string[];       // OAuth 2.1 scopes
   header?: string;         // API key header name (default: "X-API-Key")
   registration_url?: string;
+  // Extended method sub-fields (RFC-0002, v0.22):
+  trust_domain?: string;      // spiffe: accepted SPIFFE trust domain
+  supported_methods?: string[]; // did: accepted DID methods (e.g. did:web, did:key)
+  key_id?: string;            // http_signature: signing key identifier
+  algorithm?: string;         // http_signature: signature algorithm
 }
 
 /** Root-level authentication block. See SPEC.md §3.3. */
@@ -174,10 +179,20 @@ export interface TrustAudit {
   require_trace_context?: boolean;
 }
 
+/** Agent attestation requirements within the trust block. See SPEC.md §3.2 (v0.22). */
+export interface TrustAgentRequirements {
+  require_attestation?: boolean;
+  trusted_providers?: string[];   // identity-based (OIDC-A agent_provider)
+  attestation_url?: string;       // credential-based (HTTPS)
+  attestation_jwks?: string;      // JWKS for verifying attestation_url responses
+  propagate_to_governed?: boolean; // governs-edge policy floor (#47)
+}
+
 /** Root-level trust block. See SPEC.md §3.2. */
 export interface Trust {
   provenance?: TrustProvenance;
   audit?: TrustAudit;
+  agent_requirements?: TrustAgentRequirements;
 }
 
 /** Human-in-the-loop approval object — see SPEC.md §3.4. */

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -23,6 +23,7 @@ import type {
   Relationship,
   Trust,
   TrustAudit,
+  TrustAgentRequirements,
   TrustProvenance,
   Visibility,
   VisibilityCondition,
@@ -186,7 +187,19 @@ function parseTrust(raw: unknown): Trust | undefined {
     };
   }
 
-  return { provenance, audit };
+  let agent_requirements: TrustAgentRequirements | undefined;
+  const arData = data["agent_requirements"] as RawMap | undefined;
+  if (arData && typeof arData === "object") {
+    agent_requirements = {
+      require_attestation: arData["require_attestation"] !== undefined ? Boolean(arData["require_attestation"]) : undefined,
+      trusted_providers: asStringArray(arData["trusted_providers"]),
+      attestation_url: arData["attestation_url"] !== undefined ? String(arData["attestation_url"]) : undefined,
+      attestation_jwks: arData["attestation_jwks"] !== undefined ? String(arData["attestation_jwks"]) : undefined,
+      propagate_to_governed: arData["propagate_to_governed"] !== undefined ? Boolean(arData["propagate_to_governed"]) : undefined,
+    };
+  }
+
+  return { provenance, audit, agent_requirements };
 }
 
 function parseAuth(raw: unknown): Auth | undefined {
@@ -199,6 +212,10 @@ function parseAuth(raw: unknown): Auth | undefined {
     scopes: asStringArray(m["scopes"]),
     header: m["header"] !== undefined ? String(m["header"]) : undefined,
     registration_url: m["registration_url"] !== undefined ? String(m["registration_url"]) : undefined,
+    trust_domain: m["trust_domain"] !== undefined ? String(m["trust_domain"]) : undefined,
+    supported_methods: asStringArray(m["supported_methods"]),
+    key_id: m["key_id"] !== undefined ? String(m["key_id"]) : undefined,
+    algorithm: m["algorithm"] !== undefined ? String(m["algorithm"]) : undefined,
   }));
   return { methods };
 }

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -99,6 +99,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.19",
   "0.20",
   "0.21",
+  "0.22",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -557,6 +557,40 @@ export function validate(
     );
   }
 
+  // Agent attestation requirements validation (§3.2, v0.22)
+  const ar = manifest.trust?.agent_requirements;
+  if (ar) {
+    if (ar.attestation_url && !ar.attestation_url.startsWith("https://")) {
+      warnings.push(
+        `manifest: trust.agent_requirements.attestation_url SHOULD use HTTPS, got '${ar.attestation_url}'`
+      );
+    }
+    if (ar.attestation_jwks && !ar.attestation_jwks.startsWith("https://")) {
+      warnings.push(
+        `manifest: trust.agent_requirements.attestation_jwks SHOULD use HTTPS, got '${ar.attestation_jwks}'`
+      );
+    }
+    if (
+      ar.require_attestation &&
+      !(ar.trusted_providers && ar.trusted_providers.length) &&
+      !ar.attestation_url
+    ) {
+      warnings.push(
+        "manifest: trust.agent_requirements.require_attestation is true but neither trusted_providers nor attestation_url is declared — the requirement cannot be satisfied"
+      );
+    }
+    if (ar.propagate_to_governed) {
+      const hasGoverns =
+        manifest.relationships.some((r) => r.type === "governs") ||
+        manifest.manifests.some((m) => m.relationship === "governs");
+      if (!hasGoverns) {
+        warnings.push(
+          "manifest: trust.agent_requirements.propagate_to_governed is true but the manifest declares no 'governs' relationship — nothing to propagate to"
+        );
+      }
+    }
+  }
+
   // Federation validation (§3.6)
   const manifestIds = new Set<string>();
   for (const ref of manifest.manifests) {


### PR DESCRIPTION
**v0.22 "Trust & Attestation"** — the consumer-identity half of the security model, completing the arc from v0.16–v0.21 (integrity → origin evidence → composition → temporal → *attestation of who may consume*).

Promotes the attestation half of RFC-0004 and the extended-auth remainder of RFC-0002. **All five phases landed; ready for review.**

### Load-bearing principle
**KCP declares trust requirements; it does not perform auth.** The renderer never calls `attestation_url` (deterministic/network-free, C1/C7). The bridge gates restricted-unit *content* on a *presented* credential but never verifies it. Agents attest.

### Phases (all complete)
- [x] **Phase 1 — Spec**: SPEC §3.2 `trust.agent_requirements`, §3.3 extended `auth.methods`, §16.5 **C19–C21**; RFC-0004/0002 finalized; #47 → `propagate_to_governed`.
- [x] **Phase 2 — Parsers (Level 1)**: parse/expose/validate across shared-TS, Python, Java; `knowledge-schema.json`; cross-language tests.
- [x] **Phase 3 — Renderer (C19)**: surfaces `agent_requirements`, marks restricted units `requires_attestation`; flag-not-gate; `render-schema.json` + guard.
- [x] **Phase 4 — Bridges (C20)**: refuse restricted content on every retrieval path unless `attestation` presented; `search` marks `requires_attestation`; parity trio.
- [x] **Phase 5 — Close-out**: atomic version bump to **0.22** (SPEC + all packages + `KNOWN_KCP_VERSIONS` + schema enum); `examples/attestation/`; PARITY + CHANGELOG; closes #47.

### Decisions (locked with maintainer)
1. Bridge **refuses** restricted content when no attestation is presented — never calls `attestation_url`.
2. #47 → `agent_requirements.propagate_to_governed`.
3. Renderer **flags** `requires_attestation`, does not gate `load_eligible`.

### Validation
Mutation-checked, cross-language tests per phase. Local: **bridge-ts 225, python parsers 163, python bridge 166, cli 96** (+5 RFC-0019 corroboration tests that are sandbox-env-flaky — git-remote/local-HTTP — and green in CI). Consistency/version-drift guards green. The Java bridge compiles against the updated parser; its tests run in CI (Maven junit 6.1.1 isn't cached in the dev sandbox).

Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)