### PR TITLE
v0.24 — Org-Federation (RFC-0011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ _Nothing yet._
 
 ---
 
+## [0.24.0] — 2026-07-04 — Org-Federation
+
+**Spec version:** `"0.24"` | **Prior:** `"0.23"` (v0.23.0, 2026-07-04)
+
+Answers the enterprise-bootstrap question — how an agent that knows only a company domain finds
+its first manifest, gets through the door, and progressively learns what else exists — by promoting
+the two concrete fields from RFC-0011 to the §3.6 federation core. Declaration-level and advisory:
+KCP surfaces them and never acts on them; **no new conformance rules**.
+
+### Promoted (RFC-0011)
+
+- **`manifests[].context` (§3.6)** — a list of environment labels (`dev`/`test`/`staging`/`prod`,
+  non-normative) for which a sub-manifest reference is valid. One hub publishes a federation list
+  that spans environments; an agent selects only the entries matching its runtime. Absent = valid
+  everywhere.
+- **`manifests[].agent_identity` (§3.6)** — a pre-fetch credential-planning hint (`required`,
+  `credential_hint`, `issuer_hint`, `docs_url`). Tells a traversing agent what credential to
+  acquire *before* it fetches a sub-manifest, so it plans instead of failing a fetch and
+  backtracking. A declaration layer, not an auth protocol — the sub-manifest's own `auth` block
+  (§3.3) remains the enforcement point.
+
+The **Org Hub** (`network.role: hub` + a public front-door unit + a `manifests[]` block) and
+**progressive disclosure** (`public` → `internal` → `confidential` sensitivity tiers) patterns ship
+as usage conventions layered on existing fields — no new spec surface.
+
+### Implementations
+
+- **Parsers (all four):** TypeScript shared core, Python, Java, and the `kcp render` pipeline parse
+  and expose both fields. The renderer surfaces `context` and `agent_identity` as data and never
+  dereferences `docs_url` or `issuer_hint` (deterministic, network-free — consistent with C19).
+- **Validators:** warn on empty `context`, `agent_identity.required` without a `credential_hint`,
+  and `issuer_hint` used with a `credential_hint` other than `oauth2`.
+- **Example + tutorial:** [`examples/org-federation/`](./examples/org-federation/) (a runnable hub)
+  and [`guides/enterprise-discovery-with-org-federation.md`](./guides/enterprise-discovery-with-org-federation.md).
+
+### Open questions resolved conservatively
+
+RFC-0011's open questions (normative vs free-string vocabularies; Org-Hub-as-Level-4) landed on the
+cautious side: both the `context` and `credential_hint` vocabularies ship **non-normative** and
+extensible, and **no new conformance level** is introduced — parse-and-expose is Level 1.
+
+---
+
 ## [0.23.0] — 2026-07-04 — Trust & Auth Completion
 
 **Spec version:** `"0.23"` | **Prior:** `"0.22"` (v0.22.0, 2026-07-04)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ project or documentation site. It adds the metadata layer that llms.txt cannot e
 - **Temporal validity** (v0.19+): validity windows (`valid_from`/`valid_until`), supersession chains, and point-in-time (`as_of`) queries for audit and future-dated policy
 - **Composition** (v0.19+): compose manifests from other manifests — include, override, exclude — without forking
 - **Trust & attestation** (v0.22+): `trust.agent_requirements` declares what an agent must prove about *itself* before restricted units are served — extended `auth.methods` (SPIFFE, DID, HTTP Message Signatures) and attestation gating enforced by the bridge. KCP *declares* the requirement; the agent *attests*. v0.23 completes the trust/auth surface: per-unit `auth` overrides, `publisher_did`, access receipts, and `require_delegation_proof`
+- **Org-federation** (v0.24+): enterprise discovery over the §3.6 federation graph — `manifests[].context` tags each sub-manifest reference with the environment(s) it is valid for (`dev`/`test`/`staging`/`prod`), and `manifests[].agent_identity` is a pre-fetch credential hint so an agent acquires the right token *before* it fetches. Advisory declarations — the hub declares; the agent acts
 
 ---
 
@@ -433,7 +434,7 @@ The format is intentionally minimal and builds incrementally through promoted RF
 - **[RFC-0008](./RFC-0008-Agent-Readiness.md)** — Agent readiness and budget-constrained selection (accepted; promoted to SPEC.md §15 in v0.14): scored results, token-budget-aware ranking, `freshness_policy`
 - **[RFC-0009](./RFC-0009-Visibility-and-Authority.md)** — Visibility and authority (accepted; promoted to SPEC.md in v0.12): `visibility` conditions and `authority` action permissions (read/summarize/modify/share/execute)
 - **[RFC-0010](./RFC-0010-Bi-Temporal-Unit-Validity.md)** — Bi-temporal unit validity (accepted; schema promoted §4.22 in v0.19, query layer §15.13 in v0.20): `temporal` block with valid-time (`valid_from`/`valid_until`) and transaction-time (`recorded_at`/`superseded_by`), plus `as_of` / `include_all_temporal` queries
-- **[RFC-0011](./RFC-0011-Org-Federation.md)** — Organisational federation patterns (RFC): hub-and-spoke and multi-org topologies over the §3.6 federation core
+- **[RFC-0011](./RFC-0011-Org-Federation.md)** — Organisational federation and enterprise discovery over the §3.6 federation core (accepted; `manifests[].context` and `manifests[].agent_identity` promoted in v0.24; Org Hub and progressive-disclosure patterns ship as usage conventions)
 - **[RFC-0012](./RFC-0012-Capability-Discovery-Provenance.md)** — Capability discovery provenance (accepted; promoted to SPEC.md v0.12): `discovery` block with `verification_status`, `confidence`, `source`, `contradicted_by`; `verified_by`/`evidence` added in v0.19
 - **[RFC-0013](./RFC-0013-Cartridge-Catalog-Distribution.md)** — Cartridge catalog and distribution (RFC; see [CATALOG-SPEC.md](./CATALOG-SPEC.md)): packaging and distributing reusable knowledge cartridges
 - **[RFC-0014](./RFC-0014-Manifest-Composition.md)** — Manifest composition (accepted; core promoted to SPEC.md §3.11 in v0.19 via RFC-0020): `includes`, `overrides`, `excludes` — inherit base manifests without forking

--- a/RFC-0011-Org-Federation.md
+++ b/RFC-0011-Org-Federation.md
@@ -1,6 +1,6 @@
 # RFC-0011: Org Federation — Enterprise Discovery and Progressive Access
 
-**Status:** Request for Comments
+**Status:** Accepted — `manifests[].context` and `manifests[].agent_identity` promoted to [SPEC.md](./SPEC.md) §3.6 (v0.24). The Org Hub and Progressive Disclosure patterns ship as usage conventions with a reference example ([examples/org-federation/](./examples/org-federation/)) and walkthrough ([guides/enterprise-discovery-with-org-federation.md](./guides/enterprise-discovery-with-org-federation.md)); they add no new spec fields.
 **Authors:** eXOReaction AS (Thor Henning Hetland)
 **Date:** 2026-03-15
 **Discussion:** [#50 KCP Treasure Map Service](https://github.com/Cantara/knowledge-context-protocol/discussions/50)
@@ -244,8 +244,19 @@ This RFC was directly shaped by Discussion #50 ("KCP Treasure Map Service"). If 
 
 ## Status
 
-**Request for Comments.** This RFC will be promoted to the core spec (target: v0.12) after:
+**Accepted — promoted to core in v0.24.** The two concrete schema additions — `manifests[].context`
+(environment-aware references) and `manifests[].agent_identity` (pre-fetch credential-planning
+hint) — are promoted to [SPEC.md](./SPEC.md) §3.6 and parsed/surfaced by all four reference
+implementations (TypeScript shared core, Python, Java, and the `kcp render` pipeline). Both are
+declaration-level and advisory: KCP surfaces them and never acts on them.
 
-1. At least one external implementer validates the `context` and `agent_identity` field designs against a real enterprise deployment.
-2. The progressive disclosure pattern is demonstrated in a reference `examples/org-federation/` example.
-3. RFC-0009 `visibility.conditions[]` is validated in at least one bridge — confirming the two RFCs compose correctly.
+The **Org Hub** and **Progressive Disclosure** patterns are promoted as *usage conventions* — they
+introduce no new spec fields, layering instead on existing `network`, `compliance.sensitivity`,
+RFC-0009 `visibility.conditions[]`, and RFC-0007 `search_knowledge` filters. They ship with a
+reference example ([examples/org-federation/](./examples/org-federation/)) and an end-to-end
+walkthrough ([guides/enterprise-discovery-with-org-federation.md](./guides/enterprise-discovery-with-org-federation.md)).
+
+The open questions below (normative `context`/`credential_hint` vocabularies; Org-Hub-as-Level-4
+conformance) were resolved conservatively: both vocabularies ship **non-normative** and extensible,
+and no new conformance level is introduced — parse-and-expose is Level 1, consistent with the
+advisory posture of the fields.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knowledge Context Protocol (KCP) Specification
 
-**Version:** 0.23
+**Version:** 0.24
 **Status:** Draft
 **Date:** 2026-06-12
 **Repository:** github.com/cantara/knowledge-context-protocol
@@ -727,6 +727,8 @@ manifests:
 | `version_pin` | OPTIONAL | string | Semver version to pin this sub-manifest to. When present, validators SHOULD compare against the remote manifest's `version` field. See version pinning below. |
 | `version_policy` | OPTIONAL | string | How to interpret `version_pin`. Values: `exact` (versions must be equal), `minimum` (remote version >= pin), `compatible` (same major version, default). Unknown values MUST be treated as `compatible`. |
 | `temporal` | OPTIONAL | object | Source-level validity window. See `manifests[].temporal` below (v0.21). |
+| `context` | OPTIONAL | array | Environment labels for which this sub-manifest reference is valid. See `manifests[].context` below (v0.24). |
+| `agent_identity` | OPTIONAL | object | Pre-fetch credential-planning hint. See `manifests[].agent_identity` below (v0.24). |
 
 #### `manifests[].relationship` values
 
@@ -804,6 +806,93 @@ own root-level `temporal.recorded_at` already covers when the hub recorded its f
 
 **Conformance:** Parse and expose `manifests[].temporal` and detect `superseded_by` cycles —
 Level 1. Manifest-level temporal filtering at resolution time — Level 2 (C18).
+
+#### `manifests[].context` (v0.24)
+
+Promoted from [RFC-0011](./RFC-0011-Org-Federation.md). An OPTIONAL `context` list declares the
+runtime environments for which a `manifests[]` entry is valid. It lets a hub publish one
+federation list that spans environments — the same service's `dev`, `staging`, and `prod`
+manifests appear as sibling entries, and a traversing agent selects only the entries matching
+its own environment without fetching all of them and reconciling.
+
+```yaml
+manifests:
+  - id: payments-prod
+    url: "https://git.example.com/payments/knowledge.yaml"
+    relationship: child
+    context: ["prod"]
+  - id: payments-dev
+    url: "https://git.example.com/payments/knowledge-dev.yaml"
+    relationship: child
+    context: ["dev", "test"]
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `context` | OPTIONAL | array of string | Environment labels for which this entry is valid. Absent = valid in **all** environments. |
+
+**Vocabulary (non-normative):** `dev`, `test`, `staging`, `prod`. Implementations MAY extend this
+set with their own labels; unknown labels MUST NOT be treated as errors.
+
+**Resolution behaviour:** `context` is an **advisory selection hint**, not an access control. An
+agent operating in a known environment SHOULD select only the entries whose `context` list
+contains its environment (an entry with no `context` always qualifies). KCP does not enforce the
+selection; an agent with no environment notion MAY traverse every entry. This mirrors the
+advisory posture of `rate_limits` (§4.15) and `update_frequency`.
+
+**Validation:** `context` present but empty (`[]`) is a §7 warning — an entry valid in no
+environment is almost certainly a mistake; declare no `context` to mean "all environments".
+
+#### `manifests[].agent_identity` (v0.24)
+
+Promoted from [RFC-0011](./RFC-0011-Org-Federation.md). An OPTIONAL `agent_identity` block is a
+**pre-fetch credential-planning hint**: it tells a traversing agent what credential it will need
+*before* it attempts to load the sub-manifest, so the agent can acquire the credential (or prompt
+its developer to) rather than discovering the requirement only after a failed fetch. It is a
+declaration layer, **not an auth protocol** — the sub-manifest's own `auth` block (§3.3) remains
+the enforcement point.
+
+```yaml
+manifests:
+  - id: platform-engineering
+    url: "https://git.example.com/platform/knowledge.yaml"
+    relationship: foundation
+    context: ["prod"]
+    agent_identity:
+      required: true
+      credential_hint: github_pat
+      docs_url: "https://kcp.example.com/guides/agent-authentication.md"
+  - id: data-warehouse
+    url: "https://git.example.com/data/knowledge.yaml"
+    relationship: peer
+    agent_identity:
+      required: true
+      credential_hint: oauth2
+      issuer_hint: "https://auth.example.com"
+```
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `required` | OPTIONAL | boolean | Whether a credential is expected before fetch. Default `false`. |
+| `credential_hint` | OPTIONAL | string | Advisory credential type. Non-normative vocabulary: `github_pat`, `oauth2`, `confluence_pat`, `api_key`, `none`. Implementations MAY extend. |
+| `issuer_hint` | OPTIONAL | string | For `oauth2`: the issuer URL the agent should use to obtain a token. |
+| `docs_url` | OPTIONAL | string | Where a developer finds instructions for acquiring the credential. |
+
+**Resolution behaviour:** An agent encountering `agent_identity` SHOULD (1) check whether it
+already holds a matching credential, (2) if not and `required` is true, surface `docs_url` and
+pause for acquisition before fetching, (3) if `required` is false, attempt the fetch anyway and
+let the sub-manifest's `auth.methods[]` govern. KCP performs none of these steps itself and never
+dereferences `docs_url` or `issuer_hint` — consistent with the trust model's **KCP declares;
+agents act** principle (§3.2).
+
+**Validation:**
+- `agent_identity.required: true` with no `credential_hint`: §7 warning (the agent is told a
+  credential is needed but not which kind).
+- `issuer_hint` present with `credential_hint` other than `oauth2`: §7 warning (`issuer_hint` is
+  only meaningful for OAuth 2.1).
+
+**Conformance:** Parse and expose `manifests[].context` and `manifests[].agent_identity` —
+Level 1. Both are declaration-level; KCP surfaces them and never acts on them.
 
 #### Transitive resolution
 

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.23.0</version>
+    <version>0.24.0</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.23.0"
+version = "0.24.0"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "MCP bridge for the Knowledge Context Protocol — exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/bridge/typescript/tests/parser.test.ts
+++ b/bridge/typescript/tests/parser.test.ts
@@ -803,3 +803,65 @@ units:
     expect(w.some((x) => x.includes("provides_access_receipts is true but no receipt_format"))).toBe(true);
   });
 });
+
+// v0.24 Org-Federation: manifests[].context + manifests[].agent_identity (RFC-0011).
+describe("v0.24 org-federation manifest fields", () => {
+  const yaml = (require("js-yaml") as typeof import("js-yaml"));
+  const HUB = `
+kcp_version: "0.24"
+project: hub
+version: 1.0.0
+units:
+  - {id: front-door, path: README.md, intent: x, scope: global, audience: [agent]}
+manifests:
+  - id: platform
+    url: "https://git.example.com/platform/knowledge.yaml"
+    relationship: foundation
+    context: ["prod"]
+    agent_identity:
+      required: true
+      credential_hint: github_pat
+      docs_url: "https://kcp.example.com/auth.md"
+  - id: data
+    url: "https://git.example.com/data/knowledge.yaml"
+    relationship: peer
+    agent_identity:
+      required: true
+      credential_hint: oauth2
+      issuer_hint: "https://auth.example.com"
+`;
+
+  it("parses context and agent_identity on manifests[] entries", () => {
+    const m = parseDict(yaml.load(HUB) as Record<string, unknown>);
+    const platform = m.manifests.find((x) => x.id === "platform")!;
+    expect(platform.context).toEqual(["prod"]);
+    expect(platform.agent_identity!.required).toBe(true);
+    expect(platform.agent_identity!.credential_hint).toBe("github_pat");
+    expect(platform.agent_identity!.docs_url).toBe("https://kcp.example.com/auth.md");
+    const data = m.manifests.find((x) => x.id === "data")!;
+    expect(data.agent_identity!.issuer_hint).toBe("https://auth.example.com");
+    expect(data.context).toBeUndefined(); // absent = all environments
+  });
+
+  it("warns on empty context, required-without-hint, and issuer_hint misuse", () => {
+    const bad = parseDict(yaml.load(`
+kcp_version: "0.24"
+project: bad
+version: 1.0.0
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+manifests:
+  - id: a
+    url: "https://git.example.com/a/knowledge.yaml"
+    context: []
+    agent_identity: {required: true}
+  - id: b
+    url: "https://git.example.com/b/knowledge.yaml"
+    agent_identity: {credential_hint: github_pat, issuer_hint: "https://x.example.com"}
+`) as Record<string, unknown>);
+    const w = validate(bad, ".").warnings;
+    expect(w.some((x) => x.includes("context is present but empty"))).toBe(true);
+    expect(w.some((x) => x.includes("required is true but no credential_hint"))).toBe(true);
+    expect(w.some((x) => x.includes("issuer_hint is only meaningful for credential_hint 'oauth2'"))).toBe(true);
+  });
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.23.0
+    `\nKCP Developer CLI — v0.24.0
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.test.ts
+++ b/cli/src/render.test.ts
@@ -453,6 +453,35 @@ trust:
     // content_integrity-style trust internals are never re-emitted
     expect(doc.trust.tier).toBe("unsigned");
   });
