### PR TITLE
feat: procedural plane (kind: skill) + runtime-depth event contract (#132, #133)

### DIFF
--- a/RFC-0017-Observability-Hooks.md
+++ b/RFC-0017-Observability-Hooks.md
@@ -52,13 +52,14 @@ Each usage event is a row in the `usage_events` table:
 |--------|------|----------|-------------|
 | `id` | INTEGER | yes | Auto-increment row id |
 | `timestamp` | TEXT | yes | ISO 8601 UTC (e.g. `2026-03-27T14:30:00Z`) |
-| `event_type` | TEXT | yes | One of: `search`, `get_unit`, `inject` |
+| `event_type` | TEXT | yes | One of: `search`, `get_unit`, `inject`, `skill_selected`, `plan_formed`, `conclusion`, `action_trace`, `verdict_emitted` |
 | `project` | TEXT | yes | Manifest `project` field value (or basename of working directory) |
 | `query` | TEXT | no | The search query string (`search` events only) |
-| `unit_id` | TEXT | no | The unit id fetched (`get_unit`) or manifest key injected (`inject`) |
+| `unit_id` | TEXT | no | The unit id fetched (`get_unit`), manifest key injected (`inject`), or `kind: skill` unit selected/enacted (lifecycle events) |
 | `result_count` | INTEGER | no | Number of results returned (`search` events only) |
 | `token_estimate` | INTEGER | no | Token estimate of the fetched/injected content (chars / 4) |
 | `manifest_token_total` | INTEGER | no | Sum of `hints.token_estimate` across all units in the manifest |
+| `correlation_id` | TEXT | no | W3C Trace Context `traceparent` (v0.26) stitching the events of one procedural run into a single trace. Reuses `trust.audit.require_trace_context` (SPEC §3.2). |
 | `session_id` | TEXT | no | Opaque session identifier, if available |
 
 ### DDL
@@ -74,12 +75,14 @@ CREATE TABLE IF NOT EXISTS usage_events (
     result_count         INTEGER,
     token_estimate       INTEGER,
     manifest_token_total INTEGER,
+    correlation_id       TEXT,
     session_id           TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON usage_events(timestamp);
-CREATE INDEX IF NOT EXISTS idx_usage_project   ON usage_events(project);
-CREATE INDEX IF NOT EXISTS idx_usage_unit_id   ON usage_events(unit_id);
+CREATE INDEX IF NOT EXISTS idx_usage_timestamp      ON usage_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_usage_project        ON usage_events(project);
+CREATE INDEX IF NOT EXISTS idx_usage_unit_id        ON usage_events(unit_id);
+CREATE INDEX IF NOT EXISTS idx_usage_correlation_id ON usage_events(correlation_id);
 ```
 
 ### Storage convention
@@ -97,10 +100,34 @@ CREATE INDEX IF NOT EXISTS idx_usage_unit_id   ON usage_events(unit_id);
 | `search` | kcp-mcp bridge | Agent calls `search_knowledge` tool |
 | `get_unit` | kcp-mcp bridge | Agent calls `get_unit` tool |
 | `inject` | kcp-commands daemon | Manifest hit served to Claude Code PreToolUse hook |
+| `skill_selected` | procedural runtime | A `kind: skill` unit (SPEC §4.3a) is chosen to enact a task |
+| `plan_formed` | procedural runtime | The agent commits to a plan of steps for the selected skill |
+| `conclusion` | procedural runtime | An intermediate finding or decision reached while enacting the plan |
+| `action_trace` | procedural runtime | A single governed action taken inside the skill's `action_scope` |
+| `verdict_emitted` | procedural runtime | The terminal outcome of the run (success/failure/abstain) |
 
 For `inject` events: `unit_id` is the resolved manifest key (e.g. `git`, `git-log`, `docker-run`),
 `token_estimate` is `max(1, contextLength / 4)` where `contextLength` is the character length of the
 injected `additionalContext` string, and `project` is the basename of the working directory (`cwd`).
+
+### Runtime-depth lifecycle events (v0.26)
+
+The five lifecycle events — `skill_selected`, `plan_formed`, `conclusion`, `action_trace`,
+`verdict_emitted` — record the *procedural plane*: what an agent did after a `kind: skill` unit
+(SPEC §4.3a) was selected, not merely which knowledge it read. For these events `unit_id` is the
+skill's unit id, and all events of one procedural run share a single `correlation_id`.
+
+The `correlation_id` carries a [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+`traceparent` value, so a run's events can be reconstructed in order and correlated with the
+HTTP access chain that `trust.audit.require_trace_context` (SPEC §3.2) governs. When a skill is
+enacted over local file access rather than HTTP, the runtime SHOULD still generate a
+conforming `traceparent` and record it here — mirroring the local-access guidance in §3.2 — so
+every run is traceable regardless of transport. `correlation_id` is OPTIONAL on the pre-existing
+`search`/`get_unit`/`inject` events and is not required for KCP conformance.
+
+These events are subject to the same **local-only** posture as all rows in `usage_events`:
+implementations MUST NOT transmit them to external services without explicit user consent
+(see *Privacy note* below).
 
 ### `tokens_saved` calculation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1500,7 +1500,8 @@ a parse error. The manifest may describe knowledge that has not yet been created
 The `kind` field declares what type of artifact a knowledge unit represents. It provides a
 machine-readable dispatch signal that tells agents how to interact with the unit: load and
 embed (knowledge), parse as a structured definition (schema), invoke via protocol (service),
-evaluate as a gate (policy), or run on demand (executable).
+evaluate as a gate (policy), run on demand (executable), or select and enact as a governed
+procedure (skill).
 
 | Value | Meaning | Agent behaviour |
 |-------|---------|-----------------|
@@ -1509,6 +1510,7 @@ evaluate as a gate (policy), or run on demand (executable).
 | `service` | A running or callable endpoint: API, MCP server, webhook | Invoke via protocol |
 | `policy` | Rules, constraints, compliance documents | Evaluate as authoritative gate |
 | `executable` | Runnable artifacts: scripts, notebooks, workflow definitions | Invoke on demand |
+| `skill` | A governed, executable procedure or playbook | Select like knowledge; enact within a declared `action_scope` |
 
 If `kind` is omitted, parsers MUST treat the unit as `kind: knowledge`. This ensures full
 backward compatibility with v0.2 manifests.
@@ -1518,6 +1520,44 @@ Unknown `kind` values MUST be silently ignored by parsers.
 ```yaml
 kind: schema
 ```
+
+#### `kind: skill` (v0.26)
+
+A `kind: skill` unit is a governed, *executable* procedure or playbook — a repeatable sequence
+of steps an agent enacts, not prose it merely reads. It sits on the boundary between the
+declarative plane (knowledge that is loaded) and the procedural plane (procedures that are run):
+its **selection** is gated exactly like `knowledge` — the same intent-matching, `audience`,
+`scope`, temporal validity (§4.22), and negative-space (§4.20) signals decide whether the skill
+is offered to an agent — while its **enaction** is governed like an `executable`, constrained by
+an explicitly declared envelope of the tools, paths, and capabilities it is permitted to touch.
+
+That envelope is the `action_scope` object (all sub-fields OPTIONAL):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tools` | array of string | Tool names the procedure may invoke. |
+| `paths` | array of string | File-system paths (globs permitted) the procedure may read or write. |
+| `capabilities` | array of string | Named capabilities the procedure requires or exercises. |
+
+```yaml
+- id: rotate-signing-key
+  path: skills/rotate-signing-key.md
+  kind: skill
+  intent: "How do I rotate the manifest signing key safely?"
+  scope: project
+  audience: [agent, operator]
+  action_scope:
+    tools: [kcp-sign, git]
+    paths: ["schema/**", ".well-known/kcp-signing-key"]
+    capabilities: [key-management]
+```
+
+`action_scope` is advisory metadata at the parser level — declaring it carries no cryptographic
+weight — but it is the input a trusted renderer (§16) and a conformance checker use to decide
+whether the skill may be invoked and to bound what it may reach when it is. A skill fails closed
+by default like `executable`/`service`: absent an explicit eligibility grant it renders as a
+pointer with `invocation: explicit` (§16.3, C4). Skills are the manifest-declared counterpart of
+the runtime-depth lifecycle recorded in §17 (`skill_selected` … `verdict_emitted`).
 
 ### 4.4 `intent`
 
@@ -3761,7 +3801,11 @@ corroboration confirms the manifest's presence at the origin, not the checkout's
 - **Kind-based load eligibility.** Units of `kind: service` or `kind: executable` — and units
   with an *unknown* `kind`, which fail closed here even though parsers treat them leniently
   (§4.3a) — are never load-eligible at any tier. They render as pointers with
-  `invocation: explicit`.
+  `invocation: explicit`. A `kind: skill` unit (§4.3a) is governed the same way: it **fails
+  closed by default** — rendering as a pointer with `invocation: explicit` — and becomes
+  load/invoke-eligible only when the manifest carries an explicit eligibility grant for it,
+  bounded by its declared `action_scope`. The default matches `executable`/`service`; the
+  explicit-grant exception is what distinguishes a skill from a bare executable.
 - **Stats identity.** `sanitization.stats` counts leaf fields:
   `fields_in = fields_rendered + fields_dropped + fields_quarantined`.
 
@@ -3781,9 +3825,12 @@ minimum trigger `on_failure: warn` (§3.6). Pinning applies per-edge.
 A conforming renderer satisfies C1–C10 (RFC-0018), C11–C14 (RFC-0019, v0.18), C15 (RFC-0020, v0.19), C16 (v0.20), C17 (RFC-0022, v0.21), C18 (RFC-0021, v0.21), C19–C21 (RFC-0004/0002, v0.22), and C22 (RFC-0024, v0.26):
 
 - **C1–C10** (RFC-0018): determinism (C1), fail-closed emission (C2), schema-only output (C3),
-  no `load_eligible: true` on executable/service/unknown kinds (C4), no auto-traversal below
-  `trusted` (C5), recorded drops and quarantines (C6), LLM-free (C7), data-framed content at
-  every tier (C8), consumer-installed renderer only (C9), in-session artifact verification (C10).
+  no `load_eligible: true` on executable/service/unknown kinds — nor on a `kind: skill` unit
+  (§4.3a) that lacks an explicit eligibility grant, which fails closed by default and becomes
+  load/invoke-eligible only when explicitly granted, bounded by its `action_scope` (C4) — no
+  auto-traversal below `trusted` (C5), recorded drops and quarantines (C6), LLM-free (C7),
+  data-framed content at every tier (C8), consumer-installed renderer only (C9), in-session
+  artifact verification (C10).
 - **C11** (v0.18): Verifies every declared `content_hash` at render time; forces
   `load_eligible: false` with both digests recorded on mismatch; never emits
   `content_verified: true` without a matching digest.
@@ -3875,9 +3922,15 @@ convention: bridges and renderers MAY record events to a well-known SQLite datab
 
 Three tables:
 
-- **`usage_events`** — bridge query traffic. Columns: `timestamp`, `event_type`
-  (`search` | `get_unit` | `inject`), `project`, `query`, `unit_id`, `result_count`,
-  `token_estimate`, `manifest_token_total`. Defined in RFC-0017 §"Event schema".
+- **`usage_events`** — bridge query traffic and the runtime-depth procedural lifecycle. Columns:
+  `timestamp`, `event_type` (`search` | `get_unit` | `inject` | `skill_selected` |
+  `plan_formed` | `conclusion` | `action_trace` | `verdict_emitted`), `project`, `query`,
+  `unit_id`, `result_count`, `token_estimate`, `manifest_token_total`, `correlation_id` (the
+  W3C Trace Context `traceparent` that stitches one procedural run's events into a single trace;
+  reuses `trust.audit.require_trace_context`, §3.2). Defined in RFC-0017 §"Event schema". The
+  five lifecycle events (`skill_selected` → `verdict_emitted`) are the observable counterpart of
+  a `kind: skill` unit (§4.3a). This data remains **local-only**: implementations MUST NOT
+  transmit usage events to external services without explicit user consent.
 - **`render_events`** — one row per render: `timestamp`, `source_path`, `source_sha256`,
   `origin`, `tier`, `pinned`, `renderer_version`, `lint_rules`, and the four stats counters.
 - **`quarantine_events`** — one row per quarantined field, referencing `render_events(id)`:

--- a/cli/src/render.test.ts
+++ b/cli/src/render.test.ts
@@ -272,6 +272,28 @@ units:
     expect(doc.units[0].invocation).toBe("explicit");
   });
 
