### PR TITLE
fix: publish the CLI as @cantara.no/kcp — npm rejects kcp-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,9 +265,11 @@ jobs:
       - run: npm run build
       - run: npm publish --provenance --access public
 
-  # Publishes kcp-cli (cli/) the same way. No other CI job covers cli/, so this
-  # job runs its build and test suite itself before publishing.
-  publish-kcp-cli:
+  # Publishes @cantara.no/kcp (cli/) the same way. No other CI job covers cli/,
+  # so this job runs its build and test suite itself before publishing.
+  # (The name is scoped: npm's typosquat filter rejects `kcp-cli` — too similar
+  # to cp-cli/cpy-cli — and the bare `kcp` name is held by an unrelated package.)
+  publish-cli:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kcp-cli",
+  "name": "@cantara.no/kcp",
   "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kcp-cli",
+      "name": "@cantara.no/kcp",
       "version": "0.26.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kcp-cli",
+  "name": "@cantara.no/kcp",
   "version": "0.26.0",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",

--- a/guides/kcp-enable-a-github-repo.md
+++ b/guides/kcp-enable-a-github-repo.md
@@ -23,11 +23,11 @@ By the end you will have:
 ## 0. Install the CLI
 
 ```bash
-npm install -g kcp-cli          # provides the `kcp` developer CLI
+npm install -g @cantara.no/kcp  # provides the `kcp` developer CLI
 kcp --help
 ```
 
-No global install? Every command below also works as `npx --package kcp-cli kcp <command>`.
+No global install? Every command below also works as `npx --package @cantara.no/kcp kcp <command>`.
 
 ---
 
@@ -264,7 +264,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
-      - run: npm install -g kcp-cli
+      - run: npm install -g @cantara.no/kcp
       - name: Restore signing key
         env: { KCP_SIGNING_KEY: "${{ secrets.KCP_SIGNING_KEY }}" }
         run: printf '%s' "$KCP_SIGNING_KEY" > /tmp/k.pem && chmod 600 /tmp/k.pem


### PR DESCRIPTION
## Summary
- Follow-up to #122: the first manual publish of `kcp-cli` was rejected by npm's typosquat filter (`403 Package name too similar to existing packages cp-cli, cpy-cli`)
- CLI package renamed `kcp-cli` → **`@cantara.no/kcp`** (scoped under the cantara.no npm org — bypasses the similarity filter, recovers the clean `kcp` name). Binary stays `kcp`
- Guide install instructions and the ci.yml publish job (`publish-cli`) updated to match

## Test plan
- [x] cli build + tests pass after rename
- [x] lockfile regenerated
- [x] ci.yml parses
- [ ] After merge: manual first publish `cd cli && npm publish --access public`, then add the Trusted Publisher on @cantara.no/kcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)