+
+  it("surfaces manifests[].context and agent_identity, never dereferencing them (§7, v0.24)", () => {
+    const manifestPath = writeManifest(`project: hub
+version: 1.0.0
+units:
+  - id: front-door
+    path: README.md
+    intent: "front door"
+    scope: global
+    audience: [agent]
+manifests:
+  - id: platform
+    url: https://git.example.com/platform/knowledge.yaml
+    relationship: foundation
+    context: ["prod"]
+    agent_identity:
+      required: true
+      credential_hint: github_pat
+      docs_url: https://kcp.example.com/auth.md
+`);
+    const { doc } = renderOk(manifestPath);
+    const edge = doc.federation[0];
+    expect(edge.context).toEqual(["prod"]);
+    expect(edge.agent_identity.required).toBe(true);
+    expect(edge.agent_identity.credential_hint).toBe("github_pat");
+    expect(edge.agent_identity.docs_url).toBe("https://kcp.example.com/auth.md");
+    // still just data: trust is never inherited across the edge (C5)
+    expect(edge.target_tier).toBe("unrendered");
+  });
 });
 
 describe("origin derivation (§4.1)", () => {

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.23.0";
+export const RENDERER_VERSION = "kcp-cli 0.24.0";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.23.0 (all three bridges — aligned with KCP spec version)
+**Current version:** 0.24.0 (all three bridges — aligned with KCP spec version)
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -109,6 +109,7 @@ No known gaps — all three bridges are at full parity.
 | 0.21.1 | 2026-06-13 | C18 hardening (issue #98): federated temporal filtering now enforced on **every** retrieval path (`get_unit`, `read_resource`, `list_resources`), not just `search_knowledge`; effective date pinned to UTC; supersession-aware exclusion (`superseded_by` + active successor → drop); `as_of` ISO-8601 validation; `local_mirror` association canonicalised (symlink-safe) with a warning on no match; `include_all_temporal` results carry a `caution`; `list_manifests` gains optional `as_of`. All three bridges. |
 | 0.22.0 | 2026-07-04 | Trust & Attestation (RFC-0004/0002): `trust.agent_requirements` + extended `auth.methods` types (`bearer_token`, `spiffe`, `did`, `http_signature`) parsed/exposed; C20 attestation gating — restricted-unit content refused unless an `attestation` argument is presented, on every retrieval path; `search` marks `requires_attestation`; new `attestation` argument on `get_unit` + `search_knowledge`. Bridge never calls `attestation_url`. All three bridges. |
 | 0.23.0 | 2026-07-04 | Trust & Auth Completion (RFC-0002/0004): parsers expose per-unit `auth` override, `trust.provenance.publisher_did`, `trust.audit.provides_access_receipts`/`receipt_format`, and `require_delegation_proof` (closed a spec-vs-parser drift). Validators warn on non-DID `publisher_did` and receipts-without-format. Declaration-level — no new MCP tool behaviour. All four implementations. |
+| 0.24.0 | 2026-07-04 | Org-Federation (RFC-0011): parsers expose `manifests[].context` (environment-aware references) and `manifests[].agent_identity` (pre-fetch credential hint) — surfaced by the `kcp render` pipeline. Validators warn on empty `context`, `agent_identity.required` without `credential_hint`, and `issuer_hint` used off `oauth2`. Declaration-level and advisory — no new MCP tool behaviour. All four implementations. |
 
 > **Note:** v0.7.0--v0.9.0 were internal development milestones that shipped combined as v0.10.0.
 > v0.11.0--v0.13.0 were bridge feature additions that culminated in v0.14.0.

--- a/docs/index.html
+++ b/docs/index.html
@@ -2170,7 +2170,7 @@ relationships:
       <div class="section-header reveal">
         <span class="section-label">Roadmap</span>
         <h2>Where KCP is headed</h2>
-        <p>v0.21 is the current release. Fields are promoted from RFC proposals to core as they accumulate real-world validation. Remaining RFCs are open for community feedback through 2026.</p>
+        <p>v0.24 is the current release. Fields are promoted from RFC proposals to core as they accumulate real-world validation. Remaining RFCs are open for community feedback through 2026.</p>
       </div>
 
       <div class="roadmap-core reveal">
@@ -2435,7 +2435,7 @@ relationships:
 
       <div class="roadmap-core reveal">
         <div class="roadmap-core__info">
-          <span class="roadmap-core__badge">v0.23 — Current</span>
+          <span class="roadmap-core__badge">v0.23 — Shipped</span>
           <h3>Trust &amp; Auth Completion</h3>
           <p>Finishes the trust/auth surface: a per-unit <code>auth</code> override (multi-tenant sources), <code>trust.provenance.publisher_did</code> (a resolvable W3C DID for the publisher), <code>trust.audit.provides_access_receipts</code> / <code>receipt_format</code>, and <code>require_delegation_proof</code>. Declaration-level — no new gating. The pass also reconciled the RFCs with the spec, correcting stale &ldquo;not yet promoted&rdquo; notes for per-unit <code>delegation</code> and <code>compliance</code>. Promoted from RFC-0002 and RFC-0004.</p>
         </div>
@@ -2444,6 +2444,20 @@ relationships:
           <span class="roadmap-field-pill">per-unit auth</span>
           <span class="roadmap-field-pill">access receipts</span>
           <span class="roadmap-field-pill">RFC-0002</span>
+        </div>
+      </div>
+
+      <div class="roadmap-core reveal">
+        <div class="roadmap-core__info">
+          <span class="roadmap-core__badge">v0.24 — Current</span>
+          <h3>Org-Federation</h3>
+          <p>Answers the enterprise bootstrap — how an agent that knows only a company domain finds its first manifest, gets through the door, and learns what else exists. Two fields join the §3.6 federation graph: <code>manifests[].context</code> tags each sub-manifest reference with the environment(s) it is valid for (<code>dev</code>/<code>test</code>/<code>staging</code>/<code>prod</code>), and <code>manifests[].agent_identity</code> is a pre-fetch credential hint so an agent acquires the right token <em>before</em> it fetches. Advisory declarations — the hub declares; the agent acts. The Org Hub and progressive-disclosure patterns ship as usage conventions. Promoted from RFC-0011.</p>
+        </div>
+        <div class="roadmap-core__fields">
+          <span class="roadmap-field-pill">context</span>
+          <span class="roadmap-field-pill">agent_identity</span>
+          <span class="roadmap-field-pill">org hub</span>
+          <span class="roadmap-field-pill">RFC-0011</span>
         </div>
       </div>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -125,6 +125,26 @@ Validates clean: `kcp validate examples/attestation/knowledge.yaml`.
 
 ---
 
+## [org-federation/](./org-federation/)
+
+**Enterprise discovery. Hub manifest, environment-aware refs, pre-fetch credential hints (v0.24).**
+
+The front door an agent reaches knowing only a company domain — how it discovers what exists, learns
+how to authenticate, and selects the right sub-manifest for its environment (RFC-0011, SPEC §3.6):
+- `manifests[].context` — environment labels (`dev`/`test`/`staging`/`prod`) so one hub spans
+  environments and an agent takes only its slice
+- `manifests[].agent_identity` — pre-fetch credential hint (`credential_hint`, `issuer_hint`,
+  `docs_url`) so the agent acquires what it needs before fetching, not after a failed attempt
+- Org Hub (`network.role: hub` + public front door) and progressive disclosure (`public` →
+  `internal` → `confidential` sensitivity tiers) as usage conventions — no new spec fields
+- **The hub declares; the agent acts** — the renderer surfaces `context`/`agent_identity` and never
+  dereferences `docs_url`; the sub-manifest's own `auth` block enforces
+
+Walkthrough: [guides/enterprise-discovery-with-org-federation.md](../guides/enterprise-discovery-with-org-federation.md).
+Validates clean: `kcp validate examples/org-federation/knowledge.yaml`.
+
+---
+
 ## [trusted-render-demo/](./trusted-render-demo/)
 
 **Interactive walk-through of the trusted render pipeline (RFC-0018/0019/0022, SPEC §16).**

--- a/examples/org-federation/README.md
+++ b/examples/org-federation/README.md
@@ -1,0 +1,39 @@
+# Org-federation example (v0.24)
+
+An enterprise **knowledge hub** — the front door an AI agent reaches when it knows only a company
+domain name. It shows how the two RFC-0011 fields promoted in v0.24 solve the enterprise-bootstrap
+problem (SPEC §3.6):
+
+- **`manifests[].context`** — environment labels (`dev`/`test`/`staging`/`prod`) on each federation
+  edge, so one hub can publish a federation list spanning environments and an agent selects only
+  the entries matching its runtime.
+- **`manifests[].agent_identity`** — a pre-fetch credential-planning hint (`required`,
+  `credential_hint`, `issuer_hint`, `docs_url`) telling the agent what to acquire *before* it
+  fetches a sub-manifest.
+
+It also demonstrates two **usage-convention** patterns that need no new spec fields:
+
+- **Org Hub** — `network.role: hub`, a public load-eager `front-door` unit, and a `manifests[]`
+  block listing sub-manifests.
+- **Progressive disclosure** — three `compliance.sensitivity` tiers: `public` (`overview`,
+  `auth-guide`) → `internal` (`service-catalogue`) → `confidential` (`data-contracts`).
+
+The load-bearing idea, as everywhere in KCP: **the hub declares; the agent (or its runtime) acts.**
+`context` and `agent_identity` are advisory — the renderer surfaces them and never dereferences
+`docs_url` or `issuer_hint`, and the sub-manifest's own `auth` block remains the enforcement point.
+
+```bash
+kcp validate examples/org-federation/knowledge.yaml   # ✓ Valid
+kcp render   examples/org-federation/knowledge.yaml   # surfaces context + agent_identity per edge
+```
+
+## Files
+
+- [`knowledge.yaml`](./knowledge.yaml) — the hub manifest (4 units, 3 federated sub-manifests).
+- [`overview.md`](./overview.md) — the public front-door unit an unauthenticated agent loads first.
+- [`guides/agent-authentication.md`](./guides/agent-authentication.md) — how a developer obtains the
+  credentials the federation edges declare.
+- [`catalogue/services.md`](./catalogue/services.md) — the internal (T1) service index.
+- [`catalogue/data-contracts.md`](./catalogue/data-contracts.md) — the confidential (T2) data contracts.
+
+Full walkthrough: [guides/enterprise-discovery-with-org-federation.md](../../guides/enterprise-discovery-with-org-federation.md).

--- a/examples/org-federation/catalogue/data-contracts.md
+++ b/examples/org-federation/catalogue/data-contracts.md
@@ -1,0 +1,20 @@
+# Production data contracts (confidential)
+
+> `sensitivity: confidential`, `access: restricted`, `auth_scope: read:data-contracts` — served
+> only after role-specific authorisation. This is the tightest tier of the progressive-disclosure
+> ladder.
+
+Data contracts declare, per regulated dataset, where the data may be processed and what may not
+touch it. They are the "do not let an external LLM near this" layer of the enterprise.
+
+## Example contract — customer PII
+
+- **Residency:** EU only (`eu-west-1`, `eu-central-1`). No replication outside the EEA.
+- **Regulations:** GDPR, ePrivacy.
+- **Restrictions:** `no_ai_training`, `no_external_processing`.
+- **Access:** requires the `read:data-contracts` scope AND a human-approved role grant.
+
+An agent that reaches this unit has passed every tier: it loaded the public front door, authenticated
+for the internal catalogue, and obtained role approval for the confidential contracts. Each step was
+declared in advance — by `compliance.sensitivity` on the units and `agent_identity` on the
+federation edges — so the agent never had to probe blindly.

--- a/examples/org-federation/catalogue/services.md
+++ b/examples/org-federation/catalogue/services.md
@@ -1,0 +1,19 @@
+# CompanyX service catalogue (internal)
+
+> `sensitivity: internal` — visible to authenticated developers. If you are reading this, you have
+> already authenticated against the hub's OAuth 2.1 issuer.
+
+Each service publishes its own KCP manifest. The hub's `manifests[]` block federates the ones an
+agent commonly needs; this catalogue is the fuller index.
+
+| Service | Manifest | Environments | Credential |
+|---------|----------|--------------|------------|
+| Platform Engineering | `platform/knowledge.yaml` | prod | `github_pat` |
+| Platform Engineering (dev) | `platform/knowledge-dev.yaml` | dev, test | none |
+| Data Warehouse | `data/knowledge.yaml` | prod, staging | `oauth2` |
+| Payments | `payments/knowledge.yaml` | prod | `oauth2` |
+| Identity | `identity/knowledge.yaml` | prod, staging | `oauth2` |
+
+To traverse to any of these, read its `agent_identity` hint on the federation entry, acquire the
+credential per the [authentication guide](../guides/agent-authentication.md), and match your
+runtime `context` to the entry's `context` list.

--- a/examples/org-federation/guides/agent-authentication.md
+++ b/examples/org-federation/guides/agent-authentication.md
@@ -1,0 +1,31 @@
+# Agent authentication at CompanyX
+
+Our sub-manifests declare, up front, what credential an agent needs before fetching them. This
+guide explains how a developer running an agent obtains each one. You never need to guess: read
+the `agent_identity.credential_hint` on a federation entry, then follow the matching section here.
+
+## `github_pat` — Platform Engineering (prod)
+
+The production Platform Engineering hub is behind our internal GitHub. Create a fine-grained
+Personal Access Token scoped to read the `platform/knowledge` repository, then hand it to your
+agent as its Git credential. The federation entry sets `required: true`, so acquire it **before**
+attempting the fetch.
+
+## `oauth2` — Data Warehouse (prod, staging)
+
+The Data Warehouse uses OAuth 2.1. The federation entry carries an `issuer_hint`
+(`https://auth.companyx.example`) — begin the authorization-code flow against that issuer, request
+the `read:catalogue` scope, and present the resulting bearer token. This is the same issuer the
+hub's own `auth.methods` names, so a token obtained here also unlocks the hub's internal tier.
+
+## No credential — Dev mirror
+
+The dev mirror of Platform Engineering (`context: ["dev", "test"]`) sets
+`agent_identity.required: false`. An agent running in a dev or test environment can fetch it
+directly; its own `auth` block still governs anything sensitive inside.
+
+## The rule of thumb
+
+`agent_identity` tells you what to bring. The sub-manifest's `auth` block checks it at the door.
+KCP never performs either step for you — it only makes the requirement legible ahead of time so
+your agent can plan instead of failing a fetch and backtracking.

--- a/examples/org-federation/knowledge.yaml
+++ b/examples/org-federation/knowledge.yaml
@@ -1,0 +1,129 @@
+kcp_version: "0.24"
+project: companyx-knowledge-hub
+version: 1.0.0
+updated: "2026-07-04"
+language: en
+
+# Org-Federation (RFC-0011, v0.24). This manifest is an enterprise "front door": a hub that an
+# unauthenticated agent can load cold, discover what exists, learn how to authenticate, and then
+# traverse to the right sub-manifest for its environment. Two new manifests[] fields carry the
+# weight:
+#   - context:        which runtime environment each sub-manifest reference is valid for
+#   - agent_identity: what credential the agent needs BEFORE it tries to fetch that sub-manifest
+# Both are advisory declarations. KCP surfaces them; the agent (or its runtime) acts on them.
+
+# The Org Hub pattern is a topology declaration — this manifest is the network's landing page.
+network:
+  role: hub
+  entry_point: "https://kcp.companyx.example/knowledge.yaml"
+  registry_label: "CompanyX Knowledge Network"
+
+trust:
+  provenance:
+    publisher: "CompanyX Platform Team"
+    publisher_url: "https://companyx.example"
+    publisher_did: "did:web:companyx.example"
+
+# The hub itself is loadable unauthenticated (the public tier), but its internal and
+# confidential units require a developer credential. OAuth 2.1 is the enforcement point;
+# the public tier is served under the `none` fallback.
+auth:
+  methods:
+    - type: oauth2
+      issuer: "https://auth.companyx.example"
+      scopes: ["read:catalogue", "read:data-contracts"]
+    - type: none
+
+# ---------------------------------------------------------------------------
+# Progressive disclosure (usage convention): three sensitivity tiers.
+#   public       — served to anyone, load-eager, the cold-start surface.
+#   internal     — authenticated developers only.
+#   confidential — role-specific approval.
+# No new spec fields — this layers on compliance.sensitivity (§3.5).
+# ---------------------------------------------------------------------------
+units:
+  # T0 — public front door. An unauthenticated agent loads this first.
+  - id: front-door
+    path: overview.md
+    intent: "What is CompanyX, what services exist, and how does an agent get started?"
+    scope: global
+    audience: [agent, human, developer]
+    triggers: [overview, getting started, what services exist]
+    hints:
+      load_strategy: eager
+      token_estimate: 800
+    compliance:
+      sensitivity: public
+
+  # T0 — public auth guide. Tells a developer how to obtain the credentials the
+  # sub-manifests below declare via agent_identity.
+  - id: auth-guide
+    path: guides/agent-authentication.md
+    intent: "How does an agent authenticate on behalf of a developer? GitHub PAT and OAuth 2.1 flows."
+    scope: global
+    audience: [agent, developer]
+    triggers: [authentication, credentials, github pat, oauth]
+    compliance:
+      sensitivity: public
+
+  # T1 — internal service catalogue. Visible to authenticated developers.
+  - id: service-catalogue
+    path: catalogue/services.md
+    intent: "The internal catalogue of CompanyX services and their knowledge manifests."
+    scope: global
+    audience: [agent, developer]
+    triggers: [catalogue, services, api surface]
+    access: authenticated
+    compliance:
+      sensitivity: internal
+
+  # T2 — confidential. Role-specific approval; served only after full authorisation.
+  - id: data-contracts
+    path: catalogue/data-contracts.md
+    intent: "Production data-residency and sensitivity contracts for regulated services."
+    scope: global
+    audience: [agent]
+    triggers: [data contract, residency, compliance mapping]
+    access: restricted
+    auth_scope: "read:data-contracts"
+    compliance:
+      sensitivity: confidential
+
+# ---------------------------------------------------------------------------
+# Federation: the sub-manifests this hub points to. Each entry declares the
+# environment(s) it is valid for (context) and the credential an agent should
+# acquire before fetching it (agent_identity).
+# ---------------------------------------------------------------------------
+manifests:
+  # Production platform hub — needs a GitHub PAT. An agent in prod selects this.
+  - id: platform-engineering
+    url: "https://git.companyx.example/platform/knowledge.yaml"
+    label: "Platform Engineering Hub"
+    relationship: foundation
+    context: ["prod"]
+    agent_identity:
+      required: true
+      credential_hint: github_pat
+      docs_url: "https://kcp.companyx.example/guides/agent-authentication.md"
+
+  # Data warehouse — OAuth 2.1 with a named issuer. Valid in prod and staging.
+  - id: data-warehouse
+    url: "https://git.companyx.example/data/knowledge.yaml"
+    label: "Data Warehouse"
+    relationship: peer
+    context: ["prod", "staging"]
+    agent_identity:
+      required: true
+      credential_hint: oauth2
+      issuer_hint: "https://auth.companyx.example"
+      docs_url: "https://kcp.companyx.example/guides/agent-authentication.md"
+
+  # Dev mirror of platform engineering — no credential required. An agent in dev
+  # selects this instead of the prod entry above and can fetch it directly.
+  - id: platform-engineering-dev
+    url: "https://git.companyx.example/platform/knowledge-dev.yaml"
+    label: "Platform Engineering — Dev"
+    relationship: peer
+    context: ["dev", "test"]
+    agent_identity:
+      required: false

--- a/examples/org-federation/overview.md
+++ b/examples/org-federation/overview.md
@@ -1,0 +1,28 @@
+# CompanyX Knowledge Network — front door
+
+Welcome. This is the public landing page for CompanyX's knowledge network. An AI agent that
+arrives here with nothing but our domain name can read this file, learn what exists, and find out
+how to get the credentials it needs to go further.
+
+## What CompanyX runs
+
+- **Platform Engineering** — CI/CD, service scaffolding, deployment runbooks.
+- **Data Warehouse** — analytics datasets, data contracts, lineage.
+- Plus a dozen product services, each with its own KCP manifest, catalogued once you authenticate.
+
+## How an agent gets started
+
+1. **Load this file.** It is `sensitivity: public` and `load_strategy: eager` — safe to read
+   before you authenticate.
+2. **Read the [authentication guide](guides/agent-authentication.md).** It explains the two
+   credential types our sub-manifests ask for: a GitHub PAT and an OAuth 2.1 token.
+3. **Pick your environment.** The federation entries in `knowledge.yaml` are tagged with
+   `context` (`dev`, `test`, `staging`, `prod`). Fetch only the ones that match where you are
+   running.
+4. **Acquire the declared credential.** Each federation entry declares an `agent_identity` hint
+   telling you what it needs *before* you fetch it. Get that credential, then traverse.
+5. **Ask for more.** After authenticating, request the internal `service-catalogue` unit for the
+   full list of services.
+
+Nothing here is enforced by KCP — these are declarations. Enforcement happens when you actually
+present your credential to a sub-manifest's `auth` endpoint.

--- a/guides/enterprise-discovery-with-org-federation.md
+++ b/guides/enterprise-discovery-with-org-federation.md
@@ -1,0 +1,138 @@
+# Tutorial: Enterprise discovery with org-federation
+
+**Level:** intermediate · **Spec:** SPEC.md §3.6 (v0.24) · **RFC:** [RFC-0011](../RFC-0011-Org-Federation.md)
+· **Example:** [examples/org-federation/](../examples/org-federation/)
+
+An agent arrives at a large company knowing only the domain name. How does it find its first
+manifest, get through the door, and progressively learn what else exists? That is the
+**enterprise bootstrap** problem, and RFC-0011 answers it with a hub manifest plus two small
+declarations on each federation edge:
+
+- **`context`** — which runtime environment(s) a sub-manifest reference is valid for.
+- **`agent_identity`** — what credential the agent needs *before* it tries to fetch that
+  sub-manifest.
+
+Neither is enforcement. They are declarations that let an agent *plan* instead of probing blindly
+and backtracking on failed fetches. This tutorial walks the full path against the reference hub.
+
+## 1. The hub manifest — a front door
+
+Open [`examples/org-federation/knowledge.yaml`](../examples/org-federation/knowledge.yaml). Three
+things make it a hub:
+
+```yaml
+network:
+  role: hub
+  entry_point: "https://kcp.companyx.example/knowledge.yaml"
+
+units:
+  - id: front-door           # public, load-eager — the cold-start surface
+    compliance: { sensitivity: public }
+    hints: { load_strategy: eager }
+
+manifests:
+  - id: platform-engineering
+    url: "https://git.companyx.example/platform/knowledge.yaml"
+    context: ["prod"]
+    agent_identity:
+      required: true
+      credential_hint: github_pat
+      docs_url: "https://kcp.companyx.example/guides/agent-authentication.md"
+```
+
+An unauthenticated agent can load the `front-door` unit immediately — it is `sensitivity: public`.
+From there it reads the auth guide, then decides which federation edges to follow.
+
+Validate it:
+
+```bash
+kcp validate examples/org-federation/knowledge.yaml
+# ✓ Valid — no errors or warnings
+```
+
+## 2. Environment selection with `context`
+
+The hub lists three platform entries — one `prod`, one `prod`+`staging`, one `dev`+`test`:
+
+```yaml
+manifests:
+  - id: platform-engineering        # context: ["prod"]
+  - id: data-warehouse              # context: ["prod", "staging"]
+  - id: platform-engineering-dev    # context: ["dev", "test"]
+```
+
+An agent running in `prod` selects `platform-engineering` and `data-warehouse` and **ignores**
+the dev mirror. An agent in `dev` selects only `platform-engineering-dev`. No fetching all three
+and reconciling — the hub author published one federation list that spans environments, and each
+agent takes its slice. An entry with no `context` is valid everywhere.
+
+`context` is an advisory selection hint. KCP does not enforce it; an agent with no environment
+notion may traverse every entry.
+
+## 3. Credential planning with `agent_identity`
+
+Before fetching a sub-manifest, the agent reads its `agent_identity` hint:
+
+- `platform-engineering` wants a `github_pat` (`required: true`) — acquire it first.
+- `data-warehouse` wants `oauth2` and even names the issuer (`issuer_hint`) — run the
+  authorization-code flow against that issuer before fetching.
+- `platform-engineering-dev` sets `required: false` — fetch it directly; its own `auth` block
+  still governs anything sensitive inside.
+
+The agent surfaces `docs_url` to its developer for anything it cannot obtain on its own, pauses for
+the credential, then traverses. The sub-manifest's own `auth` block (§3.3) is the enforcement
+point — `agent_identity` only tells the agent what to bring.
+
+## 4. Render it — the hints are surfaced, never acted on
+
+```bash
+kcp render examples/org-federation/knowledge.yaml
+```
+
+The federation block comes through as pure data:
+
+```yaml
+federation:
+  - id: platform-engineering
+    url: https://git.companyx.example/platform/knowledge.yaml
+    relationship: foundation
+    context: [prod]
+    agent_identity:
+      required: true
+      credential_hint: github_pat
+      docs_url: https://kcp.companyx.example/guides/agent-authentication.md
+    target_tier: unrendered          # trust is never inherited across the edge (C5)
+```
+
+The renderer copies `context` and `agent_identity` verbatim and **never dereferences** `docs_url`
+or `issuer_hint` — deterministic and network-free, exactly like `attestation_url` in v0.22. A
+manifest may influence what an agent knows, never what it does.
+
+## 5. Progressive disclosure — the sensitivity ladder
+
+The hub's units climb three tiers with no new spec fields, layering on `compliance.sensitivity`:
+
+| Tier | `sensitivity` | Unit | Who sees it |
+|------|---------------|------|-------------|
+| T0 | `public` | `front-door`, `auth-guide` | anyone, unauthenticated |
+| T1 | `internal` | `service-catalogue` | authenticated developer |
+| T2 | `confidential` | `data-contracts` | role-specific approval |
+
+An agent loads T0 cold, authenticates (guided by `agent_identity` and the auth guide), reads the
+T1 catalogue, and only reaches the T2 data contracts after full authorisation. Every step was
+declared in advance, so the agent plans the climb rather than discovering each gate by hitting it.
+
+## Where this sits
+
+RFC-0011 is the **topology and discovery** layer: how an agent finds and selects manifests across
+an organisation. RFC-0009 `visibility.conditions[]` is the **access control** layer for individual
+units. Together they answer the full enterprise-bootstrap scenario. Both `context` and
+`agent_identity` are declaration-level and advisory — KCP surfaces them; the agent (or its runtime
+enforcement system) acts.
+
+## See also
+
+- [SPEC.md §3.6](../SPEC.md) — `manifests[].context` and `manifests[].agent_identity` field reference
+- [RFC-0011](../RFC-0011-Org-Federation.md) — the full design rationale and the Org Hub / progressive-disclosure patterns
+- [examples/org-federation/](../examples/org-federation/) — the runnable hub used above
+- [guides/gating-restricted-knowledge-with-attestation.md](./gating-restricted-knowledge-with-attestation.md) — the consumer-identity companion (v0.22)

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -14,6 +14,7 @@ import no.cantara.kcp.model.ExternalRelationship;
 import no.cantara.kcp.model.HumanInTheLoop;
 import no.cantara.kcp.model.KnowledgeManifest;
 import no.cantara.kcp.model.KnowledgeUnit;
+import no.cantara.kcp.model.AgentIdentity;
 import no.cantara.kcp.model.ManifestRef;
 import no.cantara.kcp.model.RateLimit;
 import no.cantara.kcp.model.RateLimits;
@@ -305,7 +306,19 @@ public class KcpParser {
                 (String) m.get("local_mirror"),
                 (String) m.get("version_pin"),
                 (String) m.get("version_policy"),
-                parseTemporal((Map<String, Object>) m.get("temporal"))
+                parseTemporal((Map<String, Object>) m.get("temporal")),
+                asStringList(m.get("context")),
+                parseAgentIdentity((Map<String, Object>) m.get("agent_identity"))
+        );
+    }
+
+    private static AgentIdentity parseAgentIdentity(Map<String, Object> a) {
+        if (a == null) return null;
+        return new AgentIdentity(
+                (Boolean) a.get("required"),
+                (String) a.get("credential_hint"),
+                (String) a.get("issuer_hint"),
+                (String) a.get("docs_url")
         );
     }
 

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -10,6 +10,7 @@ import no.cantara.kcp.model.ExternalRelationship;
 import no.cantara.kcp.model.HumanInTheLoop;
 import no.cantara.kcp.model.KnowledgeManifest;
 import no.cantara.kcp.model.KnowledgeUnit;
+import no.cantara.kcp.model.AgentIdentity;
 import no.cantara.kcp.model.ManifestRef;
 import no.cantara.kcp.model.Relationship;
 import no.cantara.kcp.model.Temporal;
@@ -54,7 +55,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");
@@ -376,6 +377,23 @@ public class KcpValidator {
             }
             if (ref.versionPin() != null && ref.versionPolicy() == null) {
                 warnings.add(p + ": 'version_pin' is set but 'version_policy' is not declared; defaulting to 'compatible'");
+            }
+            // Federation: context and agent_identity (§3.6, RFC-0011, v0.24)
+            if (ref.context() != null && ref.context().isEmpty()) {
+                warnings.add(p + ": context is present but empty; an entry valid in no environment is likely a mistake "
+                        + "(omit context to mean 'all environments')");
+            }
+            if (ref.agentIdentity() != null) {
+                AgentIdentity ai = ref.agentIdentity();
+                if (Boolean.TRUE.equals(ai.required()) && (ai.credentialHint() == null || ai.credentialHint().isBlank())) {
+                    warnings.add(p + ": agent_identity.required is true but no credential_hint is declared "
+                            + "(agents are told a credential is needed but not which kind)");
+                }
+                if (ai.issuerHint() != null && !ai.issuerHint().isBlank()
+                        && ai.credentialHint() != null && !"oauth2".equals(ai.credentialHint())) {
+                    warnings.add(p + ": agent_identity.issuer_hint is only meaningful for credential_hint 'oauth2', "
+                            + "got '" + ai.credentialHint() + "'");
+                }
             }
         }
 

--- a/parsers/java/src/main/java/no/cantara/kcp/model/AgentIdentity.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/AgentIdentity.java
@@ -1,0 +1,12 @@
+package no.cantara.kcp.model;
+
+/**
+ * Pre-fetch credential-planning hint on a manifests[] entry.
+ * A declaration layer, not an auth protocol. See SPEC.md §3.6 (v0.24).
+ */
+public record AgentIdentity(
+        Boolean required,        // default false
+        String credentialHint,   // github_pat | oauth2 | confluence_pat | api_key | none
+        String issuerHint,       // for oauth2: issuer URL
+        String docsUrl           // where a developer finds credential instructions
+) {}

--- a/parsers/java/src/main/java/no/cantara/kcp/model/ManifestRef.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/ManifestRef.java
@@ -14,5 +14,7 @@ public record ManifestRef(
         String localMirror,
         String versionPin,
         String versionPolicy,
-        Temporal temporal
+        Temporal temporal,
+        java.util.List<String> context,      // RFC-0011 / §3.6 (v0.24)
+        AgentIdentity agentIdentity           // RFC-0011 / §3.6 (v0.24)
 ) {}

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpOrgFederationTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpOrgFederationTest.java
@@ -1,0 +1,80 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.KnowledgeManifest;
+import no.cantara.kcp.model.ManifestRef;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** v0.24 Org-Federation: manifests[].context + manifests[].agent_identity (RFC-0011). */
+class KcpOrgFederationTest {
+
+    @SuppressWarnings("unchecked")
+    private static KnowledgeManifest parse(String yaml) {
+        return KcpParser.fromMap((Map<String, Object>) new Yaml().load(yaml));
+    }
+
+    private static ManifestRef ref(KnowledgeManifest m, String id) {
+        return m.manifests().stream().filter(r -> r.id().equals(id)).findFirst().orElseThrow();
+    }
+
+    @Test void parsesContextAndAgentIdentity() {
+        KnowledgeManifest m = parse("""
+            kcp_version: "0.24"
+            project: hub
+            version: 1.0.0
+            units:
+              - {id: front-door, path: README.md, intent: x, scope: global, audience: [agent]}
+            manifests:
+              - id: platform
+                url: "https://git.example.com/platform/knowledge.yaml"
+                relationship: foundation
+                context: ["prod"]
+                agent_identity:
+                  required: true
+                  credential_hint: github_pat
+                  docs_url: "https://kcp.example.com/auth.md"
+              - id: data
+                url: "https://git.example.com/data/knowledge.yaml"
+                relationship: peer
+                agent_identity:
+                  required: true
+                  credential_hint: oauth2
+                  issuer_hint: "https://auth.example.com"
+            """);
+        ManifestRef platform = ref(m, "platform");
+        assertEquals(List.of("prod"), platform.context());
+        assertEquals(Boolean.TRUE, platform.agentIdentity().required());
+        assertEquals("github_pat", platform.agentIdentity().credentialHint());
+        assertEquals("https://kcp.example.com/auth.md", platform.agentIdentity().docsUrl());
+        ManifestRef data = ref(m, "data");
+        assertEquals("https://auth.example.com", data.agentIdentity().issuerHint());
+        assertNull(data.context()); // absent = all environments
+    }
+
+    @Test void warnsEmptyContextAndAgentIdentityMisuse() {
+        KnowledgeManifest m = parse("""
+            kcp_version: "0.24"
+            project: bad
+            version: 1.0.0
+            units:
+              - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+            manifests:
+              - id: a
+                url: "https://git.example.com/a/knowledge.yaml"
+                context: []
+                agent_identity: {required: true}
+              - id: b
+                url: "https://git.example.com/b/knowledge.yaml"
+                agent_identity: {credential_hint: github_pat, issuer_hint: "https://x.example.com"}
+            """);
+        var w = KcpValidator.validate(m).warnings();
+        assertTrue(w.stream().anyMatch(x -> x.contains("context is present but empty")), w.toString());
+        assertTrue(w.stream().anyMatch(x -> x.contains("required is true but no credential_hint")), w.toString());
+        assertTrue(w.stream().anyMatch(x -> x.contains("issuer_hint is only meaningful for credential_hint 'oauth2'")), w.toString());
+    }
+}

--- a/parsers/python/kcp/model.py
+++ b/parsers/python/kcp/model.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 
 @dataclass
@@ -201,6 +201,17 @@ class ManifestRef:
     version_pin: Optional[str] = None
     version_policy: Optional[str] = None  # "exact" | "minimum" | "compatible" (default)
     temporal: Optional["Temporal"] = None  # RFC-0021 / §3.6 (v0.21) — source-level validity window
+    context: Optional[List[str]] = None  # RFC-0011 / §3.6 (v0.24) — environment labels this ref is valid for
+    agent_identity: Optional["AgentIdentity"] = None  # RFC-0011 / §3.6 (v0.24) — pre-fetch credential hint
+
+
+@dataclass
+class AgentIdentity:
+    """Pre-fetch credential-planning hint on a manifests[] entry. See SPEC.md §3.6 (v0.24)."""
+    required: Optional[bool] = None       # default false
+    credential_hint: Optional[str] = None  # github_pat | oauth2 | confluence_pat | api_key | none
+    issuer_hint: Optional[str] = None     # for oauth2: issuer URL
+    docs_url: Optional[str] = None        # where a developer finds credential instructions
 
 
 @dataclass

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -5,8 +5,8 @@ from typing import Optional, Union
 import yaml
 
 from .model import (
-    Auth, AuthMethod, Authority, Compliance, ContentHash, ContentStructure, Delegation,
-    Discovery, ExternalDependency, ExternalRelationship, FreshnessPolicy,
+    AgentIdentity, Auth, AuthMethod, Authority, Compliance, ContentHash, ContentStructure,
+    Delegation, Discovery, ExternalDependency, ExternalRelationship, FreshnessPolicy,
     KnowledgeManifest, KnowledgeUnit, ManifestRef, RateLimit, RateLimits, Relationship,
     Trust, TrustAudit, TrustAgentRequirements, TrustProvenance, Visibility,
 )
@@ -274,6 +274,20 @@ def _parse_manifest_ref(data: dict) -> ManifestRef:
         version_pin=data.get("version_pin"),
         version_policy=data.get("version_policy"),
         temporal=_parse_temporal(data.get("temporal")),
+        context=[str(c) for c in data["context"]] if isinstance(data.get("context"), list) else None,
+        agent_identity=_parse_agent_identity(data.get("agent_identity")),
+    )
+
+
+def _parse_agent_identity(data: Optional[dict]) -> Optional[AgentIdentity]:
+    """Parse a manifests[].agent_identity block (v0.24)."""
+    if not isinstance(data, dict):
+        return None
+    return AgentIdentity(
+        required=data.get("required"),
+        credential_hint=data.get("credential_hint"),
+        issuer_hint=data.get("issuer_hint"),
+        docs_url=data.get("docs_url"),
     )
 
 

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -94,7 +94,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}
@@ -504,6 +504,24 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
             warnings.append(
                 f"{p}: 'version_pin' is set but 'version_policy' is not declared; defaulting to 'compatible'"
             )
