### PR TITLE
v0.26.1: harden serving/C22 and aliases after red-team pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,59 @@ _Nothing yet._
 
 ---
 
+## [0.26.1] — 2026-07-14 — v0.26 Hardening
+
+**Spec version:** `"0.26"` (unchanged — one conformance fix + clarifications, no new fields) | **Prior:** v0.26.0 (2026-07-14)
+
+A red-team pass over the v0.26 features (`serving`/C22 and `aliases`) surfaced one genuine
+fail-open, a cross-implementation parser divergence, and several spec overclaims. All corrected
+here. No new fields; conformant v0.26.0 manifests are unaffected except where a `serving.manifest`
+mismatch should have demoted and previously did not.
+
+### Fixed (security / correctness)
+
+- **C22 present-empty fail-open (§3.12).** A **present-but-empty** `serving.manifest: []` is an
+  *exhaustive-empty* assertion ("no HTTP(S) URL is authoritative") and MUST demote every HTTP(S)
+  retrieval. The renderer previously gated on list length and treated `[]` as "no assertion",
+  silently keeping `trusted` — reopening the T11 rogue-representative attack for MCP-only
+  publishers. It now gates on presence, not length. (`kcp render`)
+- **Parser coercion parity (all four).** A YAML scalar where `aliases`/`serving` expect a list, and
+  non-string list entries, now resolve identically across TypeScript, Python, and Java: a non-list
+  is *absent* (never coerced into a one-element list) and non-string entries are dropped. Java's
+  `serving:` cast is now type-guarded so a non-object block can no longer throw. Previously Java
+  coerced scalars while TS/Python dropped them — the same signed bytes could resolve to different
+  trust decisions per implementation.
+- **Bridge `get_unit` parity.** All three bridges now match `unit_id` exactly (no whitespace
+  trimming — Python previously trimmed) and never resolve an empty `unit_id`.
+
+### Clarified / hardened (spec text)
+
+- **§3.12 `serving.mcp` honesty.** C22 covers only `serving.manifest`; the spec now states plainly
+  that `serving.mcp` has no MUST-level consumer enforcement in this version (only a server-side
+  startup SHOULD-warn and an optional client-side check), so the rogue-MCP-proxy case is closed only
+  for clients that independently re-fetch and compare.
+- **§3.12 scoping of "can only add protection."** True only for verifiers predating the block; for a
+  v0.26 verifier an incomplete/stale `serving.manifest` demotes legitimate retrievals. Added an
+  operator note (enumerate every CDN edge/mirror/redirect target; exact post-redirect matching, no
+  normalization) and two limitations: `serving` is consultable only after signature verification
+  (no origin bootstrap), and it binds location not recency (a once-listed URL can replay old signed
+  bytes — anti-rollback needs §4.22 pinning).
+- **§4.2a alias char rule.** Corrected the prose: an alias rule (`^[a-z0-9][a-z0-9._-]*$`) is *close
+  to but not identical* to the `id` rule — it permits an underscore and forbids a leading dot/hyphen.
+- **§4.2a uniqueness reconciled.** A collision is a §7 **warning** (not "MUST reject", which
+  contradicted the field prose); resolution now defines a deterministic tie-break (canonical `id`
+  first, then first-declared alias) so the outcome never depends on map ordering. RFC-0023's
+  conformance line updated to match.
+- **§4.2a resolver-side MUST.** Aliases are barred as `depends_on` / `supersedes` / `overrides` /
+  `excludes` / **`external_depends_on`** targets not just for authors but for resolvers: reference
+  resolution MUST match only canonical `id`, never aliases, including across federation boundaries
+  (closes a cross-manifest reference-hijack).
+- **§4.2a citation integrity.** An alias asserts *resolution*, not content-span containment;
+  `content_hash` covers the whole unit. Audit/citation systems MUST NOT treat an alias match as
+  evidence the content contains the aliased element.
+
+---
+
 ## [0.26.0] — 2026-07-14 — Serving Endpoint Binding + Unit Aliases
 
 **Spec version:** `"0.26"` | **Prior:** `"0.25"` (v0.25.1, 2026-07-04)

