### PR TITLE
ci: publish kcp-mcp and kcp-cli to npm on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
+  # Manual publish path: a workflow_dispatch run publishes whatever version is
+  # on the dispatched ref (also the retry path if a publish fails after tagging).
+  workflow_dispatch:
 
 jobs:
   python-tests:
@@ -233,3 +237,52 @@ jobs:
         run: |
           cd bridge/typescript
           npx tsx ../../conformance/runners/typescript/conformance_runner.ts ../../conformance/fixtures
+
+  # Publishes kcp-mcp (bridge/typescript) to npm via npm Trusted Publishing
+  # (OIDC — no token secret). Requires npm >= 11.5.1, hence Node 24. Runs on a
+  # v* tag push (the release flow) or on workflow_dispatch (manual/retry path).
+  # Same pattern as kcp-agent and kcp-harness.
+  publish-kcp-mcp:
+    needs: [typescript-bridge-tests, conformance-typescript]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC for trusted publishing + provenance attestation
+    defaults:
+      run:
+        working-directory: bridge/typescript
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          # NB: no registry-url here — setup-node would write an .npmrc with a
+          # placeholder NODE_AUTH_TOKEN, which takes precedence over OIDC and
+          # makes npm fail the PUT with a masked E404. Trusted Publishing is
+          # auto-detected by npm >= 11.5.1 when no token is configured.
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance --access public
+
+  # Publishes kcp-cli (cli/) the same way. No other CI job covers cli/, so this
+  # job runs its build and test suite itself before publishing.
+  publish-kcp-cli:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC for trusted publishing + provenance attestation
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          # NB: no registry-url — see publish-kcp-mcp.
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --provenance --access public

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "kcp",
-  "version": "0.25.1",
+  "name": "kcp-cli",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kcp",
-      "version": "0.25.1",
+      "name": "kcp-cli",
+      "version": "0.26.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kcp",
+  "name": "kcp-cli",
   "version": "0.26.0",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",

--- a/guides/kcp-enable-a-github-repo.md
+++ b/guides/kcp-enable-a-github-repo.md
@@ -23,11 +23,11 @@ By the end you will have:
 ## 0. Install the CLI
 
 ```bash
-npm install -g kcp-commands     # provides the `kcp` developer CLI
+npm install -g kcp-cli          # provides the `kcp` developer CLI
 kcp --help
 ```
 
-No global install? Every command below also works as `npx kcp <command>`.
+No global install? Every command below also works as `npx --package kcp-cli kcp <command>`.
 
 ---
 
@@ -264,7 +264,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
-      - run: npm install -g kcp-commands
+      - run: npm install -g kcp-cli
       - name: Restore signing key
         env: { KCP_SIGNING_KEY: "${{ secrets.KCP_SIGNING_KEY }}" }
         run: printf '%s' "$KCP_SIGNING_KEY" > /tmp/k.pem && chmod 600 /tmp/k.pem


### PR DESCRIPTION
## Summary
- `ci.yml` now triggers on `v*` tag pushes (and `workflow_dispatch` as the manual/retry path) and publishes both npm packages via **npm Trusted Publishing** (OIDC + provenance, no token secrets) — the same proven pattern as kcp-agent and kcp-harness
- `publish-kcp-mcp` (bridge/typescript): gated on `typescript-bridge-tests` + `conformance-typescript`
- `publish-kcp-cli` (cli/): no existing CI job covers `cli/`, so the job runs its own build + 115-test suite before publishing
- CLI renamed **`kcp` → `kcp-cli`**: the npm name `kcp` is held by an unrelated package (v1.0.8, 2022). The installed binary is unchanged (`kcp`)
- Fixed `guides/kcp-enable-a-github-repo.md`, which credited `kcp-commands` (a different package — command manifests) with providing the developer CLI

## Manual one-time setup (npmjs.com, before this works)
1. **kcp-mcp** (exists, published manually until now): package Settings → Trusted Publisher → GitHub Actions, repo `Cantara/knowledge-context-protocol`, workflow `ci.yml`
2. **kcp-cli** (new name): trusted publishing can't create a package — publish once by hand (`cd cli && npm publish --access public`), then configure the Trusted Publisher as above

After that, the existing release flow (tag `vX.Y.Z` + GitHub release) publishes both packages automatically.

## Test plan
- [x] `ci.yml` YAML parses
- [x] `cli/` build + tests pass after rename (115/115)
- [x] `cli/package-lock.json` regenerated via `npm install --package-lock-only`
- [ ] After merge + npm setup: dispatch `ci.yml` (or cut the next release) and verify both packages publish with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)