### PR TITLE
v0.23 — Trust & Auth Completion (land on main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Spec — v0.23 "Trust & Auth Completion" foundation (RFC-0002 + RFC-0004)
+
+Finishes the trust/auth story and reconciles the RFCs with what actually shipped. Declaration-
+level fields only — no new gating, no new conformance rules (implementation lands in later phases):
+
+- **Per-unit `auth` override (SPEC §3.3)** — a unit's `auth` block overrides the root
+  `auth.methods` for that unit alone (multi-tenant sources).
+- **`trust.audit.provides_access_receipts` / `receipt_format` (SPEC §3.2)** — declares the source
+  issues verifiable access receipts and their format (`jws`, `vc`, or a spec URL).
+- **`trust.provenance.publisher_did` (SPEC §3.2)** — a W3C DID for the publisher, complementing
+  `publisher`/`publisher_url` with a cryptographically resolvable identity.
+- **`require_delegation_proof` (SPEC §3.4)** — added to the delegation field reference (it was in
+  the block's example but missing from the table) and to the implementations.
+- **RFC drift audit:** RFC-0002/0004 "Still RFC-only" lists corrected — per-unit `delegation`
+  (§3.4) and per-unit `compliance` (§3.5) were already in the spec but still marked pending; the
+  four fields above are marked Accepted → v0.23.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,42 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Spec — v0.23 "Trust & Auth Completion" foundation (RFC-0002 + RFC-0004)
+_Nothing yet._
 
-Finishes the trust/auth story and reconciles the RFCs with what actually shipped. Declaration-
-level fields only — no new gating, no new conformance rules (implementation lands in later phases):
+---
 
-- **Per-unit `auth` override (SPEC §3.3)** — a unit's `auth` block overrides the root
-  `auth.methods` for that unit alone (multi-tenant sources).
-- **`trust.audit.provides_access_receipts` / `receipt_format` (SPEC §3.2)** — declares the source
-  issues verifiable access receipts and their format (`jws`, `vc`, or a spec URL).
-- **`trust.provenance.publisher_did` (SPEC §3.2)** — a W3C DID for the publisher, complementing
+## [0.23.0] — 2026-07-04 — Trust & Auth Completion
+
+**Spec version:** `"0.23"` | **Prior:** `"0.22"` (v0.22.0, 2026-07-04)
+
+Finishes the trust/auth story opened across v0.16–v0.22 and reconciles the RFCs with what
+actually shipped. Declaration-level fields — no new gating and **no new conformance rules**; the
+security *enforcement* was v0.16–v0.22's job.
+
+### Promoted (RFC-0002 + RFC-0004)
+
+- **Per-unit `auth` override (§3.3)** — a unit's `auth` block overrides the root `auth.methods`
+  for that unit alone (multi-tenant sources).
+- **`trust.audit.provides_access_receipts` / `receipt_format` (§3.2)** — declares the source
+  issues verifiable access receipts and their format (`jws`, `vc`, or a spec URL). A capability of
+  the source, not a requirement on the agent.
+- **`trust.provenance.publisher_did` (§3.2)** — a W3C DID for the publisher, complementing
   `publisher`/`publisher_url` with a cryptographically resolvable identity.
-- **`require_delegation_proof` (SPEC §3.4)** — added to the delegation field reference (it was in
-  the block's example but missing from the table) and to the implementations.
-- **RFC drift audit:** RFC-0002/0004 "Still RFC-only" lists corrected — per-unit `delegation`
-  (§3.4) and per-unit `compliance` (§3.5) were already in the spec but still marked pending; the
-  four fields above are marked Accepted → v0.23.
+- **`require_delegation_proof` (§3.4)** — was in the delegation block's example but missing from
+  the field-reference table *and* every parser; now documented and implemented.
+
+### RFC drift audit
+
+The v0.23 pass reconciled the RFC headers with the spec: RFC-0002/0004 "Still RFC-only" lists
+were stale — per-unit `delegation` (§3.4) and per-unit `compliance` (§3.5) were **already
+promoted** but still marked pending. Corrected; the four fields above marked Accepted → v0.23.
+
+### Implementations
+
+- All four parsers (shared-TS, Python, Java) parse and expose the new fields; validators warn on
+  a non-DID `publisher_did` and on `provides_access_receipts` without a `receipt_format`.
+- The renderer surfaces `publisher_did` through the provenance passthrough (`render-schema.json`).
+- `knowledge-schema.json` updated; cross-language tests added. Packages bumped to 0.23.0.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ project or documentation site. It adds the metadata layer that llms.txt cannot e
 - **Trust & integrity** (v0.16+): signed manifests, per-unit content hashes, and a trusted render pipeline so execution-capable agents never ingest unauthenticated prose
 - **Temporal validity** (v0.19+): validity windows (`valid_from`/`valid_until`), supersession chains, and point-in-time (`as_of`) queries for audit and future-dated policy
 - **Composition** (v0.19+): compose manifests from other manifests — include, override, exclude — without forking
-- **Trust & attestation** (v0.22+): `trust.agent_requirements` declares what an agent must prove about *itself* before restricted units are served — extended `auth.methods` (SPIFFE, DID, HTTP Message Signatures) and attestation gating enforced by the bridge. KCP *declares* the requirement; the agent *attests*
+- **Trust & attestation** (v0.22+): `trust.agent_requirements` declares what an agent must prove about *itself* before restricted units are served — extended `auth.methods` (SPIFFE, DID, HTTP Message Signatures) and attestation gating enforced by the bridge. KCP *declares* the requirement; the agent *attests*. v0.23 completes the trust/auth surface: per-unit `auth` overrides, `publisher_did`, access receipts, and `require_delegation_proof`
 
 ---
 
@@ -424,9 +424,9 @@ The format is intentionally minimal and builds incrementally through promoted RF
 - **[SPEC.md](./SPEC.md)** — Normative specification (field definitions, validation rules, conformance levels)
 - **[PROPOSAL.md](./PROPOSAL.md)** — The case for a knowledge architecture standard
 - **[RFC-0001](./RFC-0001-KCP-Extended.md)** — Extended capabilities (overview of all proposals; F/H/I/J/K/L/N promoted to v0.3–v0.4 core)
-- **[RFC-0002](./RFC-0002-Auth-and-Delegation.md)** — Auth and delegation metadata (`access`, `auth_scope`, `auth` promoted to core in v0.5–v0.6; `delegation` promoted to core in v0.7; extended `auth.methods` types `bearer_token`/`spiffe`/`did`/`http_signature` promoted in v0.22)
+- **[RFC-0002](./RFC-0002-Auth-and-Delegation.md)** — Auth and delegation metadata (`access`, `auth_scope`, `auth` promoted to core in v0.5–v0.6; `delegation` promoted to core in v0.7; extended `auth.methods` types `bearer_token`/`spiffe`/`did`/`http_signature` promoted in v0.22; per-unit `auth` override and `require_delegation_proof` in v0.23)
 - **[RFC-0003](./RFC-0003-Federation.md)** — Cross-manifest federation proposal (`manifests`, `external_depends_on`, `external_relationships` — promoted to core in v0.9 as DAG with local authority)
-- **[RFC-0004](./RFC-0004-Trust-and-Compliance.md)** — Trust, provenance, and compliance metadata (`trust.provenance`, `sensitivity` promoted in v0.5; `trust.audit` promoted in v0.6; `compliance` promoted to core in v0.7; `content_integrity` in v0.16; `trust.agent_requirements` attestation promoted in v0.22 — conformance C19–C21)
+- **[RFC-0004](./RFC-0004-Trust-and-Compliance.md)** — Trust, provenance, and compliance metadata (`trust.provenance`, `sensitivity` promoted in v0.5; `trust.audit` promoted in v0.6; `compliance` promoted to core in v0.7; `content_integrity` in v0.16; `trust.agent_requirements` attestation promoted in v0.22 — conformance C19–C21; `publisher_did` and access receipts in v0.23)
 - **[RFC-0005](./RFC-0005-Payment-and-Rate-Limits.md)** — Payment and rate-limit metadata proposal (`payment.default_tier` promoted to core in v0.5; `rate_limits` promoted to core in v0.8; payment methods and x402 remain RFC)
 - **[RFC-0006](./RFC-0006-Context-Window-Hints.md)** — Context window hints (accepted; promoted to SPEC.md §4.10 in v0.4)
 - **[RFC-0007](./RFC-0007-Query-Vocabulary.md)** — Query vocabulary (accepted; promoted to SPEC.md §15 in v0.14): `terms`, `audience`, `max_token_budget`, `has_capabilities`, `exclude_stale`, `federation_scope`

--- a/RFC-0002-Auth-and-Delegation.md
+++ b/RFC-0002-Auth-and-Delegation.md
@@ -23,9 +23,9 @@ The following proposals from this RFC have been promoted to the core specificati
 
 **Still RFC-only (not yet promoted):**
 - ~~`auth.methods` types beyond the core three: `bearer_token`, `spiffe`, `did`, `http_signature`~~ — **promoted to SPEC.md §3.3 in v0.22**. Parsers MUST parse and expose them; `type` values beyond the now-seven defined types are still silently ignored for forward compatibility.
-- `auth` at unit level (per-unit auth override) — awaiting real-world use cases.
-- `delegation` at unit level (per-unit delegation override) — promoted at root level in v0.7; per-unit override awaiting real-world use cases.
-- `require_delegation_proof` — awaiting XAA / OIDC-A stabilization.
+- ~~`auth` at unit level (per-unit auth override)~~ — **promoted to SPEC.md §3.3 in v0.23**. A unit's `auth` block overrides the root `auth.methods` for that unit only (multi-tenant sources).
+- ~~`delegation` at unit level (per-unit delegation override)~~ — **promoted to SPEC.md §3.4** (per-unit tightening; MUST NOT relax root constraints). Parser support completed in v0.23.
+- ~~`require_delegation_proof`~~ — **promoted to SPEC.md §3.4 in v0.23** (documented since the delegation block landed; parser support and the field-reference row completed in v0.23). Parsers expose it; proof verification is the agent runtime's responsibility.
 
 ---
 

--- a/RFC-0004-Trust-and-Compliance.md
+++ b/RFC-0004-Trust-and-Compliance.md
@@ -29,10 +29,10 @@ The following proposals from this RFC have been promoted to the core specificati
 
 **Still RFC-only (not yet promoted):**
 - ~~`trust.content_integrity`~~ — **promoted to SPEC.md §3.2 in v0.16**, activated by the trusted render pipeline (RFC-0018), with `EdDSA` (Ed25519, RFC 8037) profiled as the mandatory-to-implement JWS algorithm.
-- `trust.audit.provides_access_receipts` / `receipt_format` — awaiting implementation feedback on receipt formats.
+- ~~`trust.audit.provides_access_receipts` / `receipt_format`~~ — **promoted to SPEC.md §3.2 in v0.23**. Declares that the source issues verifiable access receipts and their format (`jws`, `vc`, or a format-spec URL). Advisory — a capability of the source, not a requirement on the agent.
 - ~~`trust.agent_requirements`~~ — **promoted to SPEC.md §3.2 in v0.22** (`require_attestation`, `trusted_providers`, `attestation_url`, `attestation_jwks`, plus `propagate_to_governed` for `governs`-edge policy propagation, resolving [#47](https://github.com/Cantara/knowledge-context-protocol/issues/47)). Conformance C19 (renderer surfaces, never attests), C20 (bridge gates restricted-unit content on presented credential), C21 (`governs` propagation). KCP declares; agents attest.
-- `trust.provenance.publisher_did` — W3C DID resolution not yet common enough for core.
-- `compliance` at unit level (per-unit compliance override) — promoted at root level in v0.7; per-unit override awaiting real-world validation.
+- ~~`trust.provenance.publisher_did`~~ — **promoted to SPEC.md §3.2 in v0.23**. A W3C DID for the publisher, complementing `publisher`/`publisher_url` with a cryptographically resolvable identity. Advisory — KCP declares it; DID resolution is the agent's.
+- ~~`compliance` at unit level (per-unit compliance override)~~ — **promoted to SPEC.md §3.5** (per-unit values override root `compliance` for that unit only). Parser support completed in v0.23.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -226,6 +226,7 @@ trust:
 | `publisher` | OPTIONAL | string | Human-readable name of the publishing organisation or individual. |
 | `publisher_url` | OPTIONAL | string | URL of the publisher's web presence. MUST use HTTPS if present. |
 | `contact` | OPTIONAL | string | Email address or URL for questions about this manifest's content. |
+| `publisher_did` | OPTIONAL | string | A [W3C Decentralized Identifier](https://www.w3.org/TR/did-core/) for the publisher (e.g. `did:web:acme.com`). Complements `publisher`/`publisher_url` with a cryptographically resolvable identity. Advisory — KCP declares it; agents that resolve DIDs verify it (v0.23). |
 
 #### `trust.audit` sub-fields
 
@@ -233,6 +234,8 @@ trust:
 |-------|----------|------|-------------|
 | `agent_must_log` | OPTIONAL | boolean | Advisory: agents SHOULD record access to this manifest's units in their own audit trail. Default: `false`. |
 | `require_trace_context` | OPTIONAL | boolean | If `true`: agents MUST include [W3C Trace Context](https://www.w3.org/TR/trace-context/) headers (`traceparent`, `tracestate`) when fetching content via HTTP, so the full access chain can be reconstructed. Compatible with [OpenTelemetry](https://opentelemetry.io/). Default: `false`. |
+| `provides_access_receipts` | OPTIONAL | boolean | If `true`: the knowledge source issues a verifiable receipt for each access, so an auditor can later confirm which agent accessed which unit and when. Declares a capability of the source, not a requirement on the agent (v0.23). Default: `false`. |
+| `receipt_format` | OPTIONAL | string | Identifies the receipt format when `provides_access_receipts` is `true` — e.g. `jws`, `vc` (W3C Verifiable Credential), or a URL to a format spec. Advisory (v0.23). |
 
 **`require_trace_context` and local file access:** KCP manifests are frequently consumed from
 local file systems or git repositories where no HTTP request occurs. When content is accessed
@@ -490,6 +493,7 @@ delegation:
 |-------|----------|------|-------------|
 | `max_depth` | OPTIONAL | integer | Maximum delegation chain depth. **The resource owner operates at depth 0.** The first agent to which access is delegated operates at depth 1. `max_depth: 0` means no delegation is permitted — only the resource owner may access the unit directly. Omit for no constraint. |
 | `require_capability_attenuation` | OPTIONAL | boolean | If `true`, each hop in the delegation chain MUST present narrower permissions than the delegating agent held. Agents SHOULD reject delegation tokens that grant equal or greater scope than the parent token. |
+| `require_delegation_proof` | OPTIONAL | boolean | If `true`, an accessing agent MUST present a verifiable delegation chain (a proof back to the resource owner) rather than merely asserting a depth. Parsers expose the field; verification of the proof is the agent runtime's responsibility. Default: `false`. |
 | `audit_chain` | OPTIONAL | boolean | If `true`, agents MUST include W3C Trace Context `traceparent`/`tracestate` headers on all access requests, enabling full delegation chain reconstruction from access logs. Compatible with OpenTelemetry. |
 | `human_in_the_loop` | OPTIONAL | object | Root-level human approval requirement. May be overridden at unit level. |
 
@@ -500,6 +504,26 @@ delegation:
 | `required` | OPTIONAL | If `true`, a human MUST approve agent access before the unit may be loaded. Default: `false`. |
 | `approval_mechanism` | OPTIONAL | How human approval is obtained: `oauth_consent` (OAuth 2.1 authorization code flow with user present), `uma` (UMA 2.0 asynchronous resource owner policy), or `custom` (described at `docs_url`). |
 | `docs_url` | OPTIONAL | URL describing the approval flow. REQUIRED when `approval_mechanism` is `custom`. |
+
+#### Per-unit `auth` overrides (v0.23)
+
+Individual units MAY declare an `auth` block (§3.3, same shape) that overrides the root-level
+`auth.methods` for that unit alone. This supports multi-tenant knowledge sources where different
+units authenticate against different providers. When a unit declares `auth`, agents use the
+unit's methods for that unit and the root methods elsewhere; a unit with no `auth` block inherits
+the root block. Per-unit `auth` is a declaration — KCP does not perform authentication.
+
+```yaml
+units:
+  - id: partner-data
+    path: data/partner.md
+    access: restricted
+    auth:                       # overrides root auth.methods for this unit only
+      methods:
+        - type: oauth2
+          issuer: "https://partner.example.com"
+          scopes: ["read:shared"]
+```
 
 #### Per-unit `delegation` overrides
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knowledge Context Protocol (KCP) Specification
 
-**Version:** 0.22
+**Version:** 0.23
 **Status:** Draft
 **Date:** 2026-06-12
 **Repository:** github.com/cantara/knowledge-context-protocol

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.22.0</version>
+    <version>0.23.0</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.22.0"
+version = "0.23.0"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "MCP bridge for the Knowledge Context Protocol — exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/bridge/typescript/tests/parser.test.ts
+++ b/bridge/typescript/tests/parser.test.ts
@@ -753,3 +753,53 @@ units:
     expect(r.warnings.some((w) => w.includes("propagate_to_governed"))).toBe(true);
   });
 });
+
+// v0.23 Trust & Auth Completion: publisher_did, access receipts, require_delegation_proof,
+// per-unit auth override (RFC-0004/0002).
+describe("v0.23 trust/auth completion fields", () => {
+  const M = (require("js-yaml") as typeof import("js-yaml")).load(`
+kcp_version: "0.22"
+project: v23
+version: 1.0.0
+trust:
+  provenance: {publisher: Acme, publisher_did: "did:web:acme.com"}
+  audit: {provides_access_receipts: true, receipt_format: jws}
+delegation: {max_depth: 2, require_delegation_proof: true}
+units:
+  - id: partner
+    path: p.md
+    intent: "partner data"
+    scope: project
+    audience: [agent]
+    access: restricted
+    auth:
+      methods:
+        - {type: oauth2, issuer: "https://partner.example.com", scopes: [read:shared]}
+`) as Record<string, unknown>;
+
+  it("parses publisher_did, access receipts, require_delegation_proof, per-unit auth", () => {
+    const m = parseDict(M);
+    expect(m.trust!.provenance!.publisher_did).toBe("did:web:acme.com");
+    expect(m.trust!.audit!.provides_access_receipts).toBe(true);
+    expect(m.trust!.audit!.receipt_format).toBe("jws");
+    expect(m.delegation!.require_delegation_proof).toBe(true);
+    expect(m.units[0].auth!.methods[0].type).toBe("oauth2");
+    expect(m.units[0].auth!.methods[0].issuer).toBe("https://partner.example.com");
+  });
+
+  it("warns on a non-DID publisher_did and on receipts without a format", () => {
+    const bad = parseDict((require("js-yaml") as typeof import("js-yaml")).load(`
+kcp_version: "0.22"
+project: bad
+version: 1.0.0
+trust:
+  provenance: {publisher_did: "acme.com"}
+  audit: {provides_access_receipts: true}
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+`) as Record<string, unknown>);
+    const w = validate(bad, ".").warnings;
+    expect(w.some((x) => x.includes("publisher_did SHOULD be a DID"))).toBe(true);
+    expect(w.some((x) => x.includes("provides_access_receipts is true but no receipt_format"))).toBe(true);
+  });
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.22.0
+    `\nKCP Developer CLI — v0.23.0
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.test.ts
+++ b/cli/src/render.test.ts
@@ -163,6 +163,25 @@ units:
     expect(unit.load_eligible).toBe(true); // attestation is the agent's gate (C20), not the renderer's
   });
 
+  it("surfaces trust.provenance.publisher_did in the render (v0.23)", () => {
+    const manifestPath = writeManifest(`project: didtest
+version: 1.0.0
+trust:
+  provenance:
+    publisher: "Acme Corp"
+    publisher_did: "did:web:acme.com"
+units:
+  - id: overview
+    path: README.md
+    intent: "overview"
+    scope: project
+    audience: [agent]
+`);
+    const { doc } = renderOk(manifestPath);
+    expect(doc.trust.provenance.publisher).toBe("Acme Corp");
+    expect(doc.trust.provenance.publisher_did).toBe("did:web:acme.com");
+  });
+
   it("quarantines imperative intent (T1) and keeps the rest", () => {
     const manifestPath = writeManifest(`project: hostile
 version: 1.0.0

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.22.0";
+export const RENDERER_VERSION = "kcp-cli 0.23.0";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.22.0 (all three bridges — aligned with KCP spec version)
+**Current version:** 0.23.0 (all three bridges — aligned with KCP spec version)
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -108,6 +108,7 @@ No known gaps — all three bridges are at full parity.
 | 0.21.0 | 2026-06-13 | Spec v0.21: parsers expose `manifests[].temporal` (RFC-0021) and `discovery.verified_by`/`evidence`; temporal validation (`superseded_by` cycle detection, validity-window §7 warnings) implemented in all four parser/validator implementations. Bridge skip-before-fetch federation temporal filtering deferred. |
 | 0.21.1 | 2026-06-13 | C18 hardening (issue #98): federated temporal filtering now enforced on **every** retrieval path (`get_unit`, `read_resource`, `list_resources`), not just `search_knowledge`; effective date pinned to UTC; supersession-aware exclusion (`superseded_by` + active successor → drop); `as_of` ISO-8601 validation; `local_mirror` association canonicalised (symlink-safe) with a warning on no match; `include_all_temporal` results carry a `caution`; `list_manifests` gains optional `as_of`. All three bridges. |
 | 0.22.0 | 2026-07-04 | Trust & Attestation (RFC-0004/0002): `trust.agent_requirements` + extended `auth.methods` types (`bearer_token`, `spiffe`, `did`, `http_signature`) parsed/exposed; C20 attestation gating — restricted-unit content refused unless an `attestation` argument is presented, on every retrieval path; `search` marks `requires_attestation`; new `attestation` argument on `get_unit` + `search_knowledge`. Bridge never calls `attestation_url`. All three bridges. |
+| 0.23.0 | 2026-07-04 | Trust & Auth Completion (RFC-0002/0004): parsers expose per-unit `auth` override, `trust.provenance.publisher_did`, `trust.audit.provides_access_receipts`/`receipt_format`, and `require_delegation_proof` (closed a spec-vs-parser drift). Validators warn on non-DID `publisher_did` and receipts-without-format. Declaration-level — no new MCP tool behaviour. All four implementations. |
 
 > **Note:** v0.7.0--v0.9.0 were internal development milestones that shipped combined as v0.10.0.
 > v0.11.0--v0.13.0 were bridge feature additions that culminated in v0.14.0.

--- a/docs/index.html
+++ b/docs/index.html
@@ -2421,7 +2421,7 @@ relationships:
 
       <div class="roadmap-core reveal">
         <div class="roadmap-core__info">
-          <span class="roadmap-core__badge">v0.22 — Current</span>
+          <span class="roadmap-core__badge">v0.22 — Shipped</span>
           <h3>Trust &amp; Attestation</h3>
           <p><code>trust.agent_requirements</code> (SPEC §3.2) declares what an agent must prove about <em>itself</em> before <code>access: restricted</code> units are served — the consumer-identity counterpart to producer integrity. Extended <code>auth.methods</code> add SPIFFE, DID, and HTTP Message Signatures (RFC 9421). The renderer surfaces the requirement (C19) and the bridge refuses restricted content on every retrieval path unless a credential is presented (C20) — but <strong>KCP declares; agents attest</strong>: nothing ever calls <code>attestation_url</code>. Promoted from RFC-0004 and RFC-0002.</p>
         </div>
@@ -2429,6 +2429,20 @@ relationships:
           <span class="roadmap-field-pill">agent_requirements</span>
           <span class="roadmap-field-pill">auth.methods</span>
           <span class="roadmap-field-pill">RFC-0004</span>
+          <span class="roadmap-field-pill">RFC-0002</span>
+        </div>
+      </div>
+
+      <div class="roadmap-core reveal">
+        <div class="roadmap-core__info">
+          <span class="roadmap-core__badge">v0.23 — Current</span>
+          <h3>Trust &amp; Auth Completion</h3>
+          <p>Finishes the trust/auth surface: a per-unit <code>auth</code> override (multi-tenant sources), <code>trust.provenance.publisher_did</code> (a resolvable W3C DID for the publisher), <code>trust.audit.provides_access_receipts</code> / <code>receipt_format</code>, and <code>require_delegation_proof</code>. Declaration-level — no new gating. The pass also reconciled the RFCs with the spec, correcting stale &ldquo;not yet promoted&rdquo; notes for per-unit <code>delegation</code> and <code>compliance</code>. Promoted from RFC-0002 and RFC-0004.</p>
+        </div>
+        <div class="roadmap-core__fields">
+          <span class="roadmap-field-pill">publisher_did</span>
+          <span class="roadmap-field-pill">per-unit auth</span>
+          <span class="roadmap-field-pill">access receipts</span>
           <span class="roadmap-field-pill">RFC-0002</span>
         </div>
       </div>

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,16 +107,18 @@ Validates clean: `kcp validate examples/temporal-validity/knowledge.yaml`.
 
 ## [attestation/](./attestation/)
 
-**Trust & Attestation. Restricted units gated behind agent attestation (v0.22).**
+**Trust & Attestation + completion. Restricted units gated behind agent attestation (v0.22–v0.23).**
 
 An internal-knowledge manifest that requires agents to prove who they are before it serves its
-restricted units (RFC-0004/0002, SPEC §3.2/§3.3, v0.22):
+restricted units (RFC-0004/0002, SPEC §3.2/§3.3):
 - `trust.agent_requirements` — `require_attestation`, `trusted_providers` (identity), `attestation_url` (credential)
 - A public `onboarding` unit (served to anyone) and a restricted `incident-runbook` (gated)
 - Extended `auth.methods`: `spiffe` (workload SVID) and `http_signature` (RFC 9421)
 - **KCP declares; agents attest** — the renderer flags `requires_attestation` and never
   dereferences `attestation_url`; the bridge refuses restricted content until an `attestation`
   argument is presented (C19/C20)
+- v0.23 completion fields: `trust.provenance.publisher_did` (resolvable publisher identity) and
+  `trust.audit.provides_access_receipts` / `receipt_format` (verifiable access receipts)
 
 Walkthrough: [guides/gating-restricted-knowledge-with-attestation.md](../guides/gating-restricted-knowledge-with-attestation.md).
 Validates clean: `kcp validate examples/attestation/knowledge.yaml`.

--- a/examples/attestation/README.md
+++ b/examples/attestation/README.md
@@ -1,4 +1,4 @@
-# Attestation example (v0.22)
+# Attestation example (v0.22–v0.23)
 
 An internal-knowledge manifest that requires agents to **attest who they are** before it will
 serve its restricted units — the consumer-identity half of KCP's security model
@@ -17,6 +17,12 @@ the real attesting (SPIFFE SVID, RFC 9421 signature, OIDC-A claim, …).
 kcp validate examples/attestation/knowledge.yaml   # ✓ Valid
 kcp render   examples/attestation/knowledge.yaml   # surfaces agent_requirements + requires_attestation
 ```
+
+**v0.23 completion fields.** The manifest also carries the publisher-side half of the trust story:
+`trust.provenance.publisher_did` (`did:web:acme.com` — a resolvable publisher identity) and
+`trust.audit.provides_access_receipts` / `receipt_format` (declaring that access is logged into
+verifiable receipts). These are declarations the renderer surfaces; like `attestation_url`, KCP
+never resolves the DID or mints a receipt itself.
 
 Full walkthrough (validate → render → bridge gating → governance propagation):
 [**guides/gating-restricted-knowledge-with-attestation.md**](../../guides/gating-restricted-knowledge-with-attestation.md).

--- a/examples/attestation/knowledge.yaml
+++ b/examples/attestation/knowledge.yaml
@@ -10,6 +10,10 @@ trust:
   provenance:
     publisher: "Acme Corp"
     contact: "knowledge-team@acme.com"
+    publisher_did: "did:web:acme.com"        # v0.23 — resolvable publisher identity
+  audit:
+    provides_access_receipts: true           # v0.23 — issues verifiable access receipts
+    receipt_format: jws
   agent_requirements:
     require_attestation: true
     # Satisfied by EITHER an allowlisted provider identity OR a credential the endpoint accepts.

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -149,6 +149,7 @@ public class KcpParser {
                 parseRateLimits((Map<String, Object>) u.get("rate_limits")),
                 parseDelegation((Map<String, Object>) u.get("delegation")),
                 parseCompliance((Map<String, Object>) u.get("compliance")),
+                parseAuth((Map<String, Object>) u.get("auth")),
                 externalDependsOn,
                 (List<String>) u.getOrDefault("requires_capabilities", List.of()),
                 parseFreshnessPolicy((Map<String, Object>) u.get("freshness_policy")),
@@ -182,7 +183,8 @@ public class KcpParser {
             provenance = new TrustProvenance(
                     (String) provMap.get("publisher"),
                     (String) provMap.get("publisher_url"),
-                    (String) provMap.get("contact")
+                    (String) provMap.get("contact"),
+                    (String) provMap.get("publisher_did")
             );
         }
 
@@ -190,7 +192,9 @@ public class KcpParser {
         if (auditMap != null) {
             audit = new TrustAudit(
                     (Boolean) auditMap.get("agent_must_log"),
-                    (Boolean) auditMap.get("require_trace_context")
+                    (Boolean) auditMap.get("require_trace_context"),
+                    (Boolean) auditMap.get("provides_access_receipts"),
+                    (String) auditMap.get("receipt_format")
             );
         }
 
@@ -249,6 +253,7 @@ public class KcpParser {
         return new Delegation(
                 (Integer) d.get("max_depth"),
                 (Boolean) d.get("require_capability_attenuation"),
+                (Boolean) d.get("require_delegation_proof"),
                 (Boolean) d.get("audit_chain"),
                 hitl
         );

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -54,7 +54,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -320,6 +320,19 @@ public class KcpValidator {
             }
         }
 
+        // Trust provenance / audit validation (§3.2, v0.23)
+        if (manifest.trust() != null) {
+            var prov = manifest.trust().provenance();
+            if (prov != null && prov.publisherDid() != null && !prov.publisherDid().startsWith("did:")) {
+                warnings.add("manifest: trust.provenance.publisher_did SHOULD be a DID (start with 'did:'), got '"
+                        + prov.publisherDid() + "'");
+            }
+            var au = manifest.trust().audit();
+            if (au != null && Boolean.TRUE.equals(au.providesAccessReceipts()) && au.receiptFormat() == null) {
+                warnings.add("manifest: trust.audit.provides_access_receipts is true but no receipt_format is declared");
+            }
+        }
+
         for (Relationship rel : manifest.relationships()) {
             String p = "relationship '" + rel.fromId() + "' -> '" + rel.toId() + "'";
             if (!unitIds.contains(rel.fromId())) {

--- a/parsers/java/src/main/java/no/cantara/kcp/model/Delegation.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/Delegation.java
@@ -7,6 +7,7 @@ package no.cantara.kcp.model;
 public record Delegation(
         Integer maxDepth,
         Boolean requireCapabilityAttenuation,
+        Boolean requireDelegationProof,   // v0.23 (SPEC §3.4)
         Boolean auditChain,
         HumanInTheLoop humanInTheLoop
 ) {

--- a/parsers/java/src/main/java/no/cantara/kcp/model/KnowledgeUnit.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/KnowledgeUnit.java
@@ -32,6 +32,7 @@ public record KnowledgeUnit(
         RateLimits rateLimits,
         Delegation delegation,
         Compliance compliance,
+        Auth auth,   // v0.23 — per-unit auth override (SPEC §3.3)
         List<ExternalDependency> externalDependsOn,
         List<String> requiresCapabilities,
         FreshnessPolicy freshnessPolicy,

--- a/parsers/java/src/main/java/no/cantara/kcp/model/TrustAudit.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/TrustAudit.java
@@ -9,6 +9,8 @@ package no.cantara.kcp.model;
  */
 public record TrustAudit(
         Boolean agentMustLog,
-        Boolean requireTraceContext
+        Boolean requireTraceContext,
+        Boolean providesAccessReceipts,   // v0.23
+        String receiptFormat              // v0.23
 ) {
 }

--- a/parsers/java/src/main/java/no/cantara/kcp/model/TrustProvenance.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/TrustProvenance.java
@@ -6,6 +6,7 @@ package no.cantara.kcp.model;
 public record TrustProvenance(
         String publisher,
         String publisherUrl,
-        String contact
+        String contact,
+        String publisherDid   // v0.23 — W3C DID publisher identity
 ) {
 }

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpTrustAuthCompletionTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpTrustAuthCompletionTest.java
@@ -1,0 +1,63 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.KnowledgeManifest;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** v0.23 Trust & Auth Completion: publisher_did, access receipts, require_delegation_proof,
+ *  per-unit auth override (RFC-0004/0002). */
+class KcpTrustAuthCompletionTest {
+
+    @SuppressWarnings("unchecked")
+    private static KnowledgeManifest parse(String yaml) {
+        return KcpParser.fromMap((Map<String, Object>) new Yaml().load(yaml));
+    }
+
+    @Test void parsesV23Fields() {
+        KnowledgeManifest m = parse("""
+            kcp_version: "0.22"
+            project: v23
+            version: 1.0.0
+            trust:
+              provenance: {publisher: Acme, publisher_did: "did:web:acme.com"}
+              audit: {provides_access_receipts: true, receipt_format: jws}
+            delegation: {max_depth: 2, require_delegation_proof: true}
+            units:
+              - id: partner
+                path: p.md
+                intent: partner data
+                scope: project
+                audience: [agent]
+                access: restricted
+                auth:
+                  methods:
+                    - {type: oauth2, issuer: "https://partner.example.com", scopes: [read:shared]}
+            """);
+        assertEquals("did:web:acme.com", m.trust().provenance().publisherDid());
+        assertEquals(Boolean.TRUE, m.trust().audit().providesAccessReceipts());
+        assertEquals("jws", m.trust().audit().receiptFormat());
+        assertEquals(Boolean.TRUE, m.delegation().requireDelegationProof());
+        assertEquals("oauth2", m.units().get(0).auth().methods().get(0).type());
+        assertEquals("https://partner.example.com", m.units().get(0).auth().methods().get(0).issuer());
+    }
+
+    @Test void warnsBadDidAndReceiptsWithoutFormat() {
+        KnowledgeManifest m = parse("""
+            kcp_version: "0.22"
+            project: bad
+            version: 1.0.0
+            trust:
+              provenance: {publisher_did: "acme.com"}
+              audit: {provides_access_receipts: true}
+            units:
+              - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+            """);
+        var w = KcpValidator.validate(m).warnings();
+        assertTrue(w.stream().anyMatch(x -> x.contains("publisher_did SHOULD be a DID")), w.toString());
+        assertTrue(w.stream().anyMatch(x -> x.contains("provides_access_receipts is true but no receipt_format")), w.toString());
+    }
+}

--- a/parsers/python/kcp/model.py
+++ b/parsers/python/kcp/model.py
@@ -54,6 +54,7 @@ class Delegation:
     """Delegation constraints block — root-level and per-unit override. See SPEC.md §3.4."""
     max_depth: Optional[int] = None
     require_capability_attenuation: Optional[bool] = None
+    require_delegation_proof: Optional[bool] = None  # v0.23 (SPEC §3.4)
     audit_chain: Optional[bool] = None
     human_in_the_loop: Optional[Any] = None  # dict per spec §3.4
 
@@ -153,6 +154,7 @@ class KnowledgeUnit:
     rate_limits: Optional["RateLimits"] = None
     delegation: Optional[Delegation] = None
     compliance: Optional[Compliance] = None
+    auth: Optional["Auth"] = None  # v0.23 — per-unit auth override (SPEC §3.3)
     external_depends_on: list[ExternalDependency] = field(default_factory=list)
     requires_capabilities: list[str] = field(default_factory=list)
     freshness_policy: Optional["FreshnessPolicy"] = None
@@ -238,6 +240,7 @@ class TrustProvenance:
     publisher: Optional[str] = None
     publisher_url: Optional[str] = None
     contact: Optional[str] = None
+    publisher_did: Optional[str] = None  # v0.23 — W3C DID publisher identity
 
 
 @dataclass
@@ -245,6 +248,8 @@ class TrustAudit:
     """Audit requirements within the trust block. See SPEC.md section 3.2."""
     agent_must_log: Optional[bool] = None
     require_trace_context: Optional[bool] = None
+    provides_access_receipts: Optional[bool] = None  # v0.23
+    receipt_format: Optional[str] = None             # v0.23
 
 
 @dataclass

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -56,6 +56,7 @@ def _parse_trust(data: Optional[dict]) -> Optional[Trust]:
             publisher=prov_data.get("publisher"),
             publisher_url=prov_data.get("publisher_url"),
             contact=prov_data.get("contact"),
+            publisher_did=prov_data.get("publisher_did"),
         )
     audit = None
     audit_data = data.get("audit")
@@ -63,6 +64,8 @@ def _parse_trust(data: Optional[dict]) -> Optional[Trust]:
         audit = TrustAudit(
             agent_must_log=audit_data.get("agent_must_log"),
             require_trace_context=audit_data.get("require_trace_context"),
+            provides_access_receipts=audit_data.get("provides_access_receipts"),
+            receipt_format=audit_data.get("receipt_format"),
         )
     agent_requirements = None
     ar_data = data.get("agent_requirements")
@@ -105,6 +108,7 @@ def _parse_delegation(data: Optional[dict]) -> Optional[Delegation]:
     return Delegation(
         max_depth=data.get("max_depth"),
         require_capability_attenuation=data.get("require_capability_attenuation"),
+        require_delegation_proof=data.get("require_delegation_proof"),
         audit_chain=data.get("audit_chain"),
         human_in_the_loop=data.get("human_in_the_loop"),
     )
@@ -313,6 +317,7 @@ def parse_dict(data: dict) -> KnowledgeManifest:
             rate_limits=_parse_rate_limits(u.get("rate_limits")),
             delegation=_parse_delegation(u.get("delegation")),
             compliance=_parse_compliance(u.get("compliance")),
+            auth=_parse_auth(u.get("auth")),
             external_depends_on=[
                 _parse_external_dependency(ed)
                 for ed in u.get("external_depends_on", [])

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -453,6 +453,18 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
                     "manifest declares no 'governs' relationship — nothing to propagate to"
                 )
 
+    # Trust provenance / audit validation (§3.2, v0.23)
+    prov = manifest.trust.provenance if manifest.trust else None
+    if prov is not None and prov.publisher_did and not prov.publisher_did.startswith("did:"):
+        warnings.append(
+            f"manifest: trust.provenance.publisher_did SHOULD be a DID (start with 'did:'), got '{prov.publisher_did}'"
+        )
+    audit = manifest.trust.audit if manifest.trust else None
+    if audit is not None and audit.provides_access_receipts and not audit.receipt_format:
+        warnings.append(
+            "manifest: trust.audit.provides_access_receipts is true but no receipt_format is declared"
+        )
+
     for rel in manifest.relationships:
         p = f"relationship '{rel.from_id}' -> '{rel.to_id}'"
         if rel.from_id not in unit_ids:

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -94,7 +94,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}

--- a/parsers/python/tests/test_trust_auth_completion.py
+++ b/parsers/python/tests/test_trust_auth_completion.py
@@ -1,0 +1,51 @@
+"""v0.23 Trust & Auth Completion: publisher_did, access receipts, require_delegation_proof,
+per-unit auth (RFC-0004/0002)."""
+import yaml
+from kcp.parser import parse_dict
+from kcp.validator import validate
+
+M = yaml.safe_load("""
+kcp_version: "0.22"
+project: v23
+version: 1.0.0
+trust:
+  provenance: {publisher: Acme, publisher_did: "did:web:acme.com"}
+  audit: {provides_access_receipts: true, receipt_format: jws}
+delegation: {max_depth: 2, require_delegation_proof: true}
+units:
+  - id: partner
+    path: p.md
+    intent: partner data
+    scope: project
+    audience: [agent]
+    access: restricted
+    auth:
+      methods:
+        - {type: oauth2, issuer: "https://partner.example.com", scopes: [read:shared]}
+""")
+
+
+def test_parses_v23_fields():
+    m = parse_dict(M)
+    assert m.trust.provenance.publisher_did == "did:web:acme.com"
+    assert m.trust.audit.provides_access_receipts is True
+    assert m.trust.audit.receipt_format == "jws"
+    assert m.delegation.require_delegation_proof is True
+    assert m.units[0].auth.methods[0].type == "oauth2"
+    assert m.units[0].auth.methods[0].issuer == "https://partner.example.com"
+
+
+def test_warns_bad_did_and_receipts_without_format():
+    m = parse_dict(yaml.safe_load("""
+kcp_version: "0.22"
+project: bad
+version: 1.0.0
+trust:
+  provenance: {publisher_did: "acme.com"}
+  audit: {provides_access_receipts: true}
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+"""))
+    w = validate(m).warnings
+    assert any("publisher_did SHOULD be a DID" in x for x in w)
+    assert any("provides_access_receipts is true but no receipt_format" in x for x in w)

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -278,6 +278,7 @@
         },
         "delegation": { "$ref": "#/definitions/delegation_object" },
         "compliance": { "$ref": "#/definitions/compliance_object" },
+        "auth": { "$ref": "#/definitions/auth_object" },
         "payment": { "$ref": "#/definitions/payment_object" },
         "rate_limits": { "$ref": "#/definitions/rate_limits_object" },
         "external_depends_on": {
@@ -457,6 +458,10 @@
         "contact": {
           "type": "string",
           "description": "Email address or URL for questions about this manifest's content."
+        },
+        "publisher_did": {
+          "type": "string",
+          "description": "A W3C Decentralized Identifier for the publisher (e.g. did:web:acme.com). Advisory; cryptographically resolvable identity (v0.23)."
         }
       }
     },
@@ -472,6 +477,14 @@
         "require_trace_context": {
           "type": "boolean",
           "description": "Whether agents SHOULD attach W3C Trace Context (traceparent/tracestate) headers when fetching unit content. For local file access, agents SHOULD generate a traceparent value and record it in local logs. Default: false."
+        },
+        "provides_access_receipts": {
+          "type": "boolean",
+          "description": "Whether the source issues a verifiable receipt for each access, so an auditor can confirm which agent accessed which unit and when. A capability of the source, not a requirement on the agent (v0.23). Default: false."
+        },
+        "receipt_format": {
+          "type": "string",
+          "description": "Identifies the receipt format when provides_access_receipts is true — e.g. jws, vc (W3C Verifiable Credential), or a URL to a format spec (v0.23)."
         }
       }
     },
@@ -575,6 +588,10 @@
         "require_capability_attenuation": {
           "type": "boolean",
           "description": "If true, each hop in the delegation chain MUST present narrower permissions than the delegating agent held."
+        },
+        "require_delegation_proof": {
+          "type": "boolean",
+          "description": "If true, an accessing agent MUST present a verifiable delegation chain back to the resource owner, not merely assert a depth. Parsers expose it; proof verification is the agent's (v0.23). Default: false."
         },
         "audit_chain": {
           "type": "boolean",

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "kcp_version": {
       "type": "string",
-      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.22\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.21\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
-      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22"]
+      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.23\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.22\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
+      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23"]
     },
     "project": {
       "type": "string",

--- a/schema/render-schema.json
+++ b/schema/render-schema.json
@@ -20,7 +20,7 @@
     "fields": ["id", "url", "relationship"]
   },
   "provenance": {
-    "fields": ["publisher", "publisher_url", "contact"]
+    "fields": ["publisher", "publisher_url", "contact", "publisher_did"]
   },
   "agent_requirements": {
     "fields": ["require_attestation", "trusted_providers", "attestation_url", "attestation_jwks", "propagate_to_governed"]

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -98,6 +98,7 @@ export interface KnowledgeUnit {
   rate_limits?: RateLimits;
   delegation?: Delegation;
   compliance?: Compliance;
+  auth?: Auth;             // v0.23 — per-unit auth override (SPEC §3.3)
   external_depends_on: ExternalDependency[];  // defaults to []
   requires_capabilities?: string[];
   freshness_policy?: FreshnessPolicy;
@@ -171,12 +172,15 @@ export interface TrustProvenance {
   publisher?: string;
   publisher_url?: string;
   contact?: string;
+  publisher_did?: string;   // v0.23 — W3C DID publisher identity
 }
 
 /** Audit requirements within the trust block. See SPEC.md §3.2. */
 export interface TrustAudit {
   agent_must_log?: boolean;
   require_trace_context?: boolean;
+  provides_access_receipts?: boolean;   // v0.23
+  receipt_format?: string;              // v0.23
 }
 
 /** Agent attestation requirements within the trust block. See SPEC.md §3.2 (v0.22). */
@@ -206,6 +210,7 @@ export interface HumanInTheLoop {
 export interface Delegation {
   max_depth?: number;
   require_capability_attenuation?: boolean;
+  require_delegation_proof?: boolean;   // v0.23 (SPEC §3.4)
   audit_chain?: boolean;
   human_in_the_loop?: HumanInTheLoop;
 }

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -133,6 +133,7 @@ function parseUnit(raw: RawMap): KnowledgeUnit {
     rate_limits: parseRateLimits(raw["rate_limits"]),
     delegation: parseDelegation(raw["delegation"]),
     compliance: parseCompliance(raw["compliance"]),
+    auth: parseAuth(raw["auth"]),
     external_depends_on: ((raw["external_depends_on"] as RawMap[]) ?? []).map(
       parseExternalDependency
     ),
@@ -175,6 +176,7 @@ function parseTrust(raw: unknown): Trust | undefined {
       publisher: provData["publisher"] !== undefined ? String(provData["publisher"]) : undefined,
       publisher_url: provData["publisher_url"] !== undefined ? String(provData["publisher_url"]) : undefined,
       contact: provData["contact"] !== undefined ? String(provData["contact"]) : undefined,
+      publisher_did: provData["publisher_did"] !== undefined ? String(provData["publisher_did"]) : undefined,
     };
   }
 
@@ -184,6 +186,8 @@ function parseTrust(raw: unknown): Trust | undefined {
     audit = {
       agent_must_log: auditData["agent_must_log"] !== undefined ? Boolean(auditData["agent_must_log"]) : undefined,
       require_trace_context: auditData["require_trace_context"] !== undefined ? Boolean(auditData["require_trace_context"]) : undefined,
+      provides_access_receipts: auditData["provides_access_receipts"] !== undefined ? Boolean(auditData["provides_access_receipts"]) : undefined,
+      receipt_format: auditData["receipt_format"] !== undefined ? String(auditData["receipt_format"]) : undefined,
     };
   }
 
@@ -228,6 +232,10 @@ function parseDelegation(raw: unknown): Delegation | undefined {
     require_capability_attenuation:
       data["require_capability_attenuation"] !== undefined
         ? Boolean(data["require_capability_attenuation"])
+        : undefined,
+    require_delegation_proof:
+      data["require_delegation_proof"] !== undefined
+        ? Boolean(data["require_delegation_proof"])
         : undefined,
     audit_chain:
       data["audit_chain"] !== undefined ? Boolean(data["audit_chain"]) : undefined,

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -100,6 +100,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.20",
   "0.21",
   "0.22",
+  "0.23",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -592,6 +592,20 @@ export function validate(
     }
   }
 
+  // Trust provenance / audit validation (§3.2, v0.23)
+  const prov = manifest.trust?.provenance;
+  if (prov?.publisher_did && !prov.publisher_did.startsWith("did:")) {
+    warnings.push(
+      `manifest: trust.provenance.publisher_did SHOULD be a DID (start with 'did:'), got '${prov.publisher_did}'`
+    );
+  }
+  const auditBlock = manifest.trust?.audit;
+  if (auditBlock?.provides_access_receipts && !auditBlock.receipt_format) {
+    warnings.push(
+      "manifest: trust.audit.provides_access_receipts is true but no receipt_format is declared"
+    );
+  }
+
   // Federation validation (§3.6)
   const manifestIds = new Set<string>();
   for (const ref of manifest.manifests) {


### PR DESCRIPTION
## Why this PR exists

**v0.23 never actually reached `main`.** The original v0.23 PR (#109) was stacked on top of the v0.22 feature branch. When #108 (v0.22 → main) merged first and #109 merged second, #109 landed **into the v0.22 branch**, not into `main`. Net result: `main` is still at `0.22` (`SPEC.md` header `0.22`, no `publisher_did` in the parsers). This PR re-homes the full v0.23 changeset onto `main` via a clean cherry-pick, plus the documentation gap-fill that was in progress.

Verified before opening: `origin/main:SPEC.md` → `**Version:** 0.22`; `grep -c publisher_did origin/main:shared/src/model.ts` → `0`.

## What's in v0.23 — Trust & Auth Completion (RFC-0002 + RFC-0004)

Declaration-level completion of the trust/auth surface — no new gating or conformance rules, plus an RFC-drift audit.

- **Per-unit `auth` override** (SPEC §3.3) — a unit may narrow/override the manifest `auth` block.
- **`trust.provenance.publisher_did`** (SPEC §3.2) — resolvable W3C DID publisher identity (validator warns if it doesn't start with `did:`).
- **`trust.audit.provides_access_receipts` / `receipt_format`** (SPEC §3.2) — declare that access is logged into verifiable receipts (validator warns if `provides_access_receipts` is set without a `receipt_format`).
- **`delegation.require_delegation_proof`** (SPEC §3.4) — was present in a SPEC example but missing from the field table and every parser; now promoted and wired through all four reference implementations.

## Coverage

- **Spec/schema:** `SPEC.md` §3.2/§3.3/§3.4, version → `0.23`; `schema/knowledge-schema.json` (+ enum), `schema/render-schema.json`.
- **Parsers (all 3):** TypeScript shared-core (`model`/`parser`/`validator`), Python (`parsers/python`), Java (`parsers/java`) — model fields, parse wiring, validator warnings, `KNOWN_KCP_VERSIONS`.
- **Renderer:** `publisher_did` surfaced; `RENDERER_VERSION` → `0.23.0`; version-drift consistency guard green (24/24).
- **Tests:** new v0.23 blocks in `bridge/typescript/tests/parser.test.ts`, `cli/src/render.test.ts`, `parsers/python/tests/test_trust_auth_completion.py`, `parsers/java/.../KcpTrustAuthCompletionTest.java`.
- **Docs/examples:** `CHANGELOG` [0.23.0], `docs/PARITY.md`, `README.md`, `docs/index.html` (v0.22 → Shipped, new v0.23 card), `examples/README.md`, `examples/attestation/` (manifest + README carry `publisher_did` and access-receipt fields).

## Notes

- Tag `v0.23.0` still needs to be cut by a maintainer (the sandbox proxy 403s on `refs/tags/*`).
- Java tests are CI-only here (Maven Central offline for the Renovate-bumped junit in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_