+        # Federation: context and agent_identity (§3.6, RFC-0011, v0.24)
+        if ref.context is not None and len(ref.context) == 0:
+            warnings.append(
+                f"{p}: context is present but empty; an entry valid in no environment is likely a mistake "
+                "(omit context to mean 'all environments')"
+            )
+        if ref.agent_identity is not None:
+            ai = ref.agent_identity
+            if ai.required is True and not ai.credential_hint:
+                warnings.append(
+                    f"{p}: agent_identity.required is true but no credential_hint is declared "
+                    "(agents are told a credential is needed but not which kind)"
+                )
+            if ai.issuer_hint and ai.credential_hint is not None and ai.credential_hint != "oauth2":
+                warnings.append(
+                    f"{p}: agent_identity.issuer_hint is only meaningful for credential_hint 'oauth2', "
+                    f"got '{ai.credential_hint}'"
+                )
 
     # Validate external_depends_on references in units
     for unit in manifest.units:

--- a/parsers/python/tests/test_org_federation.py
+++ b/parsers/python/tests/test_org_federation.py
@@ -1,0 +1,62 @@
+"""v0.24 Org-Federation: manifests[].context + manifests[].agent_identity (RFC-0011)."""
+import yaml
+from kcp.parser import parse_dict
+from kcp.validator import validate
+
+HUB = yaml.safe_load("""
+kcp_version: "0.24"
+project: hub
+version: 1.0.0
+units:
+  - {id: front-door, path: README.md, intent: x, scope: global, audience: [agent]}
+manifests:
+  - id: platform
+    url: "https://git.example.com/platform/knowledge.yaml"
+    relationship: foundation
+    context: ["prod"]
+    agent_identity:
+      required: true
+      credential_hint: github_pat
+      docs_url: "https://kcp.example.com/auth.md"
+  - id: data
+    url: "https://git.example.com/data/knowledge.yaml"
+    relationship: peer
+    agent_identity:
+      required: true
+      credential_hint: oauth2
+      issuer_hint: "https://auth.example.com"
+""")
+
+
+def test_parses_context_and_agent_identity():
+    m = parse_dict(HUB)
+    platform = next(r for r in m.manifests if r.id == "platform")
+    assert platform.context == ["prod"]
+    assert platform.agent_identity.required is True
+    assert platform.agent_identity.credential_hint == "github_pat"
+    assert platform.agent_identity.docs_url == "https://kcp.example.com/auth.md"
+    data = next(r for r in m.manifests if r.id == "data")
+    assert data.agent_identity.issuer_hint == "https://auth.example.com"
+    assert data.context is None  # absent = all environments
+
+
+def test_warns_empty_context_and_agent_identity_misuse():
+    m = parse_dict(yaml.safe_load("""
+kcp_version: "0.24"
+project: bad
+version: 1.0.0
+units:
+  - {id: u, path: u.md, intent: x, scope: project, audience: [agent]}
+manifests:
+  - id: a
+    url: "https://git.example.com/a/knowledge.yaml"
+    context: []
+    agent_identity: {required: true}
+  - id: b
+    url: "https://git.example.com/b/knowledge.yaml"
+    agent_identity: {credential_hint: github_pat, issuer_hint: "https://x.example.com"}
+"""))
+    w = validate(m).warnings
+    assert any("context is present but empty" in x for x in w)
+    assert any("required is true but no credential_hint" in x for x in w)
+    assert any("issuer_hint is only meaningful for credential_hint 'oauth2'" in x for x in w)

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "kcp_version": {
       "type": "string",
-      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.23\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.22\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
-      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23"]
+      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.24\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.23\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
+      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24"]
     },
     "project": {
       "type": "string",
@@ -750,6 +750,36 @@
           "description": "How to interpret version_pin. Default: compatible. See SPEC.md §3.6.",
           "enum": ["exact", "minimum", "compatible"],
           "default": "compatible"
+        },
+        "context": {
+          "type": "array",
+          "description": "Environment labels for which this sub-manifest reference is valid (v0.24). Absent = valid in all environments. Non-normative vocabulary: dev, test, staging, prod. Advisory selection hint. See SPEC.md §3.6.",
+          "items": { "type": "string" }
+        },
+        "agent_identity": { "$ref": "#/definitions/agent_identity" }
+      }
+    },
+    "agent_identity": {
+      "type": "object",
+      "description": "Pre-fetch credential-planning hint on a manifests[] entry (v0.24). Declaration layer, not an auth protocol. See SPEC.md §3.6.",
+      "additionalProperties": true,
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Whether a credential is expected before fetching this sub-manifest. Default: false.",
+          "default": false
+        },
+        "credential_hint": {
+          "type": "string",
+          "description": "Advisory credential type. Non-normative vocabulary: github_pat, oauth2, confluence_pat, api_key, none. Implementations MAY extend."
+        },
+        "issuer_hint": {
+          "type": "string",
+          "description": "For oauth2: the issuer URL the agent should use to obtain a token."
+        },
+        "docs_url": {
+          "type": "string",
+          "description": "Where a developer finds instructions for acquiring the credential."
         }
       }
     },

