### PR TITLE
docs(parity): record the real bridge state — three spec versions of drift

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.26.0 (all three bridges). **Spec is at v0.28.** The gap is narrower than a version-number comparison suggests: v0.27 is modelled in all three parsers. What is missing is `action_scope` (v0.26.1) in the Java and Python models, and `grant_request_events` (v0.28) everywhere. See **Known gaps** below.
+**Current version:** 0.28.0 (all three bridges, the CLI, and both parsers — aligned with the spec). The v0.26.1–v0.28 gap recorded here was closed in #146.
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -88,61 +88,53 @@ When adding any MCP capability:
 
 ---
 
-## Known gaps (all bridges) — v0.26.1 through v0.28
+## Known gaps
 
-Re-verified 2026-07-27 against `origin/main` @ 09bfbb1, **measuring the parser models rather
-than the bridge directories**. An earlier revision of this section scanned `bridge/java/` and
-`bridge/python/` and reported v0.27 as unimplemented in both. That was wrong: the bridges
-consume the models through the `kcp-parser` artifact, and the models live in `parsers/java/`
-and `parsers/python/`. Recording the mistake because it made the remaining work look like a
-two-language port when it is one field in each.
+None outstanding for v0.28. The gaps previously recorded here were closed in #146; the
+history is kept below because how they went unnoticed is more useful than the fact of
+them.
 
-### Field coverage in the parser models
+### What was wrong, and how it was found
 
-| model | `action_scope` | `authority_level` | `grant_ceiling` | task-type / agent ceilings |
-|---|---|---|---|---|
-| `shared/src/model.ts` (TypeScript) | yes | yes | yes | yes |
-| `parsers/java` | **no** | yes (`authorityLevel`) | yes (`GrantCeiling`, `GrantCeilingSource`) | yes (`TaskType`, `Agent`) |
-| `parsers/python` | **no** | yes | yes | yes |
+`action_scope` (§4.3a, v0.26.1) was absent from the Java and Python models and was parsed
+but dropped by `bridge/typescript/src/mapper.ts`. A unit whose declared scope is lost is
+indistinguishable from one that declares none, which per §4.3a authorizes nothing.
 
-**v0.27 (RFC-0025) is modelled in all three.** The outstanding item is `action_scope`
-(§4.3a, v0.26.1) in the Java and Python models — an `ActionScope` type and one unit field
-each, with parsing and tests.
+`grant_request_events` (§17, v0.28) existed in no implementation. It is now written by
+`bridge/java/.../GrantRequestLogger.java` and read by `kcp stats`. Nothing raises grant
+requests yet — RFC-0026 deferred the request/response mechanism — so the writer is a
+library seam for an adjudicator that lives in the planner. That is stated in the class
+javadoc rather than left to be inferred.
 
-`bridge/typescript/src/mapper.ts` did not surface `action_scope` on the exposed unit entry:
-parsed, then dropped at the bridge boundary. Fixed in #146.
+**Two of four validators rejected v0.27 and v0.28 manifests.** `KNOWN_KCP_VERSIONS` in
+`parsers/python/kcp/validator.py` and `KcpValidator.java` stopped at 0.26. CHANGELOG
+"Fixed" records this enum gap being closed for the JSON Schema and `shared/src/validator.ts`
+— two of four; the others were missed. Releasing would have shipped a version no reference
+implementation accepts.
 
-### §17 Observability — three of four tables were never built
+`kcp init` was scaffolding new manifests declaring `kcp_version: 0.26`, so every project
+created after v0.27 began two versions behind.
 
-| table | normative since | implemented in |
-|---|---|---|
-| `usage_events` | v0.16 | `cli/src/stats.ts`, `bridge/java/.../UsageLogger.java` |
-| `render_events` | v0.16 | **nowhere** |
-| `quarantine_events` | v0.16 | **nowhere** |
-| `grant_request_events` | v0.28 | **nowhere** |
+### The check that already existed
 
