### PR TITLE
fix(spec): §4 field table omitted `skill` from the valid kinds

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1593,7 +1593,7 @@ Each entry in `units` describes a self-contained piece of knowledge.
 | `id` | REQUIRED | string | Unique identifier within this manifest. See §4.2. |
 | `aliases` | OPTIONAL | list of strings | Additional identifiers that resolve to this unit. See §4.2a (v0.26). |
 | `path` | REQUIRED | string | Relative path to the content file. See §4.3. |
-| `kind` | OPTIONAL | string | Type of artifact. One of: `knowledge`, `schema`, `service`, `policy`, `executable`. See §4.3a. Default: `knowledge`. |
+| `kind` | OPTIONAL | string | Type of artifact. One of: `knowledge`, `schema`, `service`, `policy`, `executable`, `skill`. See §4.3a. Default: `knowledge`. |
 | `intent` | REQUIRED | string | One sentence: what question does this unit answer? See §4.4. |
 | `format` | OPTIONAL | string | Content format of the referenced file. See §4.4a. |
 | `content_type` | OPTIONAL | string | MIME type for precise format identification. See §4.4b. |

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpParserTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpParserTest.java
@@ -423,7 +423,7 @@ class KcpParserTest {
 
     @Test
     void validKindsProduceNoWarning() {
-        for (String kind : List.of("knowledge", "schema", "service", "policy", "executable")) {
+        for (String kind : List.of("knowledge", "schema", "service", "policy", "executable", "skill")) {
             Map<String, Object> unitData = new HashMap<>(Map.of(
                     "id", "u1", "path", "f.md", "intent", "test", "scope", "global",
                     "audience", List.of("agent"), "kind", kind

--- a/parsers/python/tests/test_kcp.py
+++ b/parsers/python/tests/test_kcp.py
@@ -344,7 +344,7 @@ class TestValidator:
         assert any("kind" in w and "imaginary" in w for w in result.warnings)
 
     def test_valid_kind_no_warning(self):
-        for kind in ["knowledge", "schema", "service", "policy", "executable"]:
+        for kind in ["knowledge", "schema", "service", "policy", "executable", "skill"]:
             data = {
                 **MINIMAL,
                 "kcp_version": "0.3",


### PR DESCRIPTION
`SPEC.md` lists valid `kind` values in two places and they disagree:

| Location | Values |
|---|---|
| §4.3a kind table | `knowledge` `schema` `service` `policy` `executable` `skill` |
| §4 field-reference table (line 1596) | `knowledge` `schema` `service` `policy` `executable` |

`skill` is missing from the second. A reader consulting the field table — the natural place to look up what a field accepts — would conclude `skill` is not a valid value, which is the kind `action_scope`, RFC-0024 and the kcp-skill profile all exist to govern.

**Not a behavioural split.** All three validators already accept six:

- `shared/src/validator.ts`
- `parsers/python/kcp/validator.py:87`
- `KcpValidator.java:56`

So this is documentation drift only — but it shipped in **v0.28**, tagged today.

### Why nothing caught it

Both parser suites iterate the valid-kind list explicitly, and both were written against the original five:

```python
for kind in ["knowledge", "schema", "service", "policy", "executable"]:
```

The sixth kind was added to the validators without extending the loops, so the tests kept passing while covering 5/6. Extended here — Java 103 pass, Python 100.

### Provenance

Found while verifying RFC-0027's cross-references against source instead of trusting them. Every other citation in that RFC checked out; this one was a byproduct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)