--- a/schema/render-schema.json
+++ b/schema/render-schema.json
@@ -17,7 +17,7 @@
     "fields": ["from", "to", "type"]
   },
   "federation": {
-    "fields": ["id", "url", "relationship"]
+    "fields": ["id", "url", "relationship", "context", "agent_identity"]
   },
   "provenance": {
     "fields": ["publisher", "publisher_url", "contact", "publisher_did"]

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -118,6 +118,14 @@ export interface Relationship {
   type: string;            // "enables" | "context" | "supersedes" | "contradicts" | "depends_on" | "governs"
 }
 
+/** Pre-fetch credential-planning hint on a manifests[] entry. See SPEC.md §3.6 (v0.24). */
+export interface AgentIdentity {
+  required?: boolean;       // default false
+  credential_hint?: string; // github_pat | oauth2 | confluence_pat | api_key | none
+  issuer_hint?: string;     // for oauth2: issuer URL
+  docs_url?: string;        // where a developer finds credential instructions
+}
+
 /** A reference to an external KCP manifest in the federation. See SPEC.md §3.6. */
 export interface ManifestRef {
   id: string;
@@ -130,6 +138,8 @@ export interface ManifestRef {
   version_pin?: string;
   version_policy?: string; // "exact" | "minimum" | "compatible" (default: "compatible")
   temporal?: Temporal;     // RFC-0021 / §3.6 (v0.21) — source-level validity window
+  context?: string[];      // RFC-0011 / §3.6 (v0.24) — environment labels this ref is valid for
+  agent_identity?: AgentIdentity;  // RFC-0011 / §3.6 (v0.24) — pre-fetch credential hint
 }
 
 /** A cross-manifest dependency for a knowledge unit. See SPEC.md §3.6. */

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -19,6 +19,7 @@ import type {
   KnowledgeManifest,
   KnowledgeUnit,
   ManifestRef,
+  AgentIdentity,
   RateLimits,
   Relationship,
   Trust,
@@ -423,6 +424,19 @@ function parseManifestRef(raw: RawMap): ManifestRef {
     version_pin: raw["version_pin"] !== undefined ? String(raw["version_pin"]) : undefined,
     version_policy: raw["version_policy"] !== undefined ? String(raw["version_policy"]) : undefined,
     temporal: parseTemporal(raw["temporal"]),
+    context: Array.isArray(raw["context"]) ? (raw["context"] as unknown[]).map(String) : undefined,
+    agent_identity: parseAgentIdentity(raw["agent_identity"]),
+  };
+}
+
+function parseAgentIdentity(raw: unknown): AgentIdentity | undefined {
+  if (raw === null || typeof raw !== "object") return undefined;
+  const r = raw as RawMap;
+  return {
+    required: r["required"] !== undefined ? Boolean(r["required"]) : undefined,
+    credential_hint: r["credential_hint"] !== undefined ? String(r["credential_hint"]) : undefined,
+    issuer_hint: r["issuer_hint"] !== undefined ? String(r["issuer_hint"]) : undefined,
+    docs_url: r["docs_url"] !== undefined ? String(r["docs_url"]) : undefined,
   };
 }
 

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -101,6 +101,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.21",
   "0.22",
   "0.23",
+  "0.24",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([
@@ -527,6 +528,28 @@ export function validate(
   }
   for (const id of supersededCycleIds(refSuccessor)) {
     errors.push(`manifests[].temporal.superseded_by cycle detected involving '${id}'`);
+  }
+
+  // Federation: manifests[].context and manifests[].agent_identity (§3.6, RFC-0011, v0.24).
+  for (const ref of manifest.manifests) {
+    if (ref.context !== undefined && ref.context.length === 0) {
+      warnings.push(
+        `manifests['${ref.id}']: context is present but empty; an entry valid in no environment is likely a mistake (omit context to mean 'all environments')`
+      );
+    }
+    const ai = ref.agent_identity;
+    if (ai) {
+      if (ai.required === true && !ai.credential_hint) {
+        warnings.push(
+          `manifests['${ref.id}']: agent_identity.required is true but no credential_hint is declared (agents are told a credential is needed but not which kind)`
+        );
+      }
+      if (ai.issuer_hint && ai.credential_hint !== undefined && ai.credential_hint !== "oauth2") {
+        warnings.push(
+          `manifests['${ref.id}']: agent_identity.issuer_hint is only meaningful for credential_hint 'oauth2', got '${ai.credential_hint}'`
+        );
+      }
+    }
   }
 
   // Root-level delegation validation (§3.4)

--- a/skills/kcp-navigate/SKILL.md
+++ b/skills/kcp-navigate/SKILL.md
@@ -41,6 +41,17 @@ something is documented or answer a question about the project.
    `relationships` to expand to neighbours *if* the task needs them — do not
    pull the whole manifest's worth of files.
 
+5. **Traverse federation deliberately.** If the manifest has a `manifests`
+   block (a hub), do not fetch every sub-manifest:
+   - `context` — select only the entries whose environment list matches where
+     you are running (`dev`/`test`/`staging`/`prod`); an entry with no `context`
+     is valid everywhere.
+   - `agent_identity` — read this *before* fetching. It declares the credential
+     the sub-manifest expects (`credential_hint`, `issuer_hint`, `docs_url`).
+     If `required: true`, acquire the credential (or surface `docs_url` to the
+     user) first, rather than fetching blind and failing. It is a planning
+     hint, not enforcement — the sub-manifest's own `auth` block is the gate.
+
 ## Trust note
 
 If the `knowledge.yaml` comes from a repository you do not control or an


### PR DESCRIPTION
## v0.24 — Org-Federation (RFC-0011)

*(Rebased onto main after #110 landed v0.23 — this PR now carries only the v0.24 work: 2 commits, no v0.23 duplication.)*

Answers the enterprise-bootstrap question — how an agent that knows only a company domain finds its first manifest, gets through the door, and progressively learns what else exists. Two concrete fields promote to the §3.6 federation core; the rest ships as usage conventions. Declaration-level and advisory — **the hub declares; the agent acts** — with **no new conformance rules**.

### Promoted fields (SPEC §3.6)

- **`manifests[].context: string[]`** — environment labels (`dev`/`test`/`staging`/`prod`, non-normative) for which a sub-manifest reference is valid. Absent = all environments.
- **`manifests[].agent_identity`** — pre-fetch credential-planning hint (`required`, `credential_hint`, `issuer_hint`, `docs_url`). Not an auth protocol — the sub-manifest's own `auth` block remains the enforcement point.

The **Org Hub** (`network.role: hub` + public front door) and **progressive disclosure** (`public` → `internal` → `confidential`) patterns add no new spec fields.

### Coverage

- Spec/schema: SPEC §3.6 + version → `0.24`; knowledge-schema + render-schema; RFC-0011 marked **Accepted**
- Parsers: TypeScript shared core, Python, Java, and `kcp render` — parse and expose both fields; renderer never dereferences `docs_url`/`issuer_hint`
- Validators: warnings for empty `context`, `required` without `credential_hint`, `issuer_hint` off `oauth2`; `KNOWN_KCP_VERSIONS` += `0.24` in all four
- Example + tutorial: `examples/org-federation/` + `guides/enterprise-discovery-with-org-federation.md`

### Verified locally after rebase

- TypeScript: 103 tests passed
- Python: 167 tests passed
- Java: build + tests green
- `kcp validate examples/org-federation/knowledge.yaml` — valid, no warnings