-This gap produced a false precedent worth naming: RFC-0026 justifies the new table as
-"mirroring its existing `render_events`/`quarantine_events` pattern". That pattern is
-specified but has never existed in code. It is the third instance of the same shape — the
-RFC-0025 draft cited `money_budget`/`max_units` filters absent from SPEC.md (see "Fixed"),
-and `action_scope.spend` shipped in the schema for two versions with no specification at all
-(#144). Each was a claim about what already exists, believed rather than checked.
+`cli/src/consistency.test.ts` is a cross-language version-drift guard. It asserts that every
+validator knows the current SPEC.md version, that the four agree on the known-version set,
+and that the CLI, bridges and scaffold track it. **It had been failing.** It is precisely the
+check that would have caught this drift months earlier, and it went unread.
 
-`render_events` and `quarantine_events` belong to the render pipeline (§16), which the scope
-note above places outside this parity contract — they are a `cli/` concern.
-`grant_request_events` is not: it is the audit trail for §3.14 escalation.
+Two of the three RFC-level errors found alongside were of the same family — a claim about
+what exists, believed rather than checked. RFC-0026 justified `grant_request_events` as
+"mirroring its existing `render_events`/`quarantine_events` pattern"; that pattern is
+specified and has never been implemented. The RFC-0025 draft cited `money_budget`/`max_units`
+filters absent from SPEC.md (see "Fixed"). And `action_scope.spend` shipped in the schema for
+two versions with no specification at all (#144).
 
-### Required before the next version bump
+### Still specified but unimplemented
 
-1. **`action_scope` in the Java and Python models** — `ActionScope` type, unit field, parsing,
-   tests. Treat the sub-object as an opaque passthrough (§4.3a): a field-by-field rebuild
-   drops `spend` and every sub-field a later version adds.
-2. **TypeScript `mapper.ts`** — surface `action_scope`. Done in #146.
-3. **`grant_request_events`** — implement, or record an explicit decision to ship v0.28 with
-   §17 Level 3 unimplemented. Not a new gap: two §17 tables have been unimplemented since
-   v0.16.
-
-Item 1 is the only one that blocks a version bump under the Rule above.
+`render_events` and `quarantine_events` (§17, normative since v0.16) exist nowhere. Both
+belong to the render pipeline (§16), which the scope note above places outside this parity
+contract — a `cli/` concern, not a bridge one. Recorded so the next reader does not
+rediscover it as new.
 
 ## Version history
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.26.0 (all three bridges — aligned with KCP spec version). Spec is at v0.26.1 (2026-07-22, `kind: skill` procedural plane) — see **Known gaps** below, this has not yet reached bridge parity.
+**Current version:** 0.26.0 (all three bridges). **Spec is at v0.28** — the bridges are three spec versions behind (v0.26.1 `kind: skill`, v0.27 authority/grant-ceiling, v0.28 escalation). See **Known gaps** below. Under the Rule stated next, no version may be cut until the Java and Python ports land.
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -88,25 +88,59 @@ When adding any MCP capability:
 
 ---
 
-## Known gaps (all bridges) — v0.26.1 `kind: skill`
+## Known gaps (all bridges) — v0.26.1 through v0.28
 
-Spec v0.26.1 (2026-07-22, #134) added the procedural plane: `kind: skill` units and the
-`action_scope` field (§4.3a — the tools/paths/capabilities a skill procedure may touch).
-Verified 2026-07-22:
+Re-verified 2026-07-27 against `origin/main` @ 09bfbb1. The v0.26.1 gap recorded below was
+never closed, and two further spec versions were promoted on top of it.
 
-- **TypeScript** — `bridge/typescript/src/model.ts` and `parser.ts` are symlinks to
-  `shared/src/`, which was updated by #134, so parsing/validation of `kind: skill` and
-  `action_scope` is already current. However, `mapper.ts`'s manifest-entry builder
-  (~line 268) does not include `action_scope` in the fields it copies onto the exposed
-  unit entry — it is parsed but not surfaced. Needs a one-line fix + a mapper test.
-- **Java** (`bridge/java/`) and **Python** (`bridge/python/`) — not symlinked, real
-  separate source trees. Zero references to `action_scope` or `"skill"` found in either.
-  Full Tier 1 port required (see **Rule** above) before the next version bump.
+### Field coverage in the bridges
 
-This is a real parity gap, not yet closed — tracked here rather than silently left off
-this table. Do not claim "full parity" again until all three items above are done.
+| bridge | `action_scope` (v0.26.1) | `"skill"` | `authority_level` (v0.27) | `grant_ceiling` (v0.27) |
+|---|---|---|---|---|
+| typescript | 0 | 0 | 1 | 1 |
+| java | 0 | 0 | 0 | 0 |
+| python | 0 | 0 | 0 | 0 |
 
----
+TypeScript's `1`s are inherited, not implemented: `bridge/typescript/src/{model,parser,validator}.ts`
+are symlinks into `shared/src/`, which carries the fields (`shared/src/model.ts` lines 83, 115,
+341, 344). Java (`bridge/java/`, ~2 700 lines) and Python (`bridge/python/`, ~1 480 lines) are
+separate source trees and must mirror them by hand.
+
+`mapper.ts`'s manifest-entry builder still does not surface `action_scope` — the one-line fix
+noted in the previous revision of this section remains undone.
+
+### §17 Observability — three of four tables were never built
+
+| table | normative since | implemented in |
+|---|---|---|
+| `usage_events` | v0.16 | `cli/src/stats.ts`, `bridge/java/.../UsageLogger.java` |
+| `render_events` | v0.16 | **nowhere** |
+| `quarantine_events` | v0.16 | **nowhere** |
+| `grant_request_events` | v0.28 | **nowhere** |
+
+Worth recording precisely, because it produced a false precedent: RFC-0026 justifies the new
+table as "mirroring its existing `render_events`/`quarantine_events` pattern". That pattern is
+specified but has never existed in code. This is the second RFC to cite an implementation
+precedent that is not there — the RFC-0025 draft cited `money_budget`/`max_units` filters that
+appear nowhere in SPEC.md (see CHANGELOG "Fixed"), and `action_scope.spend` shipped in the
+schema for two versions with no specification at all (#144).
+
+Two of these tables belong to the render pipeline (§16), which the scope note above places
+outside the bridge parity contract — they are a `cli/` concern. `grant_request_events` is not:
+it is the audit trail for §3.14 escalation and belongs wherever grants are adjudicated.
+
+### Required before the next version bump
+
+1. **Java + Python: v0.26.1 `kind: skill`** — parse and surface `kind` and `action_scope`.
+2. **Java + Python: v0.27** — `authority_level`, `authority_level_scale`, `grant_ceiling`,
+   and the per-task-type and per-agent ceilings (`shared/src/model.ts` 341–364).
+3. **TypeScript: `mapper.ts`** — surface `action_scope` on the exposed unit entry, plus a test.
+4. **`grant_request_events`** — or an explicit decision to ship v0.28 with §17 Level 3
+   unimplemented, recorded here rather than left to be discovered.
+
+Do not claim parity, and do not cut a release, until 1–3 are done. The Rule above is not
+advisory: three spec versions were promoted while this section already said a port was
+required, and nothing caught it because nothing checks.
 
 ## Version history
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -3,7 +3,7 @@
 All three bridges (TypeScript, Java, Python) are required to stay at feature parity on **MCP tools and prompts**.
 Static generation CLI flags (Tier 2) are currently TS + Java only — Python support is planned.
 
-**Current version:** 0.26.0 (all three bridges). **Spec is at v0.28** — the bridges are three spec versions behind (v0.26.1 `kind: skill`, v0.27 authority/grant-ceiling, v0.28 escalation). See **Known gaps** below. Under the Rule stated next, no version may be cut until the Java and Python ports land.
+**Current version:** 0.26.0 (all three bridges). **Spec is at v0.28.** The gap is narrower than a version-number comparison suggests: v0.27 is modelled in all three parsers. What is missing is `action_scope` (v0.26.1) in the Java and Python models, and `grant_request_events` (v0.28) everywhere. See **Known gaps** below.
 
 > Scope note: the `kcp` developer CLI (`cli/` — init, validate, query, stats, and as of
 > spec v0.16 `render`) versions independently of the bridges and is outside this parity
@@ -90,24 +90,27 @@ When adding any MCP capability:
 
 ## Known gaps (all bridges) — v0.26.1 through v0.28
 
-Re-verified 2026-07-27 against `origin/main` @ 09bfbb1. The v0.26.1 gap recorded below was
-never closed, and two further spec versions were promoted on top of it.
+Re-verified 2026-07-27 against `origin/main` @ 09bfbb1, **measuring the parser models rather
+than the bridge directories**. An earlier revision of this section scanned `bridge/java/` and
+`bridge/python/` and reported v0.27 as unimplemented in both. That was wrong: the bridges
+consume the models through the `kcp-parser` artifact, and the models live in `parsers/java/`
+and `parsers/python/`. Recording the mistake because it made the remaining work look like a
+two-language port when it is one field in each.
 
-### Field coverage in the bridges
+### Field coverage in the parser models
 
-| bridge | `action_scope` (v0.26.1) | `"skill"` | `authority_level` (v0.27) | `grant_ceiling` (v0.27) |
+| model | `action_scope` | `authority_level` | `grant_ceiling` | task-type / agent ceilings |
 |---|---|---|---|---|
-| typescript | 0 | 0 | 1 | 1 |
-| java | 0 | 0 | 0 | 0 |
-| python | 0 | 0 | 0 | 0 |
+| `shared/src/model.ts` (TypeScript) | yes | yes | yes | yes |
+| `parsers/java` | **no** | yes (`authorityLevel`) | yes (`GrantCeiling`, `GrantCeilingSource`) | yes (`TaskType`, `Agent`) |
+| `parsers/python` | **no** | yes | yes | yes |
 
-TypeScript's `1`s are inherited, not implemented: `bridge/typescript/src/{model,parser,validator}.ts`
-are symlinks into `shared/src/`, which carries the fields (`shared/src/model.ts` lines 83, 115,
-341, 344). Java (`bridge/java/`, ~2 700 lines) and Python (`bridge/python/`, ~1 480 lines) are
-separate source trees and must mirror them by hand.
+**v0.27 (RFC-0025) is modelled in all three.** The outstanding item is `action_scope`
+(§4.3a, v0.26.1) in the Java and Python models — an `ActionScope` type and one unit field
+each, with parsing and tests.
 
-`mapper.ts`'s manifest-entry builder still does not surface `action_scope` — the one-line fix
-noted in the previous revision of this section remains undone.
+`bridge/typescript/src/mapper.ts` did not surface `action_scope` on the exposed unit entry:
+parsed, then dropped at the bridge boundary. Fixed in #146.
 
 ### §17 Observability — three of four tables were never built
 
@@ -118,29 +121,28 @@ noted in the previous revision of this section remains undone.
 | `quarantine_events` | v0.16 | **nowhere** |
 | `grant_request_events` | v0.28 | **nowhere** |
 
-Worth recording precisely, because it produced a false precedent: RFC-0026 justifies the new
-table as "mirroring its existing `render_events`/`quarantine_events` pattern". That pattern is
-specified but has never existed in code. This is the second RFC to cite an implementation
-precedent that is not there — the RFC-0025 draft cited `money_budget`/`max_units` filters that
-appear nowhere in SPEC.md (see CHANGELOG "Fixed"), and `action_scope.spend` shipped in the
-schema for two versions with no specification at all (#144).
+This gap produced a false precedent worth naming: RFC-0026 justifies the new table as
+"mirroring its existing `render_events`/`quarantine_events` pattern". That pattern is
+specified but has never existed in code. It is the third instance of the same shape — the
+RFC-0025 draft cited `money_budget`/`max_units` filters absent from SPEC.md (see "Fixed"),
+and `action_scope.spend` shipped in the schema for two versions with no specification at all
+(#144). Each was a claim about what already exists, believed rather than checked.
 
-Two of these tables belong to the render pipeline (§16), which the scope note above places
-outside the bridge parity contract — they are a `cli/` concern. `grant_request_events` is not:
-it is the audit trail for §3.14 escalation and belongs wherever grants are adjudicated.
+`render_events` and `quarantine_events` belong to the render pipeline (§16), which the scope
+note above places outside this parity contract — they are a `cli/` concern.
+`grant_request_events` is not: it is the audit trail for §3.14 escalation.
 
 ### Required before the next version bump
 
-1. **Java + Python: v0.26.1 `kind: skill`** — parse and surface `kind` and `action_scope`.
-2. **Java + Python: v0.27** — `authority_level`, `authority_level_scale`, `grant_ceiling`,
-   and the per-task-type and per-agent ceilings (`shared/src/model.ts` 341–364).
-3. **TypeScript: `mapper.ts`** — surface `action_scope` on the exposed unit entry, plus a test.
-4. **`grant_request_events`** — or an explicit decision to ship v0.28 with §17 Level 3
-   unimplemented, recorded here rather than left to be discovered.
+1. **`action_scope` in the Java and Python models** — `ActionScope` type, unit field, parsing,
+   tests. Treat the sub-object as an opaque passthrough (§4.3a): a field-by-field rebuild
+   drops `spend` and every sub-field a later version adds.
+2. **TypeScript `mapper.ts`** — surface `action_scope`. Done in #146.
+3. **`grant_request_events`** — implement, or record an explicit decision to ship v0.28 with
+   §17 Level 3 unimplemented. Not a new gap: two §17 tables have been unimplemented since
+   v0.16.
 
-Do not claim parity, and do not cut a release, until 1–3 are done. The Rule above is not
-advisory: three spec versions were promoted while this section already said a port was
-required, and nothing caught it because nothing checks.
+Item 1 is the only one that blocks a version bump under the Rule above.
 
 ## Version history
 


### PR DESCRIPTION
Blocks the v0.28.0 release, and explains why.

## What I found while preparing to cut v0.28.0

PARITY.md claimed bridges at 0.26.0 "aligned with KCP spec version", spec at v0.26.1. **The spec is at v0.28.**

The v0.26.1 `kind: skill` gap recorded in this very file was never closed. Its own note read *"Full Tier 1 port required before the next version bump."* Two further spec versions were promoted on top of it — and nothing caught it, because nothing checks.

Re-verified against `origin/main` @ 09bfbb1:

| bridge | `action_scope` (v0.26.1) | `"skill"` | `authority_level` (v0.27) | `grant_ceiling` (v0.27) |
|---|---|---|---|---|
| typescript | 0 | 0 | 1 | 1 |
| java | 0 | 0 | **0** | **0** |
| python | 0 | 0 | **0** | **0** |

TypeScript's `1`s are **inherited, not implemented** — `model.ts`/`parser.ts`/`validator.ts` are symlinks into `shared/src/`. Java (~2 700 lines) and Python (~1 480 lines) are separate trees and must mirror the fields by hand.

## §17 Observability — three of four tables were never built

| table | normative since | implemented in |
|---|---|---|
| `usage_events` | v0.16 | `cli/src/stats.ts`, Java bridge |
| `render_events` | v0.16 | **nowhere** |
| `quarantine_events` | v0.16 | **nowhere** |
| `grant_request_events` | v0.28 | **nowhere** |

## The pattern worth naming

RFC-0026 justifies `grant_request_events` as *"mirroring its existing `render_events`/`quarantine_events` pattern."* **That pattern has never existed in code.**

This is the second RFC to cite an implementation precedent that is not there:

- the RFC-0025 draft cited `money_budget`/`max_units` filters absent from SPEC.md — caught by red-team, already recorded under "Fixed"
- `action_scope.spend` shipped in the schema for two versions with no specification at all — #144

Three instances, one shape: **a claim about what already exists, believed rather than checked.**

## What this PR does

Records the verified state and adds an explicit **"Required before the next version bump"** list, so the next release attempt starts from the truth instead of rediscovering it:

1. Java + Python: v0.26.1 `kind: skill` — parse and surface `kind`/`action_scope`
2. Java + Python: v0.27 — `authority_level`, `authority_level_scale`, `grant_ceiling`, per-task-type and per-agent ceilings
3. TypeScript: `mapper.ts` — surface `action_scope` (the one-line fix noted in the previous revision, still undone)
4. `grant_request_events` — or an explicit, recorded decision to ship v0.28 with §17 Level 3 unimplemented

No release should be cut until 1–3 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)