--- a/RFC-0023-Unit-Aliases.md
+++ b/RFC-0023-Unit-Aliases.md
@@ -147,7 +147,10 @@ When a consumer requests a unit by identifier `X`:
 4. Not found → resolution failure (existing behaviour)
 ```
 
-Step 2 is new. The resolution is deterministic because alias uniqueness is enforced.
+Step 2 is new. Uniqueness is a §7 **warning**, not a hard rejection (see SPEC.md §4.2a), so
+resolution is made deterministic by a defined tie-break rather than by assuming uniqueness holds: a
+canonical `id` always wins over any alias, and among colliding aliases the first declared (units in
+document order, then aliases in list order) wins.
 
 ### Bridge behavior
 
@@ -325,7 +328,7 @@ Aliases solve the problem with minimal spec surface:
 | Feature | Level | Notes |
 |---------|-------|-------|
 | Parse `aliases` field | Level 1 | MUST read and expose. |
-| Alias uniqueness validation | Level 1 | MUST reject duplicate aliases within manifest. |
+| Alias uniqueness validation | Level 1 | MUST warn (§7) on duplicate aliases within manifest; resolution applies the deterministic tie-break (canonical id first, then first-declared alias). |
 | Alias-based resolution | Level 1 | MUST resolve alias lookups to canonical unit. |
 | `matched_alias` in response | Level 2 | RECOMMENDED in bridge responses. |
 | Alias in `list_knowledge` | Level 2 | RECOMMENDED for discoverability. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -1280,12 +1280,21 @@ serving:
 
 Each declared list is **exhaustive for its class**: declaring `serving.manifest` asserts "these are
 the only authoritative manifest URLs"; declaring `serving.mcp` asserts "these are the only
-authorized MCP representatives". Omitting a list makes no assertion about that class. Every entry
-MUST be HTTPS — an `http://` entry is a manifest validation error (§7).
+authorized MCP representatives". *Omitting* a list makes no assertion about that class; a **present
+but empty** list (`manifest: []`) is still an assertion — the exhaustive-empty set — meaning "no URL
+of this class is authoritative", so under §"Verifier behaviour" every HTTP(S) retrieval of that
+class demotes. A verifier MUST distinguish an absent list (no assertion) from a present-empty list
+(exhaustive-empty assertion); conflating them reopens T11. Every entry MUST be HTTPS — an `http://`
+entry is a manifest validation error (§7).
 
 **URL matching.** Comparison is on the **final post-redirect** URL for retrieval, and the **dialed**
 URL for MCP endpoints. Match on scheme, host, and path after: lowercasing scheme and host, removing
-a default `:443` port, and stripping any query string and fragment. No wildcard or prefix matching.
+a default `:443` port, and stripping any query string and fragment. The path is compared exactly
+(no percent-decoding, no trailing-slash or dot-segment normalization); no wildcard or prefix
+matching. Because matching is exact on the post-redirect URL, an **incomplete** `serving.manifest`
+list demotes legitimate retrievals from unlisted-but-authentic URLs: authors MUST enumerate every
+CDN edge, redirect target, mirror, and path variant an agent may legitimately land on, or accept
+that those retrievals render at `known` rather than `trusted`.
 
 **Verifier behaviour (T11).** When a verifier retrieved the manifest over HTTP(S), `serving.manifest`
 is declared, and the final retrieval URL is not in the list, a render or plan that would tier
@@ -1293,10 +1302,19 @@ is declared, and the final retrieval URL is not in the list, a render or plan th
 retrieval URL and the declared list. This mirrors the demotion discipline of §16 corroboration and
 §4.21 content-hash mismatch: the content is intact and the signer is known, but an authorization
 claim failed — so the manifest is treated as *recognized*, not *trusted*. Local retrieval (file
-paths, git checkouts) is out of scope here — it is governed by RFC-0019 origin evidence. A
-KCP-aware MCP **server** whose default manifest declares a `serving.mcp` list that omits the
-server's own public URL SHOULD log a startup warning (it may not always know its public URL, so
-serving is still permitted).
+paths, git checkouts) is out of scope here — it is governed by RFC-0019 origin evidence.
+
+**`serving.mcp` has no MUST-level consumer enforcement in this version.** C22 covers only
+`serving.manifest` (the direct retrieval URL). For the MCP class, the only defined behaviour is a
+server-side self-check: a KCP-aware MCP **server** whose default manifest declares a `serving.mcp`
+list that omits the server's own public URL SHOULD log a startup warning (it may not always know
+its public URL, so serving is still permitted). A **client** MAY compare the MCP endpoint it dialed
+against `serving.mcp` and treat a mismatch like a C22 demotion, but this is not yet a numbered
+conformance rule — so the rogue-MCP-proxy case (the headline T11 scenario) is closed only for
+clients that both independently re-fetch the signed manifest *and* perform that dialed-URL check. A
+future revision may promote the client-side MCP check to a normative rule; until then, treat
+`serving.mcp` as an expressible, signed declaration whose enforcement is advisory on the consumer
+side.
 
 **T11 — rogue-representative attack.** A genuinely signed manifest is served, mirrored, or
 MCP-fronted by an endpoint the signer never authorized, lending the endpoint's own behaviour
@@ -1308,11 +1326,31 @@ block makes the authorization claim expressible and signed; enforcement scales w
 independently the consumer can verify, the same trust topology as certificate pinning.
 
 `serving` is OPTIONAL and additive: an absent block asserts nothing and preserves today's behaviour,
