### PR TITLE
feat: action_scope.spend — govern what a skill may buy (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`action_scope.spend` — the spend dimension of a `kind: skill` envelope (§4.3a).** A skill may
+  now declare what it is permitted to **buy** alongside the tools/paths/capabilities it may touch:
+  an optional `spend` object with a per-purchase `max_spend` cap, an `allowed_vendors` allowlist,
+  and the `currency` the cap is denominated in (all sub-fields OPTIONAL; `action_scope` stays an
+  opaque passthrough object). The conformance gate adjudicates purchases fail-closed the way it does
+  `tools`/`paths` — an unlisted vendor or over-cap buy is held — composing with (never overriding)
+  the session-cumulative `money_budget` ceiling of §4.14. The purchase **price** comes from the paid
+  resource's own `payment`/`price_per_request` declaration (§4.14, x402): KCP governs the buy
+  *decision*, a runtime wallet settles. Additive and backward-compatible. (#139)
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1529,7 +1529,7 @@ declarative plane (knowledge that is loaded) and the procedural plane (procedure
 its **selection** is gated exactly like `knowledge` — the same intent-matching, `audience`,
 `scope`, temporal validity (§4.22), and negative-space (§4.20) signals decide whether the skill
 is offered to an agent — while its **enaction** is governed like an `executable`, constrained by
-an explicitly declared envelope of the tools, paths, and capabilities it is permitted to touch.
+an explicitly declared envelope of the tools, paths, capabilities, and spend it is permitted to touch.
 
 That envelope is the `action_scope` object (all sub-fields OPTIONAL):
 
@@ -1538,6 +1538,7 @@ That envelope is the `action_scope` object (all sub-fields OPTIONAL):
 | `tools` | array of string | Tool names the procedure may invoke. |
 | `paths` | array of string | File-system paths (globs permitted) the procedure may read or write. |
 | `capabilities` | array of string | Named capabilities the procedure requires or exercises. |
+| `spend` | object | Purchases the procedure may make: a per-purchase `max_spend` cap, an `allowed_vendors` allowlist, and the `currency` the cap is denominated in (all OPTIONAL). |
 
 ```yaml
 - id: rotate-signing-key
@@ -1550,7 +1551,23 @@ That envelope is the `action_scope` object (all sub-fields OPTIONAL):
     tools: [kcp-sign, git]
     paths: ["schema/**", ".well-known/kcp-signing-key"]
     capabilities: [key-management]
+    spend:
+      max_spend: 5.00
+      allowed_vendors: [github, cloudflare]
+      currency: USD
 ```
+
+The `spend` sub-object governs **purchases** a skill may make. Like `tools` and `paths`, it is
+adjudicated fail-closed by the conformance gate: a purchase whose payee is not in
+`allowed_vendors`, or whose price exceeds `max_spend` (denominated in `currency`), is *held* — a
+declared-but-unmatched buy is refused the same way a call to an undeclared tool or a write to an
+undeclared path is. `max_spend` bounds a **single** purchase; it composes with — and never
+overrides — the session-cumulative `money_budget` ceiling of §4.14: a buy proceeds only if it
+clears *both* the per-purchase `spend` envelope here and the cumulative budget there, and either
+gate can hold it. The purchase **price** itself is not declared here — it comes from the paid
+resource's own `payment` / `price_per_request` declaration (§4.14, x402): KCP governs the buy
+*decision* against the declared envelope, while a runtime wallet performs the settlement. KCP
+dereferences no wallet and moves no funds.
 
 `action_scope` is advisory metadata at the parser level — declaring it carries no cryptographic
 weight — but it is the input a trusted renderer (§16) and a conformance checker use to decide

--- a/conformance/fixtures/level2/valid-skill-action-scope-spend.expected.json
+++ b/conformance/fixtures/level2/valid-skill-action-scope-spend.expected.json
@@ -1,0 +1,6 @@
+{
+  "valid": true,
+  "errors": [],
+  "unit_count": 2,
+  "relationship_count": 0
+}

--- a/conformance/fixtures/level2/valid-skill-action-scope-spend.yaml
+++ b/conformance/fixtures/level2/valid-skill-action-scope-spend.yaml
@@ -1,0 +1,33 @@
+# Level 2 — kind: skill unit whose action_scope declares a spend envelope (§4.3a, v0.26)
+# spend governs the purchases a skill may make: a per-purchase max_spend cap, an
+# allowed_vendors allowlist, and the currency the cap is denominated in. All sub-fields
+# are OPTIONAL and action_scope remains an opaque passthrough object.
+kcp_version: "0.26"
+project: test-skill-spend
+version: "1.0.0"
+
+units:
+  - id: provision-ci-runner
+    path: skills/provision-ci-runner.md
+    kind: skill
+    intent: "How do I provision an on-demand CI runner within budget?"
+    scope: project
+    audience: [agent, operator]
+    action_scope:
+      tools: [terraform, gh]
+      capabilities: [infra-provision]
+      spend:
+        max_spend: 25.00
+        allowed_vendors: [github, aws]
+        currency: USD
+
+  - id: buy-research-credit
+    path: skills/buy-research-credit.md
+    kind: skill
+    intent: "How do I purchase a paid research report if within cap?"
+    scope: project
+    audience: [agent]
+    action_scope:
+      spend:
+        max_spend: 0.05
+        currency: USDC

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -180,7 +180,7 @@
         },
         "action_scope": {
           "type": "object",
-          "description": "The tools, paths, and capabilities a procedure or skill is permitted to touch (v0.26). Advisory declaration surfaced to agents and used for conformance checking of a kind: skill unit. All sub-fields OPTIONAL. See SPEC.md §4.3a.",
+          "description": "The tools, paths, capabilities, and spend a procedure or skill is permitted to touch (v0.26). Advisory declaration surfaced to agents and used for conformance checking of a kind: skill unit. All sub-fields OPTIONAL. See SPEC.md §4.3a.",
           "properties": {
             "tools": {
               "type": "array",
@@ -196,6 +196,25 @@
               "type": "array",
               "description": "Named capabilities the procedure requires or exercises.",
               "items": { "type": "string" }
+            },
+            "spend": {
+              "type": "object",
+              "description": "Purchases the procedure may make (v0.26). Governs the buy decision fail-closed alongside the session-cumulative money_budget ceiling (§4.14). All sub-fields OPTIONAL.",
+              "properties": {
+                "max_spend": {
+                  "type": "number",
+                  "description": "Per-purchase spend cap, in units of 'currency'. A purchase exceeding this is held."
+                },
+                "allowed_vendors": {
+                  "type": "array",
+                  "description": "Allowlist of vendor/payee identifiers the procedure may pay. A purchase to an unlisted vendor is held.",
+                  "items": { "type": "string" }
+                },
+                "currency": {
+                  "type": "string",
+                  "description": "ISO 4217 code (USD, EUR) or crypto ticker (USDC, ETH) that 'max_spend' is denominated in."
+                }
+              }
             }
           }
         },

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -114,11 +114,19 @@ export interface KnowledgeUnit {
   temporal?: Temporal;          // RFC-0010 / §4.22 (v0.19)
 }
 
-/** Envelope of tools/paths/capabilities a `kind: skill` procedure may touch. See SPEC.md §4.3a (v0.26). */
+/** Purchases a `kind: skill` procedure may make. See SPEC.md §4.3a (v0.26). */
+export interface Spend {
+  max_spend?: number;         // per-purchase cap, denominated in `currency`
+  allowed_vendors?: string[]; // allowlist of vendor/payee identifiers the procedure may pay
+  currency?: string;          // ISO 4217 code or crypto ticker `max_spend` is denominated in
+}
+
+/** Envelope of tools/paths/capabilities/spend a `kind: skill` procedure may touch. See SPEC.md §4.3a (v0.26). */
 export interface ActionScope {
   tools?: string[];         // tool names the procedure may invoke
   paths?: string[];         // file-system paths (globs permitted) the procedure may read/write
   capabilities?: string[];  // named capabilities the procedure requires or exercises
+  spend?: Spend;            // purchases the procedure may make (per-purchase cap + vendor allowlist)
 }
 
 export interface Relationship {

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import yaml from "js-yaml";
 import type {
   ActionScope,
+  Spend,
   Auth,
   AuthMethod,
   Authority,
@@ -390,7 +391,7 @@ function parseServing(raw: unknown): Serving | undefined {
   };
 }
 
-/** §4.3a (v0.26): the tools/paths/capabilities a `kind: skill` procedure may touch. */
+/** §4.3a (v0.26): the tools/paths/capabilities/spend a `kind: skill` procedure may touch. */
 function parseActionScope(raw: unknown): ActionScope | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
   const d = raw as RawMap;
@@ -398,6 +399,18 @@ function parseActionScope(raw: unknown): ActionScope | undefined {
     tools: stringListOrUndefined(d["tools"]),
     paths: stringListOrUndefined(d["paths"]),
     capabilities: stringListOrUndefined(d["capabilities"]),
+    spend: parseSpend(d["spend"]),
+  };
+}
+
+/** §4.3a (v0.26): purchases a `kind: skill` procedure may make. */
+function parseSpend(raw: unknown): Spend | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const d = raw as RawMap;
+  return {
+    max_spend: d["max_spend"] !== undefined ? Number(d["max_spend"]) : undefined,
+    allowed_vendors: stringListOrUndefined(d["allowed_vendors"]),
+    currency: d["currency"] !== undefined ? String(d["currency"]) : undefined,
   };
 }
 


### PR DESCRIPTION
Adds `action_scope.spend { max_spend, allowed_vendors, currency }` to the schema + SPEC §4.3a — the money corner of the procedural plane (#139). Conformance adjudicates purchases (vendor + currency + max_spend, fail-closed) composing with the money_budget ceiling; x402 join documented. Conformance 57/57 (TS/Python/Java); `action_scope` stays passthrough (TS parser gains a typed `Spend`). Surfaced via ExoCortex.