### PR TITLE
docs: fix stale version claims, document kind:skill bridge parity gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Until formal acceptance, KCP remains an Apache 2.0 open specification proposed b
 
 ## Status
 
-**Current:** Draft specification — v0.21 (there is no v0.15 spec; the number was skipped to re-sync with the `kcp` CLI release train)
+**Current:** Draft specification — v0.26 (there is no v0.15 spec; the number was skipped to re-sync with the `kcp` CLI release train)
 
 The format is intentionally minimal and builds incrementally through promoted RFCs. Feedback, use cases, and pull requests are welcome.
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.25.1 (all three bridges — aligned with KCP spec version)
+**Current version:** 0.26.0 (all three bridges — aligned with KCP spec version). Spec is at v0.26.1 (2026-07-22, `kind: skill` procedural plane) — see **Known gaps** below, this has not yet reached bridge parity.
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -88,9 +88,23 @@ When adding any MCP capability:
 
 ---
 
-## Known Python gaps (Tier 1)
+## Known gaps (all bridges) — v0.26.1 `kind: skill`
 
-No known gaps — all three bridges are at full parity.
+Spec v0.26.1 (2026-07-22, #134) added the procedural plane: `kind: skill` units and the
+`action_scope` field (§4.3a — the tools/paths/capabilities a skill procedure may touch).
+Verified 2026-07-22:
+
+- **TypeScript** — `bridge/typescript/src/model.ts` and `parser.ts` are symlinks to
+  `shared/src/`, which was updated by #134, so parsing/validation of `kind: skill` and
+  `action_scope` is already current. However, `mapper.ts`'s manifest-entry builder
+  (~line 268) does not include `action_scope` in the fields it copies onto the exposed
+  unit entry — it is parsed but not surfaced. Needs a one-line fix + a mapper test.
+- **Java** (`bridge/java/`) and **Python** (`bridge/python/`) — not symlinked, real
+  separate source trees. Zero references to `action_scope` or `"skill"` found in either.
+  Full Tier 1 port required (see **Rule** above) before the next version bump.
+
+This is a real parity gap, not yet closed — tracked here rather than silently left off
+this table. Do not claim "full parity" again until all three items above are done.
 
 ---
 


### PR DESCRIPTION
## Summary
- README.md said "v0.21" — actual spec version is v0.26.
- PARITY.md header said 0.25.1 while its own version-history table already listed 0.26.0 — self-contradiction.
- Documented the real, previously-unrecorded parity gap for v0.26.1's `kind: skill` / `action_scope` (#134): TS bridge inherits parsing via its `shared/` symlink but drops `action_scope` in `mapper.ts`'s manifest-entry builder; Java and Python bridges (separate, non-symlinked source) have zero references to it yet.

Part of a ship-safety audit across kcp-memory/kcp-harness/kcp-agent/this repo.

## Test plan
- [x] Verified symlink structure (`bridge/typescript/src/model.ts` → `shared/src/model.ts`) directly
- [x] Verified zero `action_scope`/`"skill"` references in bridge/java, bridge/python via grep
- Docs-only change, no code/behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)