### PR TITLE
fix(cli): ship render-schema in npm tarball + escape scaffolded YAML (0.26.1)

### DIFF
--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.25.1",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.25.1",
+      "version": "0.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/schema/render-schema.json
+++ b/cli/schema/render-schema.json
@@ -1,1 +1,29 @@
-../../schema/render-schema.json
+{
+  "$id": "kcp-render-schema-0.2",
+  "description": "RFC-0018 §6.1 render-schema whitelist. Declares exactly which fields the KCP renderer passes through to agents. This file is the single authoritative source for the whitelist arrays in cli/src/render.ts — update this file to change what the renderer emits. The `free_text` annotation is render-specific and marks fields subject to the §6.2 imperative-mood lint; it has no equivalent in knowledge-schema.json.",
+  "top_scalars": ["project", "version", "updated", "language", "license"],
+  "unit": {
+    "fields": [
+      "id", "aliases", "kind", "path", "intent", "format", "content_type", "language",
+      "scope", "audience", "license", "validated", "update_frequency",
+      "triggers", "not_for", "payment", "rate_limits"
+    ],
+    "free_text": ["intent", "triggers", "not_for"]
+  },
+  "manifest_blocks": ["payment", "rate_limits", "serving"],
+  "content_structure": {
+    "fields": ["primary", "contains", "density"]
+  },
+  "relationship": {
+    "fields": ["from", "to", "type"]
+  },
+  "federation": {
+    "fields": ["id", "url", "relationship", "context", "agent_identity"]
+  },
+  "provenance": {
+    "fields": ["publisher", "publisher_url", "contact", "publisher_did"]
+  },
+  "agent_requirements": {
+    "fields": ["require_attestation", "trusted_providers", "attestation_url", "attestation_jwks", "propagate_to_governed"]
+  }
+}

--- a/cli/src/consistency.test.ts
+++ b/cli/src/consistency.test.ts
@@ -5,8 +5,9 @@
 // cli/ package (cwd = cli) and read sibling files directly.
 
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { lstatSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { SCAFFOLD_KCP_VERSION } from "./init.js";
 
 const REPO = resolve(process.cwd(), "..");
 const r = (p: string) => resolve(REPO, p);
@@ -131,6 +132,31 @@ describe("shared-core single-source-of-truth guard", () => {
       expect(bridge, `bridge/typescript/src/${name}.ts diverged from shared/src/${name}.ts`).toBe(shared);
     });
   }
