### PR TITLE
fix(bridge): parity port — action_scope + v0.27 authority fields

### DIFF
--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.26.1</version>
+    <version>0.28.0</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/java/src/main/java/no/cantara/kcp/mcp/GrantRequestLogger.java
+++ b/bridge/java/src/main/java/no/cantara/kcp/mcp/GrantRequestLogger.java
@@ -66,12 +66,16 @@ public final class GrantRequestLogger {
      * @param resolvedBy            populated on granted/denied rows only
      * @param correlationId         W3C traceparent stitching one run's events together
      */
-    public static void log(String id, EventType eventType, Trigger trigger,
+    public static CompletableFuture<Void> log(String id, EventType eventType, Trigger trigger,
                            String taskTypeRef, String agentRef,
                            List<String> bindingSourceRefs,
                            String currentEffectiveLevel, String requestedLevel,
                            String grantorRole, String resolvedBy, String correlationId) {
-        CompletableFuture.runAsync(() -> {
+        // Returns the future rather than discarding it. Still fire-and-forget — callers
+        // may ignore it — but writes run on a pool, so two calls can land out of order.
+        // An adjudicator recording a created->granted sequence needs them ordered, and
+        // so does any test that asserts the sequence. Awaiting is how you get that.
+        return CompletableFuture.runAsync(() -> {
             try {
                 ensureSchema();
                 insert(id, eventType, trigger, taskTypeRef, agentRef, bindingSourceRefs,

--- a/bridge/java/src/main/java/no/cantara/kcp/mcp/GrantRequestLogger.java
+++ b/bridge/java/src/main/java/no/cantara/kcp/mcp/GrantRequestLogger.java
@@ -1,0 +1,179 @@
+package no.cantara.kcp.mcp;
+
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * {@code grant_request_events} — the §17 audit trail for §3.14 escalation and grant
+ * requests (v0.28, RFC-0026). Normative at conformance Level 3.
+ *
+ * <p><b>One row per state transition, not one per request.</b> A request's full history
+ * is reconstructed by grouping rows on {@code id}. That shape is deliberate: an audit
+ * trail that overwrites a row on resolution cannot answer "how long was this pending"
+ * or "was it denied before it was granted", which are the questions an escalation log
+ * exists to answer.
+ *
+ * <p><b>Nothing in this repository calls this yet, by design.</b> RFC-0026 accepted the
+ * semantics and the audit trail while explicitly deferring the active request/response
+ * coordination mechanism to a future RFC. The adjudicator that raises grant requests
+ * lives in the planner, not here. This class is the primitive that adjudicator writes
+ * through, and {@code kcp stats} reads — so the table is usable end to end rather than
+ * write-only. It is a library primitive, not a claim that escalation ships in this repo.
+ *
+ * <p>Local-only, same as {@code usage_events}: grant requests carry internal-escalation
+ * context and MUST NOT be transmitted to external services without explicit consent.
+ *
+ * <p>Mirrors {@link UsageLogger} — same store, same WAL mode, same fire-and-forget
+ * write path. Observability must never block or break the operation it observes.
+ */
+public final class GrantRequestLogger {
+
+    /** Event types, per §17. A row's {@code event_type} MUST be one of these. */
+    public enum EventType { CREATED, GRANTED, DENIED, EXPIRED;
+        @Override public String toString() { return name().toLowerCase(); }
+    }
+
+    /** Escalation triggers, per §3.14 / RFC-0026. */
+    public enum Trigger {
+        REQUIRES_APPROVAL, INSUFFICIENT_AUTHORITY_LEVEL, CONFIDENCE_BELOW_THRESHOLD;
+        @Override public String toString() { return name().toLowerCase(); }
+    }
+
+    private static final ReentrantLock WRITE_LOCK = new ReentrantLock();
+    private static volatile boolean initialized = false;
+
+    private GrantRequestLogger() {}
+
+    /**
+     * Record a state transition for a grant request.
+     *
+     * @param id                    the GrantRequest's own id — rows sharing it form one history
+     * @param eventType             created / granted / denied / expired
+     * @param trigger               why escalation was raised; null on resolution rows
+     * @param taskTypeRef           task type the request concerns
+     * @param agentRef              agent that raised it
+     * @param bindingSourceRefs     populated for insufficient_authority_level (§3.13 sources)
+     * @param currentEffectiveLevel the level in force when the request was raised
+     * @param requestedLevel        the level being asked for
+     * @param grantorRole           role permitted to resolve it
+     * @param resolvedBy            populated on granted/denied rows only
+     * @param correlationId         W3C traceparent stitching one run's events together
+     */
+    public static void log(String id, EventType eventType, Trigger trigger,
+                           String taskTypeRef, String agentRef,
+                           List<String> bindingSourceRefs,
+                           String currentEffectiveLevel, String requestedLevel,
+                           String grantorRole, String resolvedBy, String correlationId) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                ensureSchema();
+                insert(id, eventType, trigger, taskTypeRef, agentRef, bindingSourceRefs,
+                        currentEffectiveLevel, requestedLevel, grantorRole, resolvedBy,
+                        correlationId);
+            } catch (Exception ignored) {
+                // Swallowed on purpose, as in UsageLogger: a failed audit write must not
+                // take down the adjudication it was observing. The tradeoff is that a
+                // broken log is silent — which is why ensureSchema is exercised by tests
+                // rather than trusted at runtime.
+            }
+        });
+    }
+
+    static void ensureSchema() throws Exception {
+        if (initialized) return;
+        WRITE_LOCK.lock();
+        try {
+            if (initialized) return;
+            Files.createDirectories(UsageLogger.dbPath.getParent());
+            try (Connection conn = getConnection();
+                 Statement st = conn.createStatement()) {
+                st.executeUpdate("PRAGMA journal_mode=WAL");
+                st.executeUpdate("""
+                    CREATE TABLE IF NOT EXISTS grant_request_events (
+                        row_id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                        id                      TEXT    NOT NULL,
+                        timestamp               TEXT    NOT NULL,
+                        event_type              TEXT    NOT NULL,
+                        trigger                 TEXT,
+                        task_type_ref           TEXT,
+                        agent_ref               TEXT,
+                        binding_source_refs     TEXT,
+                        current_effective_level TEXT,
+                        requested_level         TEXT,
+                        grantor_role            TEXT,
+                        resolved_by             TEXT,
+                        correlation_id          TEXT
+                    )""");
+                // Grouping on `id` is how a history is read, so it is the index that matters.
+                st.executeUpdate(
+                    "CREATE INDEX IF NOT EXISTS idx_grant_id ON grant_request_events(id)");
+                st.executeUpdate(
+                    "CREATE INDEX IF NOT EXISTS idx_grant_timestamp ON grant_request_events(timestamp)");
+                st.executeUpdate(
+                    "CREATE INDEX IF NOT EXISTS idx_grant_correlation ON grant_request_events(correlation_id)");
+            }
+            initialized = true;
+        } finally {
+            WRITE_LOCK.unlock();
+        }
+    }
+
+    private static void insert(String id, EventType eventType, Trigger trigger,
+                               String taskTypeRef, String agentRef,
+                               List<String> bindingSourceRefs,
+                               String currentEffectiveLevel, String requestedLevel,
+                               String grantorRole, String resolvedBy,
+                               String correlationId) throws Exception {
+        WRITE_LOCK.lock();
+        try (Connection conn = getConnection();
+             PreparedStatement ps = conn.prepareStatement("""
+                 INSERT INTO grant_request_events
+                     (id, timestamp, event_type, trigger, task_type_ref, agent_ref,
+                      binding_source_refs, current_effective_level, requested_level,
+                      grantor_role, resolved_by, correlation_id)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""")) {
+            ps.setString(1, id);
+            ps.setString(2, Instant.now().toString());
+            ps.setString(3, eventType.toString());
+            ps.setString(4, trigger != null ? trigger.toString() : null);
+            ps.setString(5, taskTypeRef);
+            ps.setString(6, agentRef);
+            ps.setString(7, toJsonArray(bindingSourceRefs));
+            ps.setString(8, currentEffectiveLevel);
+            ps.setString(9, requestedLevel);
+            ps.setString(10, grantorRole);
+            ps.setString(11, resolvedBy);
+            ps.setString(12, correlationId);
+            ps.executeUpdate();
+        } finally {
+            WRITE_LOCK.unlock();
+        }
+    }
+
+    /** §17 stores binding_source_refs as a JSON array; SQLite has no array type. */
+    static String toJsonArray(List<String> values) {
+        if (values == null || values.isEmpty()) return null;
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append('"').append(values.get(i).replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
+        }
+        return sb.append(']').toString();
+    }
+
+    private static Connection getConnection() throws Exception {
+        return DriverManager.getConnection("jdbc:sqlite:" + UsageLogger.dbPath);
+    }
+
+    /** Test seam — resets the one-shot schema guard between temp databases. */
+    static void resetForTests() {
+        initialized = false;
+    }
+}

--- a/bridge/java/src/test/java/no/cantara/kcp/mcp/GrantRequestLoggerTest.java
+++ b/bridge/java/src/test/java/no/cantara/kcp/mcp/GrantRequestLoggerTest.java
@@ -36,6 +36,21 @@ class GrantRequestLoggerTest {
         return DriverManager.getConnection("jdbc:sqlite:" + UsageLogger.dbPath);
     }
 
+    /** Wait for an async writer to create its table. A fixed sleep loses this race on a
+     *  slow runner — CI reported "usage_events lost" from exactly that. */
+    private void awaitTable(String name) throws Exception {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            try (Connection c = open(); Statement st = c.createStatement();
+                 ResultSet rs = st.executeQuery(
+                     "SELECT name FROM sqlite_master WHERE type='table' AND name='" + name + "'")) {
+                if (rs.next()) return;
+            }
+            Thread.sleep(50);
+        }
+        fail("table " + name + " never appeared within 10s");
+    }
+
     @Test
     void createsTheTableWithEverySpecifiedColumn() throws Exception {
         GrantRequestLogger.ensureSchema();
@@ -58,7 +73,7 @@ class GrantRequestLoggerTest {
         // §17 puts all four tables in one store. Creating this one must not disturb
         // usage_events, which the bridge writes on every search.
         UsageLogger.logSearch("proj", "q", 1, 10);
-        Thread.sleep(300);
+        awaitTable("usage_events");   // UsageLogger has no awaitable seam; poll instead
         GrantRequestLogger.ensureSchema();
         try (Connection c = open(); Statement st = c.createStatement();
              ResultSet rs = st.executeQuery(
@@ -75,14 +90,17 @@ class GrantRequestLoggerTest {
         // The shape §17 requires: a request's history is rows sharing an id, not one row
         // mutated in place. An overwriting log cannot answer "how long was this pending"
         // or "was it denied before it was granted".
+        // Await each write. Writes run on a thread pool, so firing both and sleeping
+        // races: CI observed `granted` landing first. The audit trail's whole point is
+        // ordered history, so the ordering must be established by the caller, not hoped
+        // for — which is why log() returns its future.
         GrantRequestLogger.log("req-1", GrantRequestLogger.EventType.CREATED,
                 GrantRequestLogger.Trigger.INSUFFICIENT_AUTHORITY_LEVEL,
                 "deploy", "agent-a", List.of("policy.yaml", "tenant.yaml"),
-                "suggest", "commit", "release-manager", null, "trace-1");
+                "suggest", "commit", "release-manager", null, "trace-1").join();
         GrantRequestLogger.log("req-1", GrantRequestLogger.EventType.GRANTED,
                 null, "deploy", "agent-a", null,
-                "suggest", "commit", "release-manager", "totto", "trace-1");
-        Thread.sleep(600);
+                "suggest", "commit", "release-manager", "totto", "trace-1").join();
 
         try (Connection c = open(); Statement st = c.createStatement();
              ResultSet rs = st.executeQuery(

--- a/bridge/java/src/test/java/no/cantara/kcp/mcp/GrantRequestLoggerTest.java
+++ b/bridge/java/src/test/java/no/cantara/kcp/mcp/GrantRequestLoggerTest.java
@@ -36,21 +36,6 @@ class GrantRequestLoggerTest {
         return DriverManager.getConnection("jdbc:sqlite:" + UsageLogger.dbPath);
     }
 
-    /** Wait for an async writer to create its table. A fixed sleep loses this race on a
-     *  slow runner — CI reported "usage_events lost" from exactly that. */
-    private void awaitTable(String name) throws Exception {
-        long deadline = System.currentTimeMillis() + 10_000;
-        while (System.currentTimeMillis() < deadline) {
-            try (Connection c = open(); Statement st = c.createStatement();
-                 ResultSet rs = st.executeQuery(
-                     "SELECT name FROM sqlite_master WHERE type='table' AND name='" + name + "'")) {
-                if (rs.next()) return;
-            }
-            Thread.sleep(50);
-        }
-        fail("table " + name + " never appeared within 10s");
-    }
-
     @Test
     void createsTheTableWithEverySpecifiedColumn() throws Exception {
         GrantRequestLogger.ensureSchema();
@@ -72,8 +57,19 @@ class GrantRequestLoggerTest {
     void coexistsWithUsageEvents() throws Exception {
         // §17 puts all four tables in one store. Creating this one must not disturb
         // usage_events, which the bridge writes on every search.
-        UsageLogger.logSearch("proj", "q", 1, 10);
-        awaitTable("usage_events");   // UsageLogger has no awaitable seam; poll instead
+        //
+        // The pre-existing table is created directly rather than by calling
+        // UsageLogger.logSearch. That coupling made this test order-dependent:
+        // UsageLogger.initialized is a static one-shot, so if any earlier test in the
+        // JVM initialised it against a different dbPath, ensureSchema short-circuits and
+        // never creates the table under our @TempDir. It passed locally and failed in CI
+        // purely on test order. The property under test is about schema coexistence, not
+        // about UsageLogger's write path, so the dependency was never needed.
+        try (Connection c = open(); Statement st = c.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS usage_events ("
+                    + "id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL, "
+                    + "event_type TEXT NOT NULL, project TEXT NOT NULL)");
+        }
         GrantRequestLogger.ensureSchema();
         try (Connection c = open(); Statement st = c.createStatement();
              ResultSet rs = st.executeQuery(

--- a/bridge/java/src/test/java/no/cantara/kcp/mcp/GrantRequestLoggerTest.java
+++ b/bridge/java/src/test/java/no/cantara/kcp/mcp/GrantRequestLoggerTest.java
@@ -1,0 +1,124 @@
+package no.cantara.kcp.mcp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * grant_request_events — §17 audit trail for §3.14 escalation (v0.28, RFC-0026).
+ *
+ * <p>Writes go through a CompletableFuture and swallow their exceptions, so a broken
+ * schema would fail silently in production. These tests drive ensureSchema and insert
+ * synchronously for exactly that reason: the failure mode this table has is being
+ * unwritable without anyone noticing.
+ */
+class GrantRequestLoggerTest {
+
+    @TempDir
+    Path tmp;
+
+    @BeforeEach
+    void isolateDatabase() {
+        UsageLogger.dbPath = tmp.resolve("usage.db");
+        GrantRequestLogger.resetForTests();
+    }
+
+    private Connection open() throws Exception {
+        return DriverManager.getConnection("jdbc:sqlite:" + UsageLogger.dbPath);
+    }
+
+    @Test
+    void createsTheTableWithEverySpecifiedColumn() throws Exception {
+        GrantRequestLogger.ensureSchema();
+        try (Connection c = open(); Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery("PRAGMA table_info(grant_request_events)")) {
+            var columns = new java.util.HashSet<String>();
+            while (rs.next()) columns.add(rs.getString("name"));
+            // §17 names these twelve. A missing column is a silent conformance failure:
+            // inserts still succeed, the data is simply never recorded.
+            assertTrue(columns.containsAll(List.of(
+                    "id", "timestamp", "event_type", "trigger", "task_type_ref",
+                    "agent_ref", "binding_source_refs", "current_effective_level",
+                    "requested_level", "grantor_role", "resolved_by", "correlation_id")),
+                    "missing §17 columns; present: " + columns);
+        }
+    }
+
+    @Test
+    void coexistsWithUsageEvents() throws Exception {
+        // §17 puts all four tables in one store. Creating this one must not disturb
+        // usage_events, which the bridge writes on every search.
+        UsageLogger.logSearch("proj", "q", 1, 10);
+        Thread.sleep(300);
+        GrantRequestLogger.ensureSchema();
+        try (Connection c = open(); Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                 "SELECT name FROM sqlite_master WHERE type='table'")) {
+            var tables = new java.util.HashSet<String>();
+            while (rs.next()) tables.add(rs.getString("name"));
+            assertTrue(tables.contains("usage_events"), "usage_events lost: " + tables);
+            assertTrue(tables.contains("grant_request_events"), "table missing: " + tables);
+        }
+    }
+
+    @Test
+    void oneRowPerTransition_historyReconstructsByGroupingOnId() throws Exception {
+        // The shape §17 requires: a request's history is rows sharing an id, not one row
+        // mutated in place. An overwriting log cannot answer "how long was this pending"
+        // or "was it denied before it was granted".
+        GrantRequestLogger.log("req-1", GrantRequestLogger.EventType.CREATED,
+                GrantRequestLogger.Trigger.INSUFFICIENT_AUTHORITY_LEVEL,
+                "deploy", "agent-a", List.of("policy.yaml", "tenant.yaml"),
+                "suggest", "commit", "release-manager", null, "trace-1");
+        GrantRequestLogger.log("req-1", GrantRequestLogger.EventType.GRANTED,
+                null, "deploy", "agent-a", null,
+                "suggest", "commit", "release-manager", "totto", "trace-1");
+        Thread.sleep(600);
+
+        try (Connection c = open(); Statement st = c.createStatement();
+             ResultSet rs = st.executeQuery(
+                 "SELECT event_type, trigger, resolved_by, binding_source_refs "
+                 + "FROM grant_request_events WHERE id='req-1' ORDER BY row_id")) {
+            assertTrue(rs.next());
+            assertEquals("created", rs.getString("event_type"));
+            assertEquals("insufficient_authority_level", rs.getString("trigger"));
+            assertNull(rs.getString("resolved_by"), "resolved_by belongs on resolution rows only");
+            assertEquals("[\"policy.yaml\",\"tenant.yaml\"]", rs.getString("binding_source_refs"));
+
+            assertTrue(rs.next(), "the granted transition should be a second row, not an update");
+            assertEquals("granted", rs.getString("event_type"));
+            assertEquals("totto", rs.getString("resolved_by"));
+            assertFalse(rs.next());
+        }
+    }
+
+    @Test
+    void bindingSourceRefsSerialiseAsJsonAndEscape() {
+        assertNull(GrantRequestLogger.toJsonArray(null));
+        assertNull(GrantRequestLogger.toJsonArray(List.of()));
+        assertEquals("[\"a\"]", GrantRequestLogger.toJsonArray(List.of("a")));
+        assertEquals("[\"a\",\"b\"]", GrantRequestLogger.toJsonArray(List.of("a", "b")));
+        // A quote in a source ref would otherwise produce invalid JSON that no reader
+        // can parse — and the reader is a different language.
+        assertEquals("[\"a\\\"b\"]", GrantRequestLogger.toJsonArray(List.of("a\"b")));
+    }
+
+    @Test
+    void eventTypeAndTriggerSerialiseToTheSpecVocabulary() {
+        assertEquals("created", GrantRequestLogger.EventType.CREATED.toString());
+        assertEquals("expired", GrantRequestLogger.EventType.EXPIRED.toString());
+        assertEquals("requires_approval",
+                GrantRequestLogger.Trigger.REQUIRES_APPROVAL.toString());
+        assertEquals("confidence_below_threshold",
+                GrantRequestLogger.Trigger.CONFIDENCE_BELOW_THRESHOLD.toString());
+    }
+}

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.26.1"
+version = "0.28.0"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kcp-mcp",
-  "version": "0.26.1",
-  "description": "MCP bridge for the Knowledge Context Protocol — exposes knowledge.yaml units as MCP resources",
+  "version": "0.28.0",
+  "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",
   "engines": {

--- a/bridge/typescript/src/mapper.ts
+++ b/bridge/typescript/src/mapper.ts
@@ -268,6 +268,13 @@ export function manifestToJson(
         audience: u.audience,
       };
       if (u.kind) entry["kind"] = u.kind;
+      // §4.3a: action_scope is an OPAQUE passthrough object — copied wholesale, not
+      // rebuilt field by field the way `delegation` and `compliance` are below. A
+      // rebuild silently drops sub-fields this bridge does not model (`spend` today,
+      // whatever v0.29 adds tomorrow), and a skill whose declared scope is truncated
+      // at the bridge boundary is indistinguishable from one that declares none —
+      // which authorizes nothing. Passing it through keeps the declaration intact.
+      if (u.action_scope) entry["action_scope"] = u.action_scope;
       if (u.format) entry["format"] = u.format;
       if (u.content_type) entry["content_type"] = u.content_type;
       if (u.language) entry["language"] = u.language;

--- a/bridge/typescript/tests/mapper.test.ts
+++ b/bridge/typescript/tests/mapper.test.ts
@@ -457,3 +457,61 @@ describe("manifestToJson — authority, discovery, visibility in unit output", (
     expect(json.discovery).toBeUndefined();
   });
 });
+
+describe("manifestToJson — action_scope (§4.3a)", () => {
+  // The bridge parsed action_scope but never surfaced it: mapper's entry builder
+  // copied `kind` and skipped the envelope that gives `kind: skill` its meaning.
+  // A consumer reading the manifest over MCP saw a skill with no declared scope —
+  // indistinguishable from one that declares none, which per §4.3a authorizes
+  // nothing. Built through parseDict so this covers parse -> map, not just map.
+  function skillManifest(actionScope: unknown) {
+    return parseDict({
+      project: "example",
+      version: "1.0.0",
+      kcp_version: "0.28",
+      units: [
+        {
+          id: "rotate-key",
+          path: "skills/rotate-key.md",
+          intent: "How do I rotate the signing key?",
+          scope: "project",
+          audience: ["agent"],
+          kind: "skill",
+          ...(actionScope === undefined ? {} : { action_scope: actionScope }),
+        },
+      ],
+      relationships: [],
+    });
+  }
+
+  const FULL = {
+    tools: ["kcp-sign", "git"],
+    paths: ["schema/**"],
+    capabilities: ["key-management"],
+    spend: { max_spend: 2, currency: "USD", allowed_vendors: ["registry.example.com"] },
+  };
+
+  it("surfaces action_scope on the unit entry", () => {
+    const out = JSON.parse(manifestToJson(skillManifest(FULL), "example"));
+    expect(out.units[0].action_scope).toBeDefined();
+    expect(out.units[0].action_scope.tools).toEqual(["kcp-sign", "git"]);
+    expect(out.units[0].action_scope.paths).toEqual(["schema/**"]);
+  });
+
+  it("passes action_scope through opaquely, keeping sub-fields it does not model", () => {
+    // §4.3a: action_scope is an opaque passthrough object. Rebuilding it field by
+    // field — as `delegation` and `compliance` are handled — would silently drop
+    // `spend`, and every future sub-field, at the bridge boundary.
+    const out = JSON.parse(manifestToJson(skillManifest(FULL), "example"));
+    expect(out.units[0].action_scope.spend).toEqual({
+      max_spend: 2,
+      currency: "USD",
+      allowed_vendors: ["registry.example.com"],
+    });
+  });
+
+  it("omits action_scope entirely when the unit declares none", () => {
+    const out = JSON.parse(manifestToJson(skillManifest(undefined), "example"));
+    expect("action_scope" in out.units[0]).toBe(false);
+  });
+});

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.26.1",
-  "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
+  "version": "0.28.0",
+  "description": "Developer CLI for the Knowledge Context Protocol \u2014 init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",
   "engines": {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.26.1
+    `\nKCP Developer CLI — v0.28.0
 
 Usage: kcp <command> [options]
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -224,7 +224,7 @@ function yamlQuote(s: string): string {
 
 // Scaffolded manifests declare the spec version this CLI release implements.
 // Guarded against the validator's known-version list in consistency.test.ts.
-export const SCAFFOLD_KCP_VERSION = "0.26";
+export const SCAFFOLD_KCP_VERSION = "0.28";
 
 function writeManifest(
   outputPath: string,

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.26.1";
+export const RENDERER_VERSION = "kcp-cli 0.28.0";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/cli/src/stats.ts
+++ b/cli/src/stats.ts
@@ -99,6 +99,37 @@ export function runStats(options: StatsOptions): void {
     WHERE timestamp >= ?${projectClause} ORDER BY project
   `).all(...baseParams) as { project: string }[]).map((r) => r.project);
 
+  // §17 grant_request_events (v0.28, RFC-0026) — the escalation audit trail. Guarded
+  // rather than assumed: the table is created by whichever component adjudicates grants,
+  // and nothing in this repository does that yet (RFC-0026 deferred the request/response
+  // mechanism). A missing table means "no adjudicator has run", not an error.
+  const hasGrants = db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='grant_request_events'"
+  ).get() !== undefined;
+
+  // One row per state transition, so a request is a group of rows sharing `id`, and
+  // "pending" means created with no resolution row — not a status column.
+  const grants = hasGrants
+    ? (db.prepare(`
+        SELECT
+          COUNT(DISTINCT id) AS requests,
+          COUNT(CASE WHEN event_type = 'granted' THEN 1 END) AS granted,
+          COUNT(CASE WHEN event_type = 'denied'  THEN 1 END) AS denied,
+          COUNT(CASE WHEN event_type = 'expired' THEN 1 END) AS expired
+        FROM grant_request_events
+        WHERE timestamp >= ?
+      `).get(since) as { requests: number; granted: number; denied: number; expired: number })
+    : { requests: 0, granted: 0, denied: 0, expired: 0 };
+
+  const grantTriggers = hasGrants
+    ? (db.prepare(`
+        SELECT trigger, COUNT(DISTINCT id) AS count
+        FROM grant_request_events
+        WHERE timestamp >= ? AND trigger IS NOT NULL
+        GROUP BY trigger ORDER BY count DESC
+      `).all(since) as { trigger: string; count: number }[])
+    : [];
+
   db.close();
 
   if (options.json) {
@@ -112,6 +143,11 @@ export function runStats(options: StatsOptions): void {
         top_units: topUnits,
         top_queries: topQueries,
         projects,
+        grant_requests: {
+          ...grants,
+          pending: grants.requests - grants.granted - grants.denied - grants.expired,
+          by_trigger: grantTriggers,
+        },
       }, null, 2) + "\n"
     );
     return;
@@ -120,7 +156,7 @@ export function runStats(options: StatsOptions): void {
   const label = `last ${options.days} day${options.days === 1 ? "" : "s"}`;
   process.stdout.write(`\n${bold("KCP Usage Statistics")} ${dim(`(${label})`)}\n\n`);
 
-  if (counts.total_events === 0) {
+  if (counts.total_events === 0 && grants.requests === 0) {
     process.stdout.write(dim("  No usage events in this period.\n\n"));
     return;
   }

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -7,6 +7,8 @@ import no.cantara.kcp.model.Authority;
 import no.cantara.kcp.model.Compliance;
 import no.cantara.kcp.model.ContentHash;
 import no.cantara.kcp.model.ContentStructure;
+import no.cantara.kcp.model.ActionScope;
+import no.cantara.kcp.model.Spend;
 import no.cantara.kcp.model.Delegation;
 import no.cantara.kcp.model.Discovery;
 import no.cantara.kcp.model.ExternalDependency;
@@ -223,7 +225,8 @@ public class KcpParser {
                 parseContentStructure(u.get("content_structure")),
                 parseContentHash(u.get("content_hash")),
                 parseTemporal((Map<String, Object>) u.get("temporal")),
-                (String) u.get("authority_level")
+                (String) u.get("authority_level"),
+                parseActionScope(u.get("action_scope"))
         );
     }
 
@@ -297,6 +300,31 @@ public class KcpParser {
                 (String) m.get("key_id"),
                 (String) m.get("algorithm")
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Spend parseSpend(Object raw) {
+        if (!(raw instanceof Map<?, ?> m)) return null;
+        Map<String, Object> d = (Map<String, Object>) m;
+        Object cap = d.get("max_spend");
+        return new Spend(
+                cap instanceof Number n ? n.doubleValue() : null,
+                asStringList(d.get("allowed_vendors")),
+                (String) d.get("currency"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ActionScope parseActionScope(Object raw) {
+        // A scalar or list where an object belongs yields null rather than throwing: a
+        // malformed envelope must not fail the whole parse, and null correctly reads as
+        // "declares nothing", which authorizes nothing.
+        if (!(raw instanceof Map<?, ?> m)) return null;
+        Map<String, Object> d = (Map<String, Object>) m;
+        return new ActionScope(
+                asStringList(d.get("tools")),
+                asStringList(d.get("paths")),
+                asStringList(d.get("capabilities")),
+                parseSpend(d.get("spend")));
     }
 
     @SuppressWarnings("unchecked")

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -62,7 +62,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");

--- a/parsers/java/src/main/java/no/cantara/kcp/model/ActionScope.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/ActionScope.java
@@ -1,0 +1,26 @@
+package no.cantara.kcp.model;
+
+import java.util.List;
+
+/**
+ * The envelope bounding a {@code kind: skill} unit. See SPEC.md §4.3a.
+ *
+ * <p>Absent is not the same as empty. A unit with no {@code action_scope} authorizes
+ * nothing, so the parser yields {@code null} rather than an instance with empty lists —
+ * "declares no scope" and "declares a scope permitting nothing" are different statements
+ * and must stay distinguishable.
+ *
+ * <p>Sub-fields mirror {@code shared/src/parser.ts} {@code parseActionScope}.
+ */
+public record ActionScope(
+        List<String> tools,        // tool names the procedure may invoke
+        List<String> paths,        // paths (globs permitted) it may read or write
+        List<String> capabilities, // named capabilities it requires or exercises
+        Spend spend                // purchases it may make (§4.3a.1)
+) {
+    public ActionScope {
+        tools = tools != null ? List.copyOf(tools) : null;
+        paths = paths != null ? List.copyOf(paths) : null;
+        capabilities = capabilities != null ? List.copyOf(capabilities) : null;
+    }
+}

--- a/parsers/java/src/main/java/no/cantara/kcp/model/KnowledgeUnit.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/KnowledgeUnit.java
@@ -45,7 +45,8 @@ public record KnowledgeUnit(
         ContentStructure contentStructure,
         ContentHash contentHash,
         Temporal temporal,
-        String authorityLevel  // RFC-0025 / §4.23 (v0.27) — ceiling on the root authority_level_scale
+        String authorityLevel,  // RFC-0025 / §4.23 (v0.27) — ceiling on the root authority_level_scale
+        ActionScope actionScope  // §4.3a (v0.26.1) — what a kind: skill procedure may touch
 ) {
     public KnowledgeUnit {
         audience = audience != null ? List.copyOf(audience) : List.of();

--- a/parsers/java/src/main/java/no/cantara/kcp/model/Spend.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/Spend.java
@@ -1,0 +1,20 @@
+package no.cantara.kcp.model;
+
+import java.util.List;
+
+/**
+ * What a {@code kind: skill} procedure may buy. See SPEC.md §4.3a.1.
+ *
+ * <p>Governs the buy <em>decision</em>, fail-closed — an unlisted vendor, an over-cap
+ * amount or a currency mismatch is held. KCP never settles a payment; a runtime wallet
+ * does, and a passing adjudication is not evidence that one succeeded.
+ */
+public record Spend(
+        Double maxSpend,            // per-purchase cap, denominated in `currency`
+        List<String> allowedVendors, // allowlist of vendor/payee identifiers
+        String currency             // ISO 4217 code (USD, EUR) or asset ticker (USDC)
+) {
+    public Spend {
+        allowedVendors = allowedVendors != null ? List.copyOf(allowedVendors) : null;
+    }
+}

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpActionScopeTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpActionScopeTest.java
@@ -1,0 +1,103 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.KnowledgeUnit;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * action_scope parsing — §4.3a (v0.26.1), the envelope that gives {@code kind: skill}
+ * its meaning.
+ *
+ * <p>The Java model carried v0.27 in full (authorityLevel, GrantCeiling, TaskType, Agent)
+ * but never gained {@code action_scope} from v0.26.1. A unit parsed without it is
+ * indistinguishable from one that declares none — and per §4.3a those mean opposite
+ * things: an absent envelope authorizes nothing.
+ *
+ * <p>Mirrors parsers/python/tests/test_action_scope.py and shared/src/parser.ts
+ * {@code parseActionScope}, so the three stay in cross-language parity.
+ */
+class KcpActionScopeTest {
+
+    private static KnowledgeUnit unitWith(Object actionScope) {
+        Map<String, Object> unit = new HashMap<>();
+        unit.put("id", "rotate-key");
+        unit.put("path", "skills/rotate-key.md");
+        unit.put("intent", "How do I rotate the signing key?");
+        unit.put("scope", "project");
+        unit.put("audience", List.of("agent"));
+        unit.put("kind", "skill");
+        if (actionScope != null) unit.put("action_scope", actionScope);
+
+        Map<String, Object> manifest = new HashMap<>();
+        manifest.put("project", "example");
+        manifest.put("version", "1.0.0");
+        manifest.put("kcp_version", "0.28");
+        manifest.put("units", List.of(unit));
+        return KcpParser.fromMap(manifest).units().get(0);
+    }
+
+    @Test
+    void parsesToolsPathsCapabilities() {
+        var u = unitWith(Map.of(
+                "tools", List.of("kcp-sign", "git"),
+                "paths", List.of("schema/**", ".well-known/kcp-signing-key"),
+                "capabilities", List.of("key-management")));
+        assertNotNull(u.actionScope());
+        assertEquals(List.of("kcp-sign", "git"), u.actionScope().tools());
+        assertEquals(List.of("schema/**", ".well-known/kcp-signing-key"), u.actionScope().paths());
+        assertEquals(List.of("key-management"), u.actionScope().capabilities());
+    }
+
+    @Test
+    void parsesSpend() {
+        // §4.3a.1 — the money corner. Governs the buy decision; a runtime wallet settles.
+        var u = unitWith(Map.of(
+                "tools", List.of("http"),
+                "spend", Map.of(
+                        "max_spend", 2.0,
+                        "currency", "USD",
+                        "allowed_vendors", List.of("registry.example.com"))));
+        assertNotNull(u.actionScope().spend());
+        assertEquals(2.0, u.actionScope().spend().maxSpend());
+        assertEquals("USD", u.actionScope().spend().currency());
+        assertEquals(List.of("registry.example.com"), u.actionScope().spend().allowedVendors());
+    }
+
+    @Test
+    void integerMaxSpendIsAccepted() {
+        // YAML yields an Integer for `max_spend: 2`; the field is a Double. Widening here
+        // rather than at every call site keeps `2` and `2.0` equivalent, as a reader expects.
+        var u = unitWith(Map.of("spend", Map.of("max_spend", 2, "currency", "USD")));
+        assertEquals(2.0, u.actionScope().spend().maxSpend());
+    }
+
+    @Test
+    void absentActionScopeIsNullNotEmpty() {
+        // An empty instance would read as "declares a scope permitting nothing", a
+        // different statement from "declares no scope". Keep them distinguishable.
+        assertNull(unitWith(null).actionScope());
+    }
+
+    @Test
+    void partialDeclarationLeavesOtherFieldsNull() {
+        var u = unitWith(Map.of("tools", List.of("bash")));
+        assertEquals(List.of("bash"), u.actionScope().tools());
+        assertNull(u.actionScope().paths());
+        assertNull(u.actionScope().capabilities());
+        assertNull(u.actionScope().spend());
+    }
+
+    @Test
+    void nonObjectActionScopeIsIgnored() {
+        // A malformed envelope must not fail the whole parse; null correctly reads as
+        // "declares nothing", which authorizes nothing.
+        assertNull(unitWith("tools").actionScope());
+        assertNull(unitWith(List.of("tools")).actionScope());
+        assertNull(unitWith(42).actionScope());
+    }
+}

--- a/parsers/python/kcp/model.py
+++ b/parsers/python/kcp/model.py
@@ -128,6 +128,32 @@ class FreshnessPolicy:
 
 
 @dataclass
+class Spend:
+    """What a `kind: skill` procedure may buy. See SPEC.md §4.3a.1.
+
+    Governs the buy *decision*, fail-closed — an unlisted vendor, an over-cap amount or a
+    currency mismatch is held. KCP never settles a payment; a runtime wallet does.
+    """
+    max_spend: Optional[float] = None  # per-purchase cap, denominated in ``currency``
+    allowed_vendors: Optional[List[str]] = None  # allowlist of vendor/payee identifiers
+    currency: Optional[str] = None  # ISO 4217 code (USD, EUR) or asset ticker (USDC)
+
+
+@dataclass
+class ActionScope:
+    """The envelope bounding a ``kind: skill`` unit. See SPEC.md §4.3a.
+
+    Absent is not the same as empty: a unit with no ``action_scope`` authorizes nothing,
+    so the parser yields ``None`` rather than an empty object. Sub-fields mirror
+    ``shared/src/parser.ts`` ``parseActionScope``.
+    """
+    tools: Optional[List[str]] = None  # tool names the procedure may invoke
+    paths: Optional[List[str]] = None  # paths (globs permitted) it may read or write
+    capabilities: Optional[List[str]] = None  # named capabilities it requires or exercises
+    spend: Optional[Spend] = None  # purchases it may make (§4.3a.1)
+
+
+@dataclass
 class KnowledgeUnit:
     id: str
     path: str
@@ -167,6 +193,7 @@ class KnowledgeUnit:
     content_structure: Optional[ContentStructure] = None  # RFC-0016 (v0.17)
     content_hash: Optional[ContentHash] = None  # RFC-0019 (draft)
     temporal: Optional[Temporal] = None  # RFC-0010 / §4.22 (v0.19)
+    action_scope: Optional[ActionScope] = None  # §4.3a (v0.26.1) — what a kind: skill procedure may touch
     authority_level: Optional[str] = None  # RFC-0025 / §4.23 (v0.27) — ceiling on the root authority_level_scale
 
 

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -11,6 +11,8 @@ from .model import (
     PaymentMethod, Serving, RateLimit, RateLimits, RateLimitHeaders, RateLimitTokens,
     RateLimitTokensTier, Relationship, TaskType,
     Trust, TrustAudit, TrustAgentRequirements, TrustProvenance, Visibility,
+    ActionScope,
+    Spend,
 )
 
 
@@ -101,6 +103,30 @@ def _parse_auth(data: Optional[dict]) -> Optional[Auth]:
         for m in data.get("methods", [])
     ]
     return Auth(methods=methods)
+
+
+def _parse_spend(data: Optional[dict]) -> Optional["Spend"]:
+    if not isinstance(data, dict):
+        return None
+    return Spend(
+        max_spend=data.get("max_spend"),
+        allowed_vendors=data.get("allowed_vendors"),
+        currency=data.get("currency"),
+    )
+
+
+def _parse_action_scope(data: Optional[dict]) -> Optional["ActionScope"]:
+    # A scalar or list where an object belongs yields None rather than raising: a
+    # malformed envelope must not take down the whole parse, and None correctly reads
+    # as "declares nothing", which authorizes nothing.
+    if not isinstance(data, dict):
+        return None
+    return ActionScope(
+        tools=data.get("tools"),
+        paths=data.get("paths"),
+        capabilities=data.get("capabilities"),
+        spend=_parse_spend(data.get("spend")),
+    )
 
 
 def _parse_delegation(data: Optional[dict]) -> Optional[Delegation]:
@@ -457,6 +483,7 @@ def parse_dict(data: dict) -> KnowledgeManifest:
             deprecated=u.get("deprecated"),
             payment=_parse_payment(u.get("payment")),
             rate_limits=_parse_rate_limits(u.get("rate_limits")),
+            action_scope=_parse_action_scope(u.get("action_scope")),
             delegation=_parse_delegation(u.get("delegation")),
             compliance=_parse_compliance(u.get("compliance")),
             auth=_parse_auth(u.get("auth")),

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -94,7 +94,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}

--- a/parsers/python/tests/test_action_scope.py
+++ b/parsers/python/tests/test_action_scope.py
@@ -1,0 +1,86 @@
+"""action_scope — §4.3a (v0.26.1), the envelope that gives `kind: skill` its meaning.
+
+The Python model carried v0.27 (authority_level, grant_ceiling, task types, agents) but
+never gained `action_scope` from v0.26.1. A unit parsed without it is indistinguishable
+from a unit that declares none — and per §4.3a those mean opposite things: an absent
+envelope authorizes nothing, so a skill silently loses the declaration that permits it to
+act at all.
+
+Mirrors shared/src/parser.ts `parseActionScope`: four known sub-fields, each optional,
+absent input yielding None rather than an empty object.
+"""
+
+from kcp.parser import parse_dict
+
+
+def _unit(action_scope):
+    raw = {
+        "project": "example",
+        "version": "1.0.0",
+        "kcp_version": "0.28",
+        "units": [
+            {
+                "id": "rotate-key",
+                "path": "skills/rotate-key.md",
+                "intent": "How do I rotate the signing key?",
+                "scope": "project",
+                "audience": ["agent"],
+                "kind": "skill",
+            }
+        ],
+    }
+    if action_scope is not None:
+        raw["units"][0]["action_scope"] = action_scope
+    return parse_dict(raw).units[0]
+
+
+def test_parses_tools_paths_capabilities():
+    u = _unit({
+        "tools": ["kcp-sign", "git"],
+        "paths": ["schema/**", ".well-known/kcp-signing-key"],
+        "capabilities": ["key-management"],
+    })
+    assert u.action_scope is not None
+    assert u.action_scope.tools == ["kcp-sign", "git"]
+    assert u.action_scope.paths == ["schema/**", ".well-known/kcp-signing-key"]
+    assert u.action_scope.capabilities == ["key-management"]
+
+
+def test_parses_spend():
+    # §4.3a.1 — the money corner of the envelope. Governs the buy decision; a runtime
+    # wallet settles.
+    u = _unit({
+        "tools": ["http"],
+        "spend": {
+            "max_spend": 2.0,
+            "currency": "USD",
+            "allowed_vendors": ["registry.example.com"],
+        },
+    })
+    assert u.action_scope.spend is not None
+    assert u.action_scope.spend.max_spend == 2.0
+    assert u.action_scope.spend.currency == "USD"
+    assert u.action_scope.spend.allowed_vendors == ["registry.example.com"]
+
+
+def test_absent_action_scope_is_none_not_empty():
+    # An empty object would read as "declares a scope that permits nothing", which is a
+    # different statement from "declares no scope". Keep them distinguishable.
+    u = _unit(None)
+    assert u.action_scope is None
+
+
+def test_partial_declaration_leaves_other_fields_none():
+    u = _unit({"tools": ["bash"]})
+    assert u.action_scope.tools == ["bash"]
+    assert u.action_scope.paths is None
+    assert u.action_scope.capabilities is None
+    assert u.action_scope.spend is None
+
+
+def test_non_object_action_scope_is_ignored():
+    # Matches parseActionScope: a scalar or list where an object belongs yields None
+    # rather than raising — a malformed envelope must not take down the whole parse.
+    for bad in ("tools", ["tools"], 42):
+        u = _unit(bad)
+        assert u.action_scope is None, f"expected None for {bad!r}"


### PR DESCRIPTION
Works through the list in `docs/PARITY.md` "Required before the next version bump" (#145). Opened early so the TypeScript fix is reviewable while the Java and Python ports land on the same branch.

## Done — item 3: TypeScript `mapper.ts`

`mapper.ts`'s manifest-entry builder copied `kind` and skipped `action_scope`. The field was parsed and then **dropped at the bridge boundary**, so a consumer reading a manifest over MCP saw a `kind: skill` unit with no declared scope — indistinguishable from a skill that declares none, which per §4.3a authorizes nothing at all.

Copied **wholesale**, not rebuilt key by key. `delegation` and `compliance` immediately below are reconstructed field by field, which is right for closed shapes and wrong here: §4.3a defines `action_scope` as an **opaque passthrough object**. A rebuild silently drops `spend` today and every sub-field a future version adds — there is a test asserting that round trip.

Tests go through `parseDict` rather than a hand-built manifest, so they cover **parse → map** rather than map alone:

- the field is surfaced
- sub-fields the bridge does not model survive the round trip
- the key is *absent* (not null) when a unit declares no scope

```
bridge/typescript: 258 tests pass (52 in mapper.test.ts) · tsc --noEmit clean
```

## Outstanding on this branch

- **Item 1** — Java + Python: v0.26.1 `kind: skill` + `action_scope`
- **Item 2** — Java + Python: v0.27 `authority_level`, `authority_level_scale`, `grant_ceiling`, per-task-type and per-agent ceilings
- **Item 4** — `grant_request_events`, or a recorded decision to ship v0.28 with §17 Level 3 unimplemented

Java (~2 700 lines) and Python (~1 480 lines) are separate source trees, not symlinks into `shared/`, so each needs model, parser and mapper changes with tests.

Blocks the v0.28.0 release per the Rule in PARITY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)