-and verifiers predating this block ignore it (unknown-field rule) — it can only *add* protection,
-never make a manifest less trusted.
+and verifiers predating this block ignore it (unknown-field rule) — **for a verifier that does not
+understand `serving`, it can only add protection, never make a manifest less trusted.** For a v0.26
+verifier the claim is narrower: as noted under §"URL matching", an incomplete or stale
+`serving.manifest` will demote legitimate retrievals, so declaring `serving` *can* lower the tier a
+correct consumer assigns to authentic content the author forgot to enumerate. Declaring `serving`
+therefore protects only the upgraded, checking subset of consumers; an attacker retains full T11
+leverage against every non-checking or pre-v0.26 consumer by serving the same signed bytes from a
+rogue URL. This is the certificate-pinning trust topology: coverage scales with adoption, not with
+declaration.
+
+**Limitations.**
+- **Consultable only after signature verification.** `serving` lives inside the signed bytes, so it
+  is meaningful only once a signature from a pinned/known key has verified the manifest. It does not
+  bootstrap origin trust and does not protect first contact with an unsigned or self-signed manifest
+  (the same trust-on-first-use floor as the rest of §16).
+- **Binds location, not recency.** `serving` carries no freshness, version, or revocation signal, and
+  a KCP signature over old bytes remains valid indefinitely (§4.21). A URL that was *ever* a
+  legitimate `serving.manifest` entry can replay an older, genuinely-signed manifest from that
+  once-listed URL and still match — so the "stale mirror" branch of T11 is closed only for URLs that
+  were never listed. Anti-rollback requires consumer-side version/temporal pinning (§4.22), which
+  `serving` does not provide.
 
 **Conformance:** C22 (serving demotion on retrieval-URL mismatch) — see §16.5. The MCP-server
-startup self-check is a Level-2 SHOULD.
+startup self-check and the client-side `serving.mcp` dialed-URL check are Level-2 SHOULDs (no
+numbered conformance rule in this version).
 
 ---
 
@@ -1405,28 +1443,45 @@ units:
 
 **Rules:**
 
-- Each alias MUST follow the same character rules as `id` (§4.2): lowercase ASCII letters, digits,
-  hyphens, and dots, and MUST NOT be empty.
+- An alias MUST match `^[a-z0-9][a-z0-9._-]*$`: lowercase ASCII letters, digits, dots, hyphens, and
+  underscores, beginning with a letter or digit, and MUST NOT be empty. (This is *close to* but not
+  identical to the `id` rule of §4.2: unlike `id`, an alias may contain an underscore and MUST NOT
+  begin with a dot or hyphen. The stricter leading-character rule keeps aliases unambiguous with the
+  reference syntaxes they must never appear in.)
 - An alias MUST be unique across **all** `id` values **and** all `aliases` values within the same
-  manifest (after composition resolution). A collision is a §7 warning.
+  manifest (after composition resolution). A collision is a §7 **warning**, not a rejection — the
+  manifest still loads. Because a collision is only warned, resolution defines a deterministic
+  tie-break so the outcome never depends on hash-map ordering: a canonical `id` always wins over any
+  alias, and among colliding aliases the **first declared** (units in document order, then aliases in
+  list order) wins. Validators SHOULD warn on every collision so authors can remove the ambiguity.
 - A lookup by an alias resolves to the same unit as a lookup by that unit's `id`. The alias does not
   create a separate unit — it is an alternative reference to the existing one. Implementations that
-  resolve by identifier MUST also match against declared aliases.
+  resolve *content by identifier* (e.g. `get_unit`, search) MUST also match against declared aliases.
 - `id` remains the **canonical** identifier. Aliases are secondary: they are NOT valid targets for
-  `depends_on`, `supersedes`, `relationships`, `overrides`, or `excludes`. This keeps the topology
-  and composition layers unambiguous. When a lookup matched an alias, serialized output (search
-  results, audit logs) SHOULD surface both the matched alias and the canonical `id`.
+  `depends_on`, `supersedes`, `relationships`, `overrides`, `excludes`, or `external_depends_on`.
+  This binds authors — but resolvers MUST also enforce it: when resolving any of those reference
+  targets (including across a federation boundary, where the target manifest is attacker-influenceable),
+  a resolver MUST match **only** canonical `id` values, never `aliases`. Matching an alias there would
+  let a hostile federated manifest declare an alias equal to a canonical id you expect and silently
+  divert the reference. Alias matching is confined to direct content lookup (`get_unit`, search).
+  When a lookup matched an alias, serialized output (search results, audit logs) SHOULD surface both
+  the matched alias and the canonical `id`.
 - Aliases share their unit's temporal validity (§4.22) and `content_hash` (§4.21) — they are
-  identifier-level indirection only, never a distinct content payload.
+  identifier-level indirection only, never a distinct content payload. An alias therefore asserts
+  *resolution*, not content-span containment: `content_hash` covers the whole unit, not the
+  subdivision an alias names. A precise-looking alias (`reg-art-21-2d`) that resolves to a
+  full-article unit is "verified" against the *article's* hash — it carries no integrity assurance
+  that the article actually contains that sub-clause. Audit and citation systems MUST NOT treat an
+  alias match as evidence that the referenced content contains the aliased element.
 
 Implementations MAY impose a reasonable upper bound on alias count (RECOMMENDED: 100 per unit) and
 SHOULD warn when a unit exceeds it. `aliases` is OPTIONAL and additive: manifests without it are
 unaffected, and a parser that ignores it simply fails to resolve alias lookups (existing
 unknown-id behaviour).
 
-**Conformance:** Parse and expose `aliases`, reject duplicate aliases, and resolve alias lookups to
-the canonical unit — Level 1. Surfacing `matched_alias` in bridge responses and listing aliases —
-Level 2.
+**Conformance:** Parse and expose `aliases`, **warn on** duplicate aliases (with the deterministic
+tie-break above), and resolve alias lookups to the canonical unit — Level 1. Surfacing
+`matched_alias` in bridge responses and listing aliases — Level 2.
 
 ### 4.3 `path`
 
