### PR TITLE
spec: access = auth axis only (#115); inclusive temporal bounds + supersession (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Clarified (kcp-agent interop, #114/#115)
+
+- **§4.11 `access` declares the authentication gate only** — payment requirements are never
+  expressed through `access`. An anonymous pay-per-request unit is `access: public` with a
+  `payment` block (the RFC-0005 `none | x402` anonymous-micropayment cell), not
+  `access: restricted`. Mirrored in the §4.14 auth-relationship paragraph. (#115)
+- **§4.22 temporal boundaries are inclusive** — a unit is active for `valid_from <= d <=
+  valid_until`, codifying what the query-time filter already encoded. Overlapping validity
+  windows during transitions are resolved by supersession: a unit whose `superseded_by`
+  successor is itself selectable SHOULD NOT be selected. (#114)
+
+### Validators (all four)
+
+- New §7 warning: units with `access: authenticated`/`restricted` in a manifest whose `auth`
+  block declares only method `none` — no credential can satisfy the gate; the pattern a
+  payment-as-access confusion produces. TypeScript (shared core, CLI + bridge), Python, Java.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1824,6 +1824,16 @@ no enforcement layer exists at the transport or storage level. See §14.1.
 
 Unknown `access` values MUST be silently ignored by parsers.
 
+**`access` declares the authentication gate only.** It answers *who may fetch this unit* —
+never *what fetching costs*. Publishers MUST NOT use `access: authenticated` or
+`access: restricted` to express a payment requirement. A unit that is anonymous-but-paid
+(e.g. x402 pay-per-request with no account) declares `access: public` — or omits `access` —
+together with a `payment` block (§4.14); the RFC-0005 auth × payment matrix explicitly
+supports this `none | x402` combination as *anonymous micropayment*. A validator SHOULD warn
+when units with `access: authenticated` or `restricted` exist in a manifest whose `auth`
+block (§3.3) declares only method `none`, since no credential could ever satisfy the gate —
+the pattern a payment-as-access confusion produces.
+
 `auth_scope` is OPTIONAL. Parsers MUST NOT reject a manifest because `auth_scope` is absent
 on a unit with `access: restricted`. A validator SHOULD warn when `auth_scope` is present on
 a unit whose `access` is not `restricted`, as the scope has no effect without the access gate.
@@ -1978,6 +1988,11 @@ type-specific.
 separate: `auth` describes *who* the agent proves it is; `payment` describes *what* access costs.
 When both are present, the agent MUST satisfy auth *before* attempting payment. Access-by-proof
 lives in `trust`; access-by-transaction lives in `payment`.
+
+The unit-level `access` field (§4.11) belongs to the auth axis only — payment requirements are
+never expressed through `access`. An anonymous pay-per-request unit is `access: public` (or
+omits `access`) with a metered `payment` block, not `access: restricted`. A fail-closed agent
+that cannot satisfy an `access` gate will skip the unit even when it could settle the payment.
 
 `payment` is OPTIONAL at both root and unit level. When omitted entirely, all units are assumed
 `free`. Unit-level `payment` **replaces** the root-level `payment` for that unit (it does not
@@ -2597,6 +2612,14 @@ effect on how the unit is evaluated — absence means "always valid" (backward-c
 - Bridges that implement temporal evaluation MUST filter at query time:
   `valid_from <= today AND (valid_until IS NULL OR valid_until >= today)`.
   Temporal filtering is applied after `not_for` filtering and before the top-N cut (§15.4).
+- `valid_from` and `valid_until` are **inclusive** boundaries — a unit is active for any
+  evaluation date `d` where `valid_from <= d <= valid_until` (this is exactly what the
+  query-time filter above encodes). A date-granularity value covers the whole named day.
+- Validity windows MAY overlap during transitions (old unit valid until Sunday, successor
+  valid from Saturday); `superseded_by` disambiguates the overlap. A unit whose declared
+  `superseded_by` successor is itself selectable (active as of the evaluation date and
+  audience/access-eligible) SHOULD NOT be selected — supersession takes precedence over
+  temporal overlap.
 - Root-level `temporal` provides defaults. Unit-level overrides are field-by-field (not block-level).
 - `superseded_by` cycles MUST be detected and reported as a manifest error.
 

--- a/cli/src/access-validation.test.ts
+++ b/cli/src/access-validation.test.ts
@@ -1,0 +1,63 @@
+// Tests for the §4.11 access/auth-axis warnings — 'access' declares the
+// authentication gate only. An auth block whose only method is 'none' can never
+// satisfy a protected unit (the payment-as-access anti-pattern surfaced by
+// kcp-agent interop testing, issue #115).
+
+import { describe, expect, it } from "vitest";
+import { parseDict } from "./parser.js";
+import { validate } from "./validator.js";
+
+function validateManifest(extra: Record<string, unknown>) {
+  return parseAndValidate({ kcp_version: "0.25", project: "test", version: "1.0.0", ...extra });
+}
+
+function parseAndValidate(raw: Record<string, unknown>) {
+  return validate(parseDict(raw));
+}
+
+const unit = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  path: `docs/${id}.md`,
+  intent: `Unit ${id}`,
+  scope: "project",
+  audience: ["agent"],
+  ...extra,
+});
+
+const NONE_ONLY_WARNING = "declares only method 'none'";
+const NO_AUTH_WARNING = "no 'auth' block is declared";
+
+describe("access vs auth coherence (§4.11)", () => {
+  it("warns when protected units exist and the auth block declares only method 'none'", () => {
+    const r = validateManifest({
+      auth: { methods: [{ type: "none" }] },
+      units: [unit("paid", { access: "restricted", payment: { default_tier: "metered" } })],
+    });
+    expect(r.warnings.some((w) => w.includes(NONE_ONLY_WARNING))).toBe(true);
+    expect(r.isValid).toBe(true); // warning, not error
+  });
+
+  it("does not warn when the auth block declares a real method", () => {
+    const r = validateManifest({
+      auth: { methods: [{ type: "none" }, { type: "api_key" }] },
+      units: [unit("internal", { access: "restricted" })],
+    });
+    expect(r.warnings.some((w) => w.includes(NONE_ONLY_WARNING))).toBe(false);
+  });
+
+  it("does not warn when no unit is access-protected (anonymous-paid is access: public)", () => {
+    const r = validateManifest({
+      auth: { methods: [{ type: "none" }] },
+      units: [unit("paid", { payment: { default_tier: "metered" } })],
+    });
+    expect(r.warnings.some((w) => w.includes(NONE_ONLY_WARNING))).toBe(false);
+  });
+
+  it("still warns when protected units exist with no auth block at all (existing §7 rule)", () => {
+    const r = validateManifest({
+      units: [unit("internal", { access: "authenticated" })],
+    });
+    expect(r.warnings.some((w) => w.includes(NO_AUTH_WARNING))).toBe(true);
+    expect(r.warnings.some((w) => w.includes(NONE_ONLY_WARNING))).toBe(false);
+  });
+});

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -300,6 +300,14 @@ public class KcpValidator {
             warnings.add("manifest: units with access 'authenticated' or 'restricted' exist but no 'auth' block is declared");
         }
 
+        // §4.11: 'access' declares the authentication gate only. An auth block whose only
+        // method is 'none' can never satisfy a protected unit — the incoherent pattern a
+        // payment-as-access confusion produces.
+        if (hasProtectedUnits && manifest.auth() != null && !manifest.auth().methods().isEmpty()
+                && manifest.auth().methods().stream().allMatch(m -> "none".equals(m.type()))) {
+            warnings.add("manifest: units with access 'authenticated' or 'restricted' exist but the 'auth' block declares only method 'none' — no credential can satisfy the gate. If these units are pay-per-request rather than credential-gated, use access 'public' with a 'payment' block (§4.11/§4.14)");
+        }
+
         // Agent attestation requirements validation (§3.2, v0.22)
         var ar = manifest.trust() != null ? manifest.trust().agentRequirements() : null;
         if (ar != null) {

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -427,6 +427,23 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
             "but no 'auth' block is declared"
         )
 
+    # §4.11: 'access' declares the authentication gate only. An auth block whose
+    # only method is 'none' can never satisfy a protected unit — the incoherent
+    # pattern a payment-as-access confusion produces.
+    if (
+        has_protected
+        and manifest.auth is not None
+        and manifest.auth.methods
+        and all(m.type == "none" for m in manifest.auth.methods)
+    ):
+        warnings.append(
+            "manifest: units with access 'authenticated' or 'restricted' exist "
+            "but the 'auth' block declares only method 'none' — no credential can "
+            "satisfy the gate. If these units are pay-per-request rather than "
+            "credential-gated, use access 'public' with a 'payment' block "
+            "(§4.11/§4.14)"
+        )
+
     # Agent attestation requirements validation (§3.2, v0.22)
     ar = manifest.trust.agent_requirements if manifest.trust else None
     if ar is not None:

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -589,6 +589,21 @@ export function validate(
     );
   }
 
+  // §4.11: 'access' declares the authentication gate only. An auth block whose only
+  // method is 'none' can never satisfy a protected unit — the incoherent pattern a
+  // payment-as-access confusion produces (anonymous-paid units belong at access 'public'
+  // with a 'payment' block, per the RFC-0005 auth × payment matrix).
+  if (
+    hasProtected &&
+    manifest.auth &&
+    manifest.auth.methods.length > 0 &&
+    manifest.auth.methods.every((m) => m.type === "none")
+  ) {
+    warnings.push(
+      "manifest: units with access 'authenticated' or 'restricted' exist but the 'auth' block declares only method 'none' — no credential can satisfy the gate. If these units are pay-per-request rather than credential-gated, use access 'public' with a 'payment' block (§4.11/§4.14)"
+    );
+  }
+
   // Agent attestation requirements validation (§3.2, v0.22)
   const ar = manifest.trust?.agent_requirements;
   if (ar) {


### PR DESCRIPTION
## Summary

Resolves the two spec questions raised by kcp-agent interop testing (Cantara/kcp-agent#2):

- **#115 — `access` declares the authentication gate only.** New normative paragraph in §4.11 (mirrored in §4.14): publishers MUST NOT express payment requirements through `access`; anonymous pay-per-request units are `access: public` + `payment` block, per the RFC-0005 `none | x402` anonymous-micropayment cell. The reference agent's fail-closed reading (Reading B) is confirmed correct.
- **#114 — temporal boundaries are inclusive.** §4.22 codifies `valid_from <= d <= valid_until` (exactly what the existing query-time filter formula already encoded) and adds the transition rule: a unit whose declared `superseded_by` successor is itself selectable SHOULD NOT be selected — supersession takes precedence over temporal overlap.
- **Validator warning (all four implementations).** New §7 warning when `access: authenticated`/`restricted` units coexist with an `auth` block whose only method is `none` — no credential can ever satisfy the gate; this is the exact fingerprint of the payment-as-access confusion. Implemented in the TS shared core (CLI + bridge via symlink), Python, and Java; 4 new tests in `cli/src/access-validation.test.ts`.

No new fields, no behavioural change to conformant manifests — clarifications + one advisory warning only.

## Test plan

- [x] CLI suite: 108/108 (includes 4 new access-validation tests + validator byte-parity consistency guards)
- [x] TS bridge suite: 232/232
- [x] Python validator: smoke-tested warning fires on `restricted` + auth-only-`none`, silent otherwise
- [x] Java parser: `mvn compile` clean

Closes #114. Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)