### PR TITLE
ci: guard against raw NUL bytes in tracked source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
+      - run: ./scripts/check-nul-bytes.sh
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/scripts/check-nul-bytes.sh
+++ b/scripts/check-nul-bytes.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Fail if any tracked text/source file contains a raw NUL byte.
+#
+# Raw NULs in source are a runtime-parity hazard: node parses them fine, but
+# bun's transpiler mangles them — the same bytes produced different verdicts
+# per runtime in kcp-harness#51. Write backslash-u0000 escapes instead of raw bytes.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Self-test first: grep needs -a here — without it, binary-classified files
+# silently no-match and the sweep reports a false clean. Prove the detector
+# can see a planted NUL before trusting it.
+probe="$(mktemp)"
+printf 'x\x00y' > "$probe"
+if ! grep -qaP '\x00' "$probe"; then
+  rm -f "$probe"
+  echo "check-nul-bytes: self-test failed — detector cannot see NUL bytes" >&2
+  exit 2
+fi
+rm -f "$probe"
+
+bad="$(git ls-files \
+  | grep -E '\.(ts|js|mjs|cjs|json|ya?ml|md|sh|txt|html|css|py|java|rs|toml)$' \
+  | xargs -d '\n' --no-run-if-empty grep -alP '\x00' 2>/dev/null || true)"
+
+if [ -n "$bad" ]; then
+  echo "Raw NUL bytes found in tracked source files:" >&2
+  echo "$bad" >&2
+  echo 'Replace raw NUL bytes with backslash-u0000 escape sequences (see Cantara/kcp-harness#51).' >&2
+  exit 1
+fi
+echo "check-nul-bytes: clean"


### PR DESCRIPTION
Family-wide NUL sweep (context: Cantara/kcp-harness#51, where raw NUL bytes in source produced different behavior under node vs bun). This repo is clean — the guard keeps it that way: `scripts/check-nul-bytes.sh` fails CI on any raw NUL in tracked source files, and self-tests its detector first (`grep -P` without `-a` silently no-matches on binary-classified files — a false clean, not an error).

Same guard lands in pi-kcp, kcp-harness, kcp-agent, and kcp-skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS3EX1Y56oQJTnE5zxjhJg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FS3EX1Y56oQJTnE5zxjhJg)_