### PR TITLE
spec: define action_scope.spend (§4.3a.1); drop a fabricated §4.14 citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   an optional `spend` object with a per-purchase `max_spend` cap, an `allowed_vendors` allowlist,
   and the `currency` the cap is denominated in (all sub-fields OPTIONAL; `action_scope` stays an
   opaque passthrough object). The conformance gate adjudicates purchases fail-closed the way it does
-  `tools`/`paths` — an unlisted vendor or over-cap buy is held — composing with (never overriding)
-  the session-cumulative `money_budget` ceiling of §4.14. The purchase **price** comes from the paid
+  `tools`/`paths` — an unlisted vendor or over-cap buy is held — composing with (never overriding) a
+  cumulative session budget where the caller maintains one — that budget is supplied at run
+  time and is deliberately not a manifest field (§4.3a.1). The purchase **price** comes from the paid
   resource's own `payment`/`price_per_request` declaration (§4.14, x402): KCP governs the buy
   *decision*, a runtime wallet settles. Additive and backward-compatible. (#139)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1766,6 +1766,7 @@ That envelope is the `action_scope` object (all sub-fields OPTIONAL):
 | `tools` | array of string | Tool names the procedure may invoke. |
 | `paths` | array of string | File-system paths (globs permitted) the procedure may read or write. |
 | `capabilities` | array of string | Named capabilities the procedure requires or exercises. |
+| `spend` | object | Purchases the procedure may make. See §4.3a.1. |
 
 ```yaml
 - id: rotate-signing-key
@@ -1786,6 +1787,67 @@ whether the skill may be invoked and to bound what it may reach when it is. A sk
 by default like `executable`/`service`: absent an explicit eligibility grant it renders as a
 pointer with `invocation: explicit` (§16.3, C4). Skills are the manifest-declared counterpart of
 the runtime-depth lifecycle recorded in §17 (`skill_selected` … `verdict_emitted`).
+
+
+#### 4.3a.1 `action_scope.spend` — what a procedure may buy
+
+`tools` and `paths` bound what a skill may *touch*. `spend` bounds what it may *buy*.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `max_spend` | number | Per-purchase cap, denominated in `currency`. A purchase exceeding it is held. |
+| `allowed_vendors` | array of string | Allowlist of vendor/payee identifiers. A purchase to an unlisted vendor is held. |
+| `currency` | string | ISO 4217 code (`USD`, `EUR`) or asset ticker (`USDC`) that `max_spend` is denominated in. |
+
+All sub-fields are OPTIONAL, and `action_scope` remains an opaque passthrough object for
+parsers that do not implement conformance checking.
+
+```yaml
+- id: enrich-company-record
+  kind: skill
+  path: skills/enrich-company-record.md
+  intent: "How do I enrich a company record from a paid registry?"
+  scope: project
+  audience: [agent]
+  action_scope:
+    tools: [http]
+    spend:
+      max_spend: 2.00
+      currency: USD
+      allowed_vendors: ["registry.example.com"]
+```
+
+**Adjudication is fail-closed and per purchase.** A conformance checker adjudicates a
+purchase — vendor, amount, currency — exactly as it adjudicates `tools` and `paths`:
+
+- a vendor not present in `allowed_vendors` is **held**;
+- an amount exceeding `max_spend` is **held**;
+- a currency that does not match `currency` is **held** — implementations MUST NOT convert
+  between currencies to satisfy a cap, since the conversion rate is not part of the
+  declaration and a held purchase is the safe outcome;
+- a skill declaring no `spend` may make **no purchase at all**. Absence is not permission,
+  consistent with the fail-closed default the rest of `action_scope` uses.
+
+**KCP governs the decision, never the settlement.** As with `payment` (§4.14), the protocol
+declares what is permitted; a runtime wallet executes. A conformance checker adjudicates
+between a payment challenge and the retry that satisfies it. It does not hold funds, and an
+implementation MUST NOT treat a passing adjudication as evidence that a payment succeeded.
+
+**Composition with a session budget.** A per-purchase cap does not bound a sequence of
+purchases. Implementations that maintain a cumulative session budget MUST apply both, and
+the effective limit is the **lower** of the two — a skill declaring `max_spend: 2.00`
+cannot spend 2.00 forty times if the session budget is 10.00.
+
+That session budget is **not a manifest field**. It is supplied by the caller at plan or
+run time and is out of scope for this specification; the reference planner implements it as
+a gate alongside `max_units` and `context_budget`. This distinction matters: a manifest
+declares what a *procedure* may buy, and only the invoking party can know what the *session*
+may spend in total.
+
+**Over-threshold purchases route to review.** Where an implementation supports escalation
+(§3.14), a purchase held by any of the rules above SHOULD raise a grant request rather than
+fail silently, so that a human can authorise the specific purchase without widening the
+declared scope.
 
 ### 4.4 `intent`
 

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -215,7 +215,7 @@
             },
             "spend": {
               "type": "object",
-              "description": "Purchases the procedure may make (v0.26). Governs the buy decision fail-closed alongside the session-cumulative money_budget ceiling (§4.14). All sub-fields OPTIONAL.",
+              "description": "Purchases the procedure may make. Governs the buy decision fail-closed; where the caller maintains a cumulative session budget the effective limit is the lower of the two. That session budget is supplied at run time and is not a manifest field. All sub-fields OPTIONAL. See SPEC.md §4.3a.1.",
               "properties": {
                 "max_spend": {
                   "type": "number",


### PR DESCRIPTION
Closes the gap blocking a release: the schema validates a field the specification never defines.

## The problem

`action_scope.spend` (`max_spend`, `allowed_vendors`, `currency`) has been in `schema/knowledge-schema.json` since v0.26. SPEC.md never defined it — §4.3a's `action_scope` table lists three fields, and `spend` appears in no section.

A schema that validates a field the spec does not describe is how independent implementations diverge: each one guesses the semantics.

## The dangling citation

Both the schema description and the CHANGELOG entry justified the field by citing:

> the session-cumulative `money_budget` ceiling of **§4.14**

**§4.14 is `payment`** and defines no such thing. `money_budget` exists only as a gate in the reference planner (`kcp-agent/src/trace.ts`, alongside `max_units` and `context_budget`) — a run-time parameter supplied by the caller, never a manifest field.

**This is a repeat.** CHANGELOG "Fixed" already records a red-team pass over the RFC-0025 draft catching *"a fabricated precedent citation (referenced `money_budget`/`max_units` filters that do not exist anywhere in SPEC.md)"*. The same citation reappeared here, in a different artifact.

## What §4.3a.1 specifies

- **Fail-closed per purchase** — unlisted vendor held, over-cap held, currency mismatch held. Implementations **MUST NOT** convert between currencies to satisfy a cap: the rate is not part of the declaration, and a held purchase is the safe outcome.
- **Absence is not permission** — a skill declaring no `spend` may make no purchase at all, consistent with the rest of `action_scope`.
- **KCP governs the decision, never settlement** — mirroring §4.14. A passing adjudication is explicitly *not* evidence that a payment succeeded.
- **Composition with a session budget** — both apply, the lower wins. A skill with `max_spend: 2.00` cannot spend 2.00 forty times against a session budget of 10.00. That budget is **not a manifest field**: only the invoking party can know what a session may spend in total.
- **Over-threshold routes to review** — a held purchase SHOULD raise a grant request (§3.14) rather than fail silently, so a human can authorise one purchase without widening the declared scope.

## Verification

```
schema valid against its meta-schema
the new SPEC example validates against the unit schema
a non-numeric max_spend is still rejected
check-nul-bytes: clean
```

Schema and CHANGELOG descriptions corrected to match the spec text.

Refs #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)