@@ -3790,7 +3845,10 @@ A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18)
 - **C22** (v0.26): When a verifier retrieved the manifest over HTTP(S), the manifest declares a
   `serving.manifest` list (§3.12), and the final post-redirect retrieval URL is **not** in that
   list (per the §3.12 matching rules), the render/plan MUST NOT tier above `known` and MUST emit a
-  §7 warning naming both the retrieval URL and the declared list. The signer is authentic and the
+  §7 warning naming both the retrieval URL and the declared list. A **present-but-empty** list
+  (`manifest: []`) is an exhaustive-empty assertion — no HTTP(S) URL is authoritative — so *every*
+  HTTP(S) retrieval matches nothing and demotes; only an **absent** list means "no assertion" and
+  never demotes. A verifier MUST NOT conflate the two. The signer is authentic and the
   bytes intact — but an authorization claim failed, so the manifest is treated as *recognized*, not
   *trusted* (T11, the rogue-representative attack). The retrieval URL is a determinism input to the
   render (C1 preserved), supplied by the consumer's channel as with §16 corroboration; local

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.26.0</version>
+    <version>0.26.1</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
+++ b/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpServer.java
@@ -759,11 +759,12 @@ public final class KcpServer {
 
         // §4.2a (v0.26): resolve a declared alias to its canonical unit. The canonical id wins;
         // matchedAlias is set only when the lookup came in via an alias, and the first-declared
-        // unit wins an alias collision (mirrors the duplicate-id rule).
+        // unit wins an alias collision (mirrors the duplicate-id rule). An empty unit_id never
+        // resolves — guard before the alias scan so a malformed empty-string alias can't match.
         String unitId = requestedId;
         String matchedAlias = null;
-        KnowledgeUnit unit = rs.units().get(requestedId);
-        if (unit == null) {
+        KnowledgeUnit unit = requestedId.isEmpty() ? null : rs.units().get(requestedId);
+        if (unit == null && !requestedId.isEmpty()) {
             for (Map.Entry<String, KnowledgeUnit> e : rs.units().entrySet()) {
                 if (e.getValue().aliases() != null && e.getValue().aliases().contains(requestedId)) {
                     unit = e.getValue();

--- a/bridge/python/kcp_mcp/server.py
+++ b/bridge/python/kcp_mcp/server.py
@@ -675,14 +675,17 @@ def _handle_get_unit(
     """Fetch the content of a specific knowledge unit by id."""
     source_temporal = source_temporal or {}
     ref_temporal_by_id = ref_temporal_by_id or {}
-    requested_id = arguments.get("unit_id", "").strip()
+    # Exact match, no trimming — the TS and Java bridges do not trim either, and an id/alias
+    # can never legitimately contain surrounding whitespace (§4.2 char rules).
+    requested_id = arguments.get("unit_id", "")
     # §4.2a (v0.26): resolve a declared alias to its canonical unit. The canonical id wins;
     # matched_alias is set only when the lookup came in via an alias, and the first-declared
-    # unit wins an alias collision (mirrors the duplicate-id rule).
+    # unit wins an alias collision (mirrors the duplicate-id rule). An empty unit_id never
+    # resolves (guard before the alias scan so a malformed empty-string alias can't match).
     matched_alias: str | None = None
     unit_id = requested_id
-    ctx = unit_context.get(requested_id)
-    if ctx is None:
+    ctx = unit_context.get(requested_id) if requested_id else None
+    if ctx is None and requested_id:
         for uid, (u, _d) in unit_context.items():
             if requested_id in (u.aliases or []):
                 ctx = unit_context[uid]

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.26.0"
+version = "0.26.1"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "MCP bridge for the Knowledge Context Protocol — exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/bridge/typescript/src/server.ts
+++ b/bridge/typescript/src/server.ts
@@ -713,13 +713,17 @@ export function createKcpServer(
       }
 
       case "get_unit": {
+        // Exact match, no trimming (parity with the Python + Java bridges); an id/alias can
+        // never legitimately carry surrounding whitespace (§4.2 char rules).
         const requestedId = String(args?.["unit_id"] ?? "");
         // §4.2a (v0.26): resolve a declared alias to its canonical unit. The canonical id
-        // takes precedence; matchedAlias is set only when the lookup came in via an alias.
-        let ctx = unitContextMap.get(requestedId);
+        // takes precedence; matchedAlias is set only when the lookup came in via an alias. An
+        // empty unit_id never resolves — guard before the alias lookup so a malformed
+        // empty-string alias can't match.
+        let ctx = requestedId ? unitContextMap.get(requestedId) : undefined;
         let matchedAlias: string | undefined;
         let unitId = requestedId;
-        if (!ctx) {
+        if (!ctx && requestedId) {
           const canonical = aliasToId.get(requestedId);
           if (canonical) {
             ctx = unitContextMap.get(canonical);

--- a/bridge/typescript/tests/parser.test.ts
+++ b/bridge/typescript/tests/parser.test.ts
@@ -1009,4 +1009,31 @@ units:
     expect(r.errors.some((e) => e.includes("serving.manifest entry 'http://insecure/knowledge.yaml' must be an HTTPS URL"))).toBe(true);
     expect(r.isValid).toBe(false);
   });
+
+  it("coerces malformed aliases/serving to absent (parser parity with Python + Java)", () => {
+    // A scalar where a list is expected is *absent* (not a one-element list); non-string
+    // entries are dropped; a non-object serving block is absent without throwing.
+    const m = parseDict(yaml.load(`
+kcp_version: "0.26"
+project: malformed
+version: 1.0.0
+serving: "https://not-an-object/knowledge.yaml"
+units:
+  - id: u1
+    path: a.txt
+    intent: x
+    scope: global
+    audience: [agent]
+    aliases: reg-art-21-2a
+  - id: u2
+    path: b.txt
+    intent: y
+    scope: global
+    audience: [agent]
+    aliases: [good-alias, null, 42, true]
+`) as Record<string, unknown>);
+    expect(m.serving).toBeUndefined();                 // scalar serving -> absent
+    expect(m.units[0].aliases).toBeUndefined();        // scalar aliases -> absent, not ["reg-art-21-2a"]
+    expect(m.units[1].aliases).toEqual(["good-alias"]); // null/number/bool dropped
+  });
 });

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.26.0
+    `\nKCP Developer CLI — v0.26.1
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.test.ts
+++ b/cli/src/render.test.ts
@@ -611,6 +611,66 @@ units:
     expect(doc.trust.serving_check.result).toBe("match");
   });
 
+  it("demotes on a present-but-empty serving.manifest — [] is exhaustive-empty, not absent (§3.12)", () => {
+    // A signer who distributes only via MCP writes `manifest: []` to assert "no HTTP URL
+    // is authoritative". Any HTTP retrieval must then demote — an empty list must NOT be
+    // conflated with an omitted list (that fail-open would reopen T11).
+    const manifestPath = writeManifest(`kcp_version: "0.26"
+project: mcp-only
+version: 1.0.0
+serving:
+  manifest: []
+  mcp:
+    - https://mcp.example.com/mcp
+units:
+  - id: overview
+    path: docs/overview.md
+    intent: "Architecture overview and module boundaries"
+`);
+    const pub = signManifest(manifestPath, "org-key");
+    const keysPath = writeAllowlist([
+      { key_id: "org-key", method: "jws", algorithm: "EdDSA", public_key: pub,
+        scope: { domains: ["github.com/testorg"] } },
+    ]);
+    const { doc, result } = renderOk(manifestPath, {
+      keysPath, origin: "github.com/testorg/repo",
+      retrievedFrom: "https://any.example.com/knowledge.yaml",
+    });
+    expect(doc.trust.tier).toBe("known");
+    expect(doc.trust.serving_check.result).toBe("mismatch");
+    expect(result.warnings.some((w) => w.includes("(empty)") && w.includes("C22"))).toBe(true);
+  });
+
+  it("treats a non-list serving.manifest as no assertion (not_declared), never crashes", () => {
+    const manifestPath = writeManifest(`kcp_version: "0.26"
+project: malformed
+version: 1.0.0
+serving:
+  manifest: "https://wiki.example.com/knowledge.yaml"
+units:
+  - id: overview
+    path: docs/overview.md
+    intent: "Architecture overview and module boundaries"
+`);
+    const { doc } = renderOk(manifestPath, {
+      retrievedFrom: "https://rogue.example.net/knowledge.yaml",
+    });
+    expect(doc.trust.serving_check.result).toBe("not_declared");
+  });
+
+  it("does not claim a demotion in the warning when the tier was already below trusted", () => {
+    // Unsigned manifest (empty allowlist) with a mismatched retrieval URL: the check still
+    // records a mismatch, but the warning must not say "trusted tier demoted".
+    const manifestPath = writeManifest(SERVING_MANIFEST);
+    const { doc, result } = renderOk(manifestPath, {
+      retrievedFrom: "https://rogue.example.net/knowledge.yaml",
+    });
+    expect(doc.trust.tier).toBe("unsigned");
+    expect(doc.trust.serving_check.result).toBe("mismatch");
+    expect(result.warnings.some((w) => w.includes("demoted to known"))).toBe(false);
+    expect(result.warnings.some((w) => w.includes("tier remains unsigned"))).toBe(true);
+  });
+
   it("records not_declared and never demotes when the manifest omits serving.manifest", () => {
     const manifestPath = writeManifest(MINIMAL_MANIFEST);
     const pub = signManifest(manifestPath, "org-key");

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.26.0";
+export const RENDERER_VERSION = "kcp-cli 0.26.1";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 
@@ -456,12 +456,20 @@ export function renderManifest(options: RenderOptions): RenderResult {
   // bytes are intact — only the authorization-to-serve claim failed (recognized,
   // not trusted). Local retrieval (no retrievedFrom) is out of scope here.
   let servingCheck: RawMap | undefined;
-  const servingBlock = doc.serving as RawMap | undefined;
-  const servingManifest = servingBlock && Array.isArray(servingBlock.manifest)
-    ? (servingBlock.manifest as unknown[]).map(String)
-    : undefined;
+  const servingBlock =
+    doc.serving && typeof doc.serving === "object" && !Array.isArray(doc.serving)
+      ? (doc.serving as RawMap)
+      : undefined;
+  // §3.12: a *declared* serving.manifest list is exhaustive for its class — even when
+  // empty (an empty list asserts "no HTTP URL is authoritative", so every HTTP retrieval
+  // must demote). Only an absent/non-list `manifest` means "no assertion". Gate on
+  // presence (Array.isArray), never on length, or a `manifest: []` fails open (T11).
+  const servingManifest =
+    servingBlock && Array.isArray(servingBlock.manifest)
+      ? (servingBlock.manifest as unknown[]).map(String)
+      : undefined;
   if (options.retrievedFrom !== undefined) {
-    if (servingManifest && servingManifest.length > 0) {
+    if (servingManifest !== undefined) {
       const got = normalizeServingUrl(options.retrievedFrom);
       const allowed = servingManifest
         .map(normalizeServingUrl)
@@ -472,15 +480,21 @@ export function renderManifest(options: RenderOptions): RenderResult {
         result: matched ? "match" : "mismatch",
       };
       if (!matched) {
-        if (tier === "trusted") tier = "known";
+        // Only a `trusted` tier is demoted; below that the warning must not claim a
+        // demotion that did not happen (the signer/bytes verdict is unchanged).
+        const wasTrusted = tier === "trusted";
+        if (wasTrusted) tier = "known";
+        const listText = servingManifest.length ? servingManifest.join(", ") : "(empty)";
         warnings.push(
           `retrieval URL '${options.retrievedFrom}' is not in the manifest's serving.manifest ` +
-            `list [${servingManifest.join(", ")}]; trusted tier demoted to known (§3.12 / C22)`
+            `list [${listText}]` +
+            (wasTrusted ? "; trusted tier demoted to known" : `; tier remains ${tier}`) +
+            ` (§3.12 / C22)`
         );
       }
     } else {
       // A retrieval URL was supplied but the manifest makes no serving.manifest
-      // assertion — nothing to enforce, recorded for auditability only.
+      // assertion (absent or non-list) — nothing to enforce, recorded for audit only.
       servingCheck = { retrieved_from: options.retrievedFrom, result: "not_declared" };
     }
   }

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -81,7 +81,7 @@ public class KcpParser {
         Compliance compliance = parseCompliance((Map<String, Object>) data.get("compliance"));
         Payment payment = parsePayment(data.get("payment"));
         RateLimits rateLimits = parseRateLimits((Map<String, Object>) data.get("rate_limits"));
-        Serving serving = parseServing((Map<String, Object>) data.get("serving"));
+        Serving serving = parseServing(data.get("serving"));
 
         List<Map<String, Object>> unitMaps = (List<Map<String, Object>>) data.getOrDefault("units", List.of());
         List<KnowledgeUnit> units = unitMaps.stream().map(KcpParser::parseUnit).toList();
@@ -133,7 +133,7 @@ public class KcpParser {
 
         return new KnowledgeUnit(
                 (String) u.get("id"),
-                asStringList(u.get("aliases")),
+                asStringListStrict(u.get("aliases")),
                 validateUnitPath((String) u.get("path")),
                 (String) u.get("kind"),
                 (String) u.get("intent"),
@@ -382,9 +382,11 @@ public class KcpParser {
         );
     }
 
-    private static Serving parseServing(Map<String, Object> s) {
-        if (s == null) return null;
-        return new Serving(asStringList(s.get("manifest")), asStringList(s.get("mcp")));
+    private static Serving parseServing(Object raw) {
+        // Type-guard rather than cast: a non-object `serving:` (a string/list/number) must
+        // parse to "no serving block", not throw ClassCastException as an unchecked cast would.
+        if (!(raw instanceof Map<?, ?> s)) return null;
+        return new Serving(asStringListStrict(s.get("manifest")), asStringListStrict(s.get("mcp")));
     }
 
     @SuppressWarnings("unchecked")
@@ -535,6 +537,18 @@ public class KcpParser {
             return list.stream().filter(java.util.Objects::nonNull).map(Object::toString).toList();
         }
         return List.of(raw.toString());
+    }
+
+    /**
+     * v0.26 strict string-list coercion for {@code aliases} and {@code serving} — a non-{@code List}
+     * is *absent* (null) and non-{@code String} entries are dropped, matching the TypeScript and
+     * Python parsers exactly. Unlike {@link #asStringList}, it never coerces a scalar into a
+     * one-element list, so the same signed bytes cannot resolve to different trust decisions across
+     * implementations. Structural validity (must be a list of strings) is the JSON schema's job.
+     */
+    private static List<String> asStringListStrict(Object raw) {
+        if (!(raw instanceof List<?> list)) return null;
+        return list.stream().filter(x -> x instanceof String).map(x -> (String) x).toList();
     }
 
     /**

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpAliasesServingTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpAliasesServingTest.java
@@ -79,6 +79,34 @@ class KcpAliasesServingTest {
                 () -> "expected bad-char warning, got: " + w);
     }
 
+    @Test void malformedAliasesAndServingCoerceToAbsent() {
+        // v0.26 parser parity: a scalar where a list is expected is *absent* (not coerced to a
+        // one-element list), non-string entries are dropped, and a non-object serving block is
+        // absent without throwing — matching the TypeScript and Python parsers exactly.
+        KnowledgeManifest m = parse("""
+            kcp_version: "0.26"
+            project: malformed
+            version: 1.0.0
+            serving: "https://not-an-object/knowledge.yaml"
+            units:
+              - id: u1
+                path: a.txt
+                intent: x
+                scope: global
+                audience: [agent]
+                aliases: reg-art-21-2a
+              - id: u2
+                path: b.txt
+                intent: y
+                scope: global
+                audience: [agent]
+                aliases: [good-alias, null, 42, true]
+            """);
+        assertNull(m.serving());                                      // scalar serving -> absent, no throw
+        assertNull(m.units().get(0).aliases());                       // scalar aliases -> absent
+        assertEquals(List.of("good-alias"), m.units().get(1).aliases()); // null/int/bool dropped
+    }
+
     @Test void servingRequiresHttps() {
         KnowledgeManifest m = parse("""
             kcp_version: "0.26"

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -206,13 +206,24 @@ def _parse_payment(data: Optional[dict]) -> Optional[Payment]:
     )
 
 
+def _string_list_or_none(raw: object) -> Optional[list]:
+    """v0.26: coerce a raw value into a string list for aliases/serving. A non-list is
+    *absent* (None) and non-string entries are dropped — so the TypeScript, Python, and Java
+    parsers agree byte-for-byte on malformed input rather than one coercing a scalar to a
+    one-element list while another drops it. Structural validity (must be a list of strings)
+    is the JSON schema's job; this keeps the runtime parsers in lockstep."""
+    if not isinstance(raw, list):
+        return None
+    return [x for x in raw if isinstance(x, str)]
+
+
 def _parse_serving(data: Optional[dict]) -> Optional[Serving]:
     """Parse a serving block (root-level). See SPEC.md §3.12 (v0.26)."""
     if not isinstance(data, dict):
         return None
     return Serving(
-        manifest=[str(u) for u in data["manifest"]] if isinstance(data.get("manifest"), list) else None,
-        mcp=[str(u) for u in data["mcp"]] if isinstance(data.get("mcp"), list) else None,
+        manifest=_string_list_or_none(data.get("manifest")),
+        mcp=_string_list_or_none(data.get("mcp")),
     )
 
 
@@ -382,7 +393,7 @@ def parse_dict(data: dict) -> KnowledgeManifest:
     units = [
         KnowledgeUnit(
             id=u["id"],
-            aliases=[str(a) for a in u["aliases"]] if isinstance(u.get("aliases"), list) else None,
+            aliases=_string_list_or_none(u.get("aliases")),
             path=_validate_unit_path(u["path"]),
             intent=u["intent"],
             scope=u.get("scope", "global"),

--- a/parsers/python/tests/test_aliases_serving.py
+++ b/parsers/python/tests/test_aliases_serving.py
@@ -62,6 +62,34 @@ units:
     assert any("must match" in x for x in w)  # "BAD Alias" fails the char rule
 
 
+def test_malformed_aliases_and_serving_coerce_to_absent():
+    # v0.26 parser parity: a scalar where a list is expected is treated as *absent*
+    # (not coerced into a one-element list), non-string entries are dropped, and a
+    # non-object serving block is absent — matching the TS and Java parsers exactly.
+    m = parse_dict(yaml.safe_load("""
+kcp_version: "0.26"
+project: malformed
+version: 1.0.0
+serving: "https://not-an-object/knowledge.yaml"
+units:
+  - id: u1
+    path: a.txt
+    intent: x
+    scope: global
+    audience: [agent]
+    aliases: reg-art-21-2a
+  - id: u2
+    path: b.txt
+    intent: y
+    scope: global
+    audience: [agent]
+    aliases: [good-alias, null, 42, true]
+"""))
+    assert m.serving is None                       # scalar serving -> absent, no crash
+    assert m.units[0].aliases is None              # scalar aliases -> absent, not ["reg-art-21-2a"]
+    assert m.units[1].aliases == ["good-alias"]    # null/int/bool entries dropped
+
+
 def test_serving_requires_https():
     m = parse_dict(yaml.safe_load("""
 kcp_version: "0.26"

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -98,7 +98,7 @@ function asLicenseOrIndexing(value: unknown): LicenseValue | undefined {
 function parseUnit(raw: RawMap): KnowledgeUnit {
   return {
     id: String(raw["id"] ?? ""),
-    aliases: Array.isArray(raw["aliases"]) ? (raw["aliases"] as unknown[]).map(String) : undefined,
+    aliases: stringListOrUndefined(raw["aliases"]),
     path: validateUnitPath(String(raw["path"] ?? "")),
     intent: String(raw["intent"] ?? ""),
     scope: String(raw["scope"] ?? "global"),
@@ -365,12 +365,26 @@ function parsePayment(raw: unknown): Payment | undefined {
   };
 }
 
+/**
+ * v0.26: coerce a raw value into a string list for `aliases` / `serving`. A non-list is
+ * treated as *absent* (undefined) and non-string entries are dropped — so the TypeScript,
+ * Python, and Java parsers agree byte-for-byte on malformed input instead of one coercing a
+ * scalar to a one-element list while another drops it (a cross-impl divergence that would let
+ * the same signed bytes resolve to different trust decisions). Structural validity (must be a
+ * list of strings) is the JSON schema's job; this keeps the runtime parsers in lockstep.
+ */
+function stringListOrUndefined(raw: unknown): string[] | undefined {
+  return Array.isArray(raw)
+    ? (raw as unknown[]).filter((x): x is string => typeof x === "string")
+    : undefined;
+}
+
 function parseServing(raw: unknown): Serving | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
   const d = raw as RawMap;
   return {
-    manifest: Array.isArray(d["manifest"]) ? (d["manifest"] as unknown[]).map(String) : undefined,
-    mcp: Array.isArray(d["mcp"]) ? (d["mcp"] as unknown[]).map(String) : undefined,
+    manifest: stringListOrUndefined(d["manifest"]),
+    mcp: stringListOrUndefined(d["mcp"]),
   };
 }
 


### PR DESCRIPTION
A four-agent adversarial red-team of the v0.26 features (`serving`/C22 and unit `aliases`) surfaced one genuine fail-open, a cross-implementation parser divergence, and several spec overclaims. All corrected here. **Spec version stays `"0.26"`** — one conformance fix plus clarifications, no new fields; conformant v0.26.0 manifests are unaffected except where a `serving.manifest` mismatch *should* have demoted and previously didn't.

## Security / correctness fixes

- **C22 present-empty fail-open (§3.12).** A present-but-empty `serving.manifest: []` is an *exhaustive-empty* assertion — "no HTTP(S) URL is authoritative" — and MUST demote every HTTP(S) retrieval. The renderer gated on list *length* and treated `[]` as "no assertion", silently keeping `trusted` — reopening the **T11 rogue-representative** attack for MCP-only publishers. Now gates on presence, not length. The demotion warning also no longer claims a demotion when the tier was already below `trusted`.
- **Parser coercion parity (all four).** A YAML scalar where `aliases`/`serving` expect a list, and non-string list entries, now resolve identically across TypeScript/Python/Java: a non-list is *absent* (never coerced into a one-element list) and non-string entries are dropped. Java's `serving:` cast is type-guarded so a non-object block can no longer throw `ClassCastException`. Previously Java coerced scalars while TS/Python dropped them — the same signed bytes could resolve to different trust decisions per implementation.
- **Bridge `get_unit` parity.** All three bridges now match `unit_id` exactly (Python no longer trims whitespace) and never resolve an empty `unit_id`.

## Spec-text hardening (SPEC.md + RFC-0023)

- **§3.12 `serving.mcp` honesty** — C22 covers only `serving.manifest`; the spec now states plainly that `serving.mcp` has no MUST-level consumer enforcement this version (server startup SHOULD-warn + optional client check only), so the rogue-MCP-proxy case is closed only for clients that independently re-fetch and compare.
- **§3.12 "can only add protection"** scoped to pre-v0.26 verifiers, with an operator note (exact post-redirect matching demotes unlisted-but-authentic URLs — enumerate every CDN edge/mirror/redirect target) and two limitations: `serving` is consultable only *after* signature verification (no origin bootstrap), and it binds location not recency (a once-listed URL can replay old signed bytes; anti-rollback needs §4.22 pinning).
- **§4.2a alias char-rule prose** corrected — the alias rule (`^[a-z0-9][a-z0-9._-]*$`) is *close to but not identical* to the `id` rule (permits `_`, forbids a leading `.`/`-`).
- **§4.2a uniqueness reconciled** — a collision is a §7 **warning** (not the contradictory "MUST reject"), with a deterministic tie-break (canonical `id` first, then first-declared alias) so resolution never depends on map ordering. RFC-0023's conformance line updated to match.
- **§4.2a resolver-side MUST** — `depends_on`/`supersedes`/`overrides`/`excludes`/**`external_depends_on`** MUST resolve only canonical `id`, never aliases, including across federation boundaries (closes a cross-manifest reference-hijack).
- **§4.2a citation integrity** — an alias asserts *resolution*, not content-span containment; `content_hash` covers the whole unit, so audit/citation systems MUST NOT treat an alias match as evidence the content contains the aliased element.

## What the red-team cleared (no change needed)

- No rogue host can normalize-collide onto a declared host (userinfo-spoofing resolves to the rogue host and demotes).
- Alias resolution does **not** bypass the C18 temporal or C20 attestation gates in any bridge — both run against the resolved canonical unit; federation shadowing is blocked by canonical-id-first + duplicate-id precedence.

## Tests

New parser/render/bridge tests across all four implementations. Full local sweep: consistency guard **24**, CLI render **79** (5 pre-existing sandbox git-origin-evidence failures, unrelated — they fail on `main` too), TS bridge **239**, Python parsers **174**, Python bridge **170**, Java parsers **158**, Java bridge **170**. Versions bumped to **0.26.1** across CLI + three bridges + `RENDERER_VERSION` + banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC96jSunDgPqxdVa1qFLgN)_