+});
+
+describe("packaged schema copy", () => {
+  // cli/schema/render-schema.json ships in the npm tarball (package.json
+  // "files"). npm pack SKIPS symlinks, so this must be a regular file — the
+  // 0.26.0 release shipped without it because it was a symlink, and `kcp
+  // sign`/`kcp render` crashed for every npm user. Content equality with the
+  // authoritative root schema is guarded so the copy cannot drift.
+  it("cli/schema/render-schema.json is a regular file, not a symlink", () => {
+    expect(lstatSync(r("cli/schema/render-schema.json")).isSymbolicLink()).toBe(false);
+  });
+
+  it("cli/schema/render-schema.json is byte-identical to schema/render-schema.json", () => {
+    const root = readFileSync(r("schema/render-schema.json"), "utf8");
+    const cli = readFileSync(r("cli/schema/render-schema.json"), "utf8");
+    expect(cli).toBe(root);
+  });
+});
+
+describe("init scaffold version", () => {
+  it("SCAFFOLD_KCP_VERSION matches the current SPEC.md version", () => {
+    const m = readFileSync(r("SPEC.md"), "utf8").match(/\*\*Version:\*\*\s*([\d.]+)/);
+    expect(m, "SPEC.md version header not found").toBeTruthy();
+    expect(SCAFFOLD_KCP_VERSION).toBe(m![1]);
+  });
 });
 
 describe("render-schema.json guards", () => {

--- a/cli/src/init.test.ts
+++ b/cli/src/init.test.ts
@@ -1,0 +1,76 @@
+// Tests for kcp init — scaffold output must always be valid YAML and a valid
+// manifest. Regression: v0.26.0 embedded filename-derived intents containing
+// double quotes without escaping, producing a scaffold that failed `kcp
+// validate` (bad indentation of a mapping entry).
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+import { runInit, SCAFFOLD_KCP_VERSION } from "./init.js";
+import { parseFile } from "./parser.js";
+import { validate } from "./validator.js";
+
+let dir: string;
+let prevCwd: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kcp-init-test-"));
+  prevCwd = process.cwd();
+  process.chdir(dir);
+});
+
+afterEach(() => {
+  process.chdir(prevCwd);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// runInit is non-interactive when stdin is not a TTY (vitest) or yes=true.
+async function scaffold(): Promise<string> {
+  await runInit("knowledge.yaml", true);
+  return readFileSync(join(dir, "knowledge.yaml"), "utf8");
+}
+
+describe("kcp init scaffold", () => {
+  it("escapes double quotes in filename-derived intents (regression: 0.26.0)", async () => {
+    mkdirSync(join(dir, "docs"));
+    // "rate-limits.md" → fallback intent: What is covered in "rate limits"?
+    writeFileSync(join(dir, "docs", "rate-limits.md"), "# API Rate Limits\n");
+
+    const text = await scaffold();
+    const doc = yaml.load(text) as { units: Array<{ intent: string }> };
+    expect(doc.units).toHaveLength(1);
+    expect(doc.units[0].intent).toBe('What is covered in "rate limits"?');
+  });
+
+  it("produces a manifest that passes validation", async () => {
+    mkdirSync(join(dir, "docs"));
+    writeFileSync(join(dir, "README.md"), "# Demo\n");
+    writeFileSync(join(dir, "docs", "rate-limits.md"), "# API Rate Limits\n");
+
+    await scaffold();
+    const manifest = parseFile(join(dir, "knowledge.yaml"));
+    const result = validate(manifest, dir);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("declares the current scaffold kcp_version", async () => {
+    const text = await scaffold();
+    const doc = yaml.load(text) as { kcp_version: string };
+    expect(doc.kcp_version).toBe(SCAFFOLD_KCP_VERSION);
+  });
+
+  it("escapes double quotes in the project name", async () => {
+    // Project name derives from the cwd basename; simulate a quoted name via
+    // a directory literally containing a quote character.
+    const quoted = join(dir, 'my "quoted" project');
+    mkdirSync(quoted);
+    process.chdir(quoted);
+    await runInit("knowledge.yaml", true);
+    const text = readFileSync(join(quoted, "knowledge.yaml"), "utf8");
+    const doc = yaml.load(text) as { project: string };
+    expect(doc.project).toBe('my "quoted" project');
+  });
+});

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -215,6 +215,17 @@ export async function runInit(outputPath: string, yes = false): Promise<void> {
   writeManifest(outputPath, projectName, language, selectedFiles);
 }
 
+// Escape a string for embedding in a double-quoted YAML scalar. Derived
+// intents can contain double quotes (filename-based fallback wraps the name
+// in quotes), which produced invalid YAML when embedded unescaped.
+function yamlQuote(s: string): string {
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+// Scaffolded manifests declare the spec version this CLI release implements.
+// Guarded against the validator's known-version list in consistency.test.ts.
+export const SCAFFOLD_KCP_VERSION = "0.26";
+
 function writeManifest(
   outputPath: string,
   projectName: string,
@@ -224,8 +235,8 @@ function writeManifest(
   const today = new Date().toISOString().slice(0, 10);
 
   const lines: string[] = [
-    `kcp_version: "0.16"`,
-    `project: "${projectName}"`,
+    `kcp_version: "${SCAFFOLD_KCP_VERSION}"`,
+    `project: ${yamlQuote(projectName)}`,
     `version: "1.0.0"`,
     `updated: "${today}"`,
     `language: ${language}`,
@@ -245,7 +256,7 @@ function writeManifest(
     for (const f of selectedFiles) {
       lines.push(`  - id: ${f.suggestedId}`);
       lines.push(`    path: ${f.path}`);
-      lines.push(`    intent: "${f.suggestedIntent}"`);
+      lines.push(`    intent: ${yamlQuote(f.suggestedIntent)}`);
       lines.push(`    scope: ${f.suggestedScope}`);
       lines.push(`    audience: [human, agent]`);
       lines.push(``);


### PR DESCRIPTION
## Summary
- **Published package is broken for `sign`/`render`**: `cli/schema/render-schema.json` was a symlink, and `npm pack` silently skips symlinks — the `@cantara.no/kcp@0.26.0` tarball shipped with no `schema/` at all, so `kcp sign` and `kcp render` crash with ENOENT for every npm user. Fixed by committing a real copy, with consistency guards (must be a regular file, must stay byte-identical to `schema/render-schema.json`).
- **`kcp init` scaffolds invalid YAML** when a filename-derived intent contains double quotes (e.g. `rate-limits.md` → `intent: "What is covered in "rate limits"?"`) — the scaffold fails its own `kcp validate`. Fixed with proper YAML escaping for project name + intents, plus `init.test.ts` regression coverage.
- Scaffold now declares the current spec version instead of the stale `"0.16"`, guarded against `SPEC.md`.
- Versions `cli` and `bridge/typescript` to **0.26.1** so a `v0.26.1` tag can publish both packages without colliding with existing versions.

Both bugs found dogfooding the first npm release in a scratch repo. Fix verified end-to-end: `npm pack` now includes the schema (50 files), and `kcp sign` runs clean from an install of the packed tarball.

## Test plan
- [x] `npm test` — 122/122 (cli), incl. new init regression tests + packaging guards
- [x] `npm run typecheck` + `npm run build` clean
- [x] `npm pack --dry-run` includes `schema/render-schema.json`
- [x] `kcp sign` verified against an install of the locally packed tarball
- [ ] After merge: tag `v0.26.1` → CI publishes `kcp-mcp@0.26.1` + `@cantara.no/kcp@0.26.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)