+  it("never sets load_eligible on kind: skill by default, even when trusted (C4)", () => {
+    const manifestPath = writeManifest(`project: test
+version: 1.0.0
+units:
+  - id: rotate-signing-key
+    kind: skill
+    path: skills/rotate-signing-key.md
+    intent: "How do I rotate the manifest signing key safely?"
+`);
+    // make it trusted: signed + allowlisted, so tier-dependence cannot mask the rule
+    const pub = signManifest(manifestPath, "org-key");
+    const keysPath = writeAllowlist([
+      { key_id: "org-key", method: "jws", algorithm: "EdDSA", public_key: pub },
+    ]);
+
+    const { doc } = renderOk(manifestPath, { keysPath });
+    expect(doc.trust.tier).toBe("trusted");
+    expect(doc.units[0].load_eligible).toBe(false);
+    expect(doc.units[0].invocation).toBe("explicit");
+    expect(doc.units[0].kind).toBe("skill"); // known kind, not dropped as unknown
+  });
+
   it("fails closed on unknown kind values (§6.3)", () => {
     const manifestPath = writeManifest(`project: test
 version: 1.0.0

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -39,8 +39,10 @@ export const RENDERER_VERSION = "kcp-cli 0.26.1";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 
-const KNOWN_KINDS = ["knowledge", "schema", "policy", "service", "executable"];
-const NEVER_LOAD_KINDS = ["service", "executable"];
+const KNOWN_KINDS = ["knowledge", "schema", "policy", "service", "executable", "skill"];
+// skill fails closed by default like executable/service (§4.3a, §16.3 C4); an explicit
+// eligibility grant is required to make it load/invoke-eligible.
+const NEVER_LOAD_KINDS = ["service", "executable", "skill"];
 
 // Render-schema whitelist (§6.1) — loaded from the authoritative
 // schema/render-schema.json (the file RENDER_SCHEMA names). Update

--- a/conformance/fixtures/level2/invalid-skill-missing-intent.expected.json
+++ b/conformance/fixtures/level2/invalid-skill-missing-intent.expected.json
@@ -1,0 +1,8 @@
+{
+  "valid": false,
+  "errors": ["unit 'rotate-signing-key' missing required field 'intent'"],
+  "unit_count": 1,
+  "relationship_count": 0,
+  "_note": "Python parser raises KeyError during parsing (parse_error). Java/TypeScript reach validation. Both behaviours are acceptable — the skill unit is rejected either way.",
+  "parse_error_also_acceptable": true
+}

--- a/conformance/fixtures/level2/invalid-skill-missing-intent.yaml
+++ b/conformance/fixtures/level2/invalid-skill-missing-intent.yaml
@@ -1,0 +1,16 @@
+# Level 2 — kind: skill unit declares an action_scope but omits the required 'intent'.
+# A skill is selected like knowledge (§4.3a), so it is held to the same required-field
+# discipline: an envelope without a routing intent is not a loadable/selectable unit.
+kcp_version: "0.26"
+project: test-skill-missing-intent
+version: "1.0.0"
+
+units:
+  - id: rotate-signing-key
+    path: skills/rotate-signing-key.md
+    kind: skill
+    scope: project
+    audience: [agent, operator]
+    action_scope:
+      tools: [kcp-sign, git]
+      paths: ["schema/**"]

--- a/conformance/fixtures/level2/valid-skill-action-scope.expected.json
+++ b/conformance/fixtures/level2/valid-skill-action-scope.expected.json
@@ -1,0 +1,6 @@
+{
+  "valid": true,
+  "errors": [],
+  "unit_count": 2,
+  "relationship_count": 0
+}

--- a/conformance/fixtures/level2/valid-skill-action-scope.yaml
+++ b/conformance/fixtures/level2/valid-skill-action-scope.yaml
@@ -1,0 +1,25 @@
+# Level 2 — kind: skill unit with an action_scope envelope (§4.3a, v0.26)
+kcp_version: "0.26"
+project: test-skill
+version: "1.0.0"
+
+units:
+  - id: rotate-signing-key
+    path: skills/rotate-signing-key.md
+    kind: skill
+    intent: "How do I rotate the manifest signing key safely?"
+    scope: project
+    audience: [agent, operator]
+    action_scope:
+      tools: [kcp-sign, git]
+      paths: ["schema/**", ".well-known/kcp-signing-key"]
+      capabilities: [key-management]
+
+  - id: reindex-catalog
+    path: skills/reindex-catalog.md
+    kind: skill
+    intent: "How do I rebuild the catalog index after a bulk import?"
+    scope: project
+    audience: [agent]
+    action_scope:
+      capabilities: [catalog-write]

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -49,7 +49,7 @@ public class KcpValidator {
     private static final Set<String> VALID_SCOPES = Set.of("global", "project", "module");
     private static final Set<String> VALID_AUDIENCES = Set.of("human", "agent", "developer", "operator", "architect", "devops");
     private static final Set<String> VALID_RELATIONSHIP_TYPES = Set.of("enables", "context", "supersedes", "contradicts", "depends_on", "governs");
-    private static final Set<String> VALID_KINDS = Set.of("knowledge", "schema", "service", "policy", "executable");
+    private static final Set<String> VALID_KINDS = Set.of("knowledge", "schema", "service", "policy", "executable", "skill");
     private static final Set<String> VALID_FORMATS = Set.of(
             "markdown", "pdf", "openapi", "json-schema", "jupyter",
             "html", "asciidoc", "rst", "vtt", "yaml", "json", "csv", "text");

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -84,7 +84,7 @@ def compute_content_digest(target: str, algorithm: str) -> Optional[str]:
 VALID_SCOPES = {"global", "project", "module"}
 VALID_AUDIENCES = {"human", "agent", "developer", "operator", "architect", "devops"}
 VALID_RELATIONSHIP_TYPES = {"enables", "context", "supersedes", "contradicts", "depends_on", "governs"}
-VALID_KINDS = {"knowledge", "schema", "service", "policy", "executable"}
+VALID_KINDS = {"knowledge", "schema", "service", "policy", "executable", "skill"}
 VALID_FORMATS = {
     "markdown", "pdf", "openapi", "json-schema", "jupyter",
     "html", "asciidoc", "rst", "vtt", "yaml", "json", "csv", "text",

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -174,9 +174,30 @@
         },
         "kind": {
           "type": "string",
-          "description": "Type of artifact. Default: knowledge. Values: knowledge (documentation), schema (machine-readable definition), service (callable endpoint), policy (authoritative rules), executable (runnable artifact).",
-          "enum": ["knowledge", "schema", "service", "policy", "executable"],
+          "description": "Type of artifact. Default: knowledge. Values: knowledge (documentation), schema (machine-readable definition), service (callable endpoint), policy (authoritative rules), executable (runnable artifact), skill (governed executable procedure/playbook whose selection is gated like knowledge; declares an action_scope). See SPEC.md §4.3a.",
+          "enum": ["knowledge", "schema", "service", "policy", "executable", "skill"],
           "default": "knowledge"
+        },
+        "action_scope": {
+          "type": "object",
+          "description": "The tools, paths, and capabilities a procedure or skill is permitted to touch (v0.26). Advisory declaration surfaced to agents and used for conformance checking of a kind: skill unit. All sub-fields OPTIONAL. See SPEC.md §4.3a.",
+          "properties": {
+            "tools": {
+              "type": "array",
+              "description": "Tool names the procedure may invoke.",
+              "items": { "type": "string" }
+            },
+            "paths": {
+              "type": "array",
+              "description": "File-system paths (globs permitted) the procedure may read or write.",
+              "items": { "type": "string" }
+            },
+            "capabilities": {
+              "type": "array",
+              "description": "Named capabilities the procedure requires or exercises.",
+              "items": { "type": "string" }
+            }
+          }
         },
         "intent": {
           "type": "string",

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -79,7 +79,8 @@ export interface KnowledgeUnit {
   intent: string;
   scope: string;           // "global" | "project" | "module"
   audience: string[];
-  kind?: string;           // "knowledge" | "schema" | "service" | "policy" | "executable"
+  kind?: string;           // "knowledge" | "schema" | "service" | "policy" | "executable" | "skill"
+  action_scope?: ActionScope;  // §4.3a (v0.26) — tools/paths/capabilities a kind: skill procedure may touch
   format?: string;         // "markdown" | "pdf" | "openapi" | "json-schema" | etc.
   content_type?: string;
   language?: string;
@@ -111,6 +112,13 @@ export interface KnowledgeUnit {
   content_structure?: ContentStructure;  // RFC-0016 (v0.17)
   content_hash?: ContentHash;  // RFC-0019 (draft)
   temporal?: Temporal;          // RFC-0010 / §4.22 (v0.19)
+}
+
+/** Envelope of tools/paths/capabilities a `kind: skill` procedure may touch. See SPEC.md §4.3a (v0.26). */
+export interface ActionScope {
+  tools?: string[];         // tool names the procedure may invoke
+  paths?: string[];         // file-system paths (globs permitted) the procedure may read/write
+  capabilities?: string[];  // named capabilities the procedure requires or exercises
 }
 
 export interface Relationship {

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from "node:fs";
 import yaml from "js-yaml";
 import type {
+  ActionScope,
   Auth,
   AuthMethod,
   Authority,
@@ -104,6 +105,7 @@ function parseUnit(raw: RawMap): KnowledgeUnit {
     scope: String(raw["scope"] ?? "global"),
     audience: asStringArray(raw["audience"]),
     kind: raw["kind"] !== undefined ? String(raw["kind"]) : undefined,
+    action_scope: parseActionScope(raw["action_scope"]),
     format: raw["format"] !== undefined ? String(raw["format"]) : undefined,
     content_type:
       raw["content_type"] !== undefined
@@ -385,6 +387,17 @@ function parseServing(raw: unknown): Serving | undefined {
   return {
     manifest: stringListOrUndefined(d["manifest"]),
     mcp: stringListOrUndefined(d["mcp"]),
+  };
+}
+
+/** §4.3a (v0.26): the tools/paths/capabilities a `kind: skill` procedure may touch. */
+function parseActionScope(raw: unknown): ActionScope | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const d = raw as RawMap;
+  return {
+    tools: stringListOrUndefined(d["tools"]),
+    paths: stringListOrUndefined(d["paths"]),
+    capabilities: stringListOrUndefined(d["capabilities"]),
   };
 }
 

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -63,6 +63,7 @@ const VALID_KINDS = new Set([
   "service",
   "policy",
   "executable",
+  "skill",
 ]);
 const VALID_REL_TYPES = new Set([
   "enables",


### PR DESCRIPTION
Realizes the **procedural plane** (#132) and the **runtime-depth event contract** (#133).

- `schema`: add `"skill"` to the unit `kind` enum; add optional `action_scope { tools?, paths?, capabilities? }`.
- `SPEC.md §4.3a`: `kind: skill` — a governed *executable* procedure; selection gated like knowledge, enaction bounded by `action_scope`; **fails closed by default**, load/invoke-eligible only with an explicit grant. §16.3/§16.5 C4 amended.
- `SPEC §17` + `RFC-0017`: `usage_events.event_type` gains `skill_selected | plan_formed | conclusion | action_trace | verdict_emitted`; new `correlation_id` column carrying W3C `traceparent` (reusing §3.2 `require_trace_context`); local-only posture kept.
- Cross-language: `"skill"` added to TS/Python/Java validators; `ActionScope` in shared model/parser; conformance fixtures (valid + invalid).

Tests: cli vitest **126/126**; conformance harness **56/0** in all three runners. No version bump (tagged v0.26 draft). Surfaced via ExoCortex while writing the defendable-agents explainer.