### PR TITLE
v0.29: kind: playbook — governed composition of units (RFC-0027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,65 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.29.0] — 2026-07-27 — Playbooks
+
+Adds `kind: playbook` (RFC-0027): an ordered composition of units, governed **per step**.
+
+The gap it closes: `kind: executable` is governed at invocation and opaque thereafter, so a
+procedure that reads state, proposes a change, waits for a human, and then commits must
+declare one authority level for all four phases — either over-granting the reading steps or
+blocking the committing one. RFC-0025 supplied the authority scale and RFC-0026 the
+escalation vocabulary, but neither had a step to attach to.
+
+### Added
+
+- **SPEC.md §4.3b** — `steps`, and the semantics around them: effective authority as a
+  five-source minimum, execution order and the `depends_on` default, what constitutes
+  failure, what `success_condition` is (a prose assertion the protocol never evaluates),
+  stop conditions, scope verifiability, and the orchestration boundary.
+- **`kind: playbook`** in both SPEC.md kind tables, the JSON schema `enum`, and all three
+  validators.
+- **`steps` parsing** in TypeScript, Python and Java, with `escalation` accepting a bare
+  string as shorthand for a single-element list.
+- **Conformance rules** in all three validators: non-empty `steps`, `uses`-or-`action`,
+  unique step ids, acyclic `depends_on`, resolvable `uses`, no nesting, inline-step
+  reporting, and unverifiable-`action_scope` reporting.
+- 28 tests per language, mirroring each other case for case.
+
+### Notes
+
+Two rules are **errors, not warnings**, and both were warnings in the RFC draft until
+adversarial review showed they were load-bearing. An unresolvable `uses` is an error because
+a resolvable `uses` is the entire justification for a distinct kind — without it,
+`executable` plus a metadata block would do. Nesting is an error pending RFC-0027 Open
+Question 1, because as a warning it was no guard: nested playbooks form a combined
+`depends_on` graph that the per-playbook cycle check never sees.
+
+`not_evaluated` is a first-class `success_condition` outcome and does **not** satisfy a
+`depends_on` edge. Without that, an implementation with no evaluator could run a whole
+playbook to `commit` having verified nothing.
+
+### Known gaps
+
+- `uses` resolves by unit id, not by signed hash. Superseding a referenced unit with a
+  broader `action_scope` silently widens an already-approved playbook (RFC-0027 OQ2).
+- The orchestrator-MUST-NOT-execute rule binds an actor with no schema representation, so
+  no validator can check it.
+- Playbook nesting, per-step evidence, run-level budget and cross-step temporal drift remain
+  open (RFC-0027 OQ1, 3, 6, 7).
+
+---
+
+## [0.28.1] — 2026-07-27
+
+### Fixed
+
+- **SPEC.md §4 field table** omitted `skill` from the valid `kind` values while §4.3a listed
+  it. Documentation drift only — all three validators already accepted it — but both parser
+  suites iterated the original five kinds, so nothing failed when the sixth arrived (#148).
+
+---
+
 ## [0.28.0] — 2026-07-27 — Implementation Parity
 
 First release since 0.26.0 (14 July). Ships v0.27 (Authority Level and Grant Ceiling,

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knowledge Context Protocol (KCP) Specification
 
-**Version:** 0.28
+**Version:** 0.29
 **Status:** Draft
 **Date:** 2026-07-24
 **Repository:** github.com/cantara/knowledge-context-protocol
@@ -1593,7 +1593,7 @@ Each entry in `units` describes a self-contained piece of knowledge.
 | `id` | REQUIRED | string | Unique identifier within this manifest. See §4.2. |
 | `aliases` | OPTIONAL | list of strings | Additional identifiers that resolve to this unit. See §4.2a (v0.26). |
 | `path` | REQUIRED | string | Relative path to the content file. See §4.3. |
-| `kind` | OPTIONAL | string | Type of artifact. One of: `knowledge`, `schema`, `service`, `policy`, `executable`, `skill`. See §4.3a. Default: `knowledge`. |
+| `kind` | OPTIONAL | string | Type of artifact. One of: `knowledge`, `schema`, `service`, `policy`, `executable`, `skill`, `playbook`. See §4.3a. Default: `knowledge`. |
 | `intent` | REQUIRED | string | One sentence: what question does this unit answer? See §4.4. |
 | `format` | OPTIONAL | string | Content format of the referenced file. See §4.4a. |
 | `content_type` | OPTIONAL | string | MIME type for precise format identification. See §4.4b. |
@@ -1739,6 +1739,7 @@ procedure (skill).
 | `policy` | Rules, constraints, compliance documents | Evaluate as authoritative gate |
 | `executable` | Runnable artifacts: scripts, notebooks, workflow definitions | Invoke on demand |
 | `skill` | A governed, executable procedure or playbook | Select like knowledge; enact within a declared `action_scope` |
+| `playbook` | An ordered composition of units, governed per step | Select like knowledge; enact step by step, each within its own ceiling (§4.3b) |
 
 If `kind` is omitted, parsers MUST treat the unit as `kind: knowledge`. This ensures full
 backward compatibility with v0.2 manifests.
@@ -1848,6 +1849,138 @@ may spend in total.
 (§3.14), a purchase held by any of the rules above SHOULD raise a grant request rather than
 fail silently, so that a human can authorise the specific purchase without widening the
 declared scope.
+
+### 4.3b `steps` — the composition a `kind: playbook` declares (v0.29)
+
+A `kind: playbook` unit declares an ordered composition of other units, governed **per
+step**. It MUST declare a non-empty `steps` list; a playbook with no steps is a manifest
+error, not a degenerate `executable`.
+
+The distinction from `executable` is that a playbook's steps are *references to other
+units*. `executable` is opaque by construction — an agent may invoke it or not, and
+everything it does thereafter is outside the protocol. A playbook's `uses` is resolvable,
+so a conformance checker can confirm the target exists, is `kind: skill`, and declares an
+`action_scope`. That checkability is the whole benefit of the kind.
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `id` | REQUIRED | string | Unique within the playbook. |
+| `uses` | OPTIONAL | string | Unit id this step enacts. SHOULD name a `kind: skill` unit. |
+| `action` | OPTIONAL | string | Inline description, when no unit exists yet. |
+| `depends_on` | OPTIONAL | list of strings | Step ids that must complete successfully first. |
+| `authority_level` | OPTIONAL | string | §3.13 scale. Ceiling semantics: at most this level. |
+| `escalation` | OPTIONAL | string or list | §3.14 trigger(s). A bare string means a single-element list. |
+| `success_condition` | RECOMMENDED | string | Observable result confirming the step succeeded. |
+| `on_failure` | OPTIONAL | string | `abort` \| `continue` \| `escalate`. Default `abort`. |
+| `timeout` | OPTIONAL | string | ISO 8601 duration. Elapsing constitutes failure. |
+
+Either `uses` or `action` MUST be present.
+
+A playbook unit MAY also declare `authority_level` (a ceiling over every step) and
+`action_scope` (declarative only — see *Scope verifiability* below).
+
+#### Effective authority
+
+A step's effective authority is the **lowest** of: the step's `authority_level`, the
+playbook's `authority_level`, the `grant_ceiling` in force for the task type (§3.13), any
+tenant-scoped ceiling, and the authority granted to the enacting agent. This is §3.13's
+lowest-of rule applied within a composition. **A playbook can never raise authority** —
+composing units cannot grant what neither the units nor the grants allow, which is what
+makes a playbook safe to select automatically.
+
+An omitted source is dropped from the minimum rather than defaulted to the most
+restrictive value. This is safe because the enacting agent's own granted authority is
+never absent, so every minimum has at least one real bound. What omission costs is
+precision, not safety.
+
+`authority_level` and `action_scope` are **independent bounds and both apply**. The
+declared level caps how far a step may go; the `uses` unit's `action_scope` bounds what it
+may touch. Neither substitutes for the other, and the declared level is a cap, not a
+description of what the step does.
+
+#### Execution order
+
+Absent `depends_on` means the step depends on the step immediately preceding it in
+declaration order. Declaration order is total, so this default is always well-defined,
+including where explicit edges form a branching graph.
+
+The resulting graph MUST be acyclic. Steps with no dependency path between them MAY be
+enacted concurrently; an implementation that does not support concurrency MUST enact steps
+in declaration order.
+
+#### Failure, and what `success_condition` is
+
+A step has **failed** when its enactment terminated abnormally, its `success_condition` was
+evaluated and not confirmed, or its `timeout` elapsed. An implementation MUST record which.
+
+`success_condition` is a **prose assertion, not an expression in an evaluation language**.
+This specification deliberately defines no evaluation mechanism: the assertions that matter
+are checked by the enacting agent against the world, not by a parser against a string. A
+conformance checker therefore lints its presence and shape, never its truth.
+
+Implementations MUST record one of `confirmed`, `not_confirmed`, `not_evaluated` per step,
+and MUST NOT treat `not_evaluated` as `confirmed`. A step **completed successfully** — and
+so satisfies a `depends_on` edge — only when it terminated normally, did not time out, and
+its `success_condition` is `confirmed` or absent. `not_evaluated` does not satisfy a
+dependency: treating it as satisfied would let an implementation without an evaluator run a
+whole playbook to `commit` having verified nothing.
+
+#### Stop conditions
+
+`on_failure: continue` means **the run continues past this step**, not that steps depending
+on it may proceed. A step MUST NOT be enacted unless every step it transitively depends on
+completed successfully. Without that rule, `continue` on a verification step removes the
+abort gate while the downstream `commit` step still runs.
+
+`on_failure: abort` halts the whole run, not only the failing step's branch. An
+implementation MUST NOT begin any further step after an abort, and MUST record in-flight
+steps as either cancelled or superseded.
+
+An `escalation` trigger is evaluated **before** the step is enacted — `requires_approval`
+on a `commit` step gates the promotion rather than reporting it. Multiple triggers are
+disjunctive: any one firing suspends the step. `on_failure: escalate` fires after
+enactment, on failure. Both raise a grant request per §3.14; a granted request enacts the
+step, a denied or expired one is treated as `abort`. A suspended step's `timeout` clock
+pauses for the duration of the suspension.
+
+#### Scope verifiability
+
+A playbook's declared `action_scope` is a declaration for review, not a grant, and is
+expected to be the union of its steps' scopes. That union is computable **only when every
+step declares `uses` and every referenced unit declares an `action_scope`.** An inline
+(`action`) step references no unit and so is bounded only by its `authority_level` — it is
+scope-*unbounded*, not merely widely scoped.
+
+Where the union is not computable, a validator MUST report the declared scope as
+*unverified* rather than passing it silently: an unverifiable declaration that lints clean
+is worse than none, because it reads as checked.
+
+#### Orchestration
+
+Where a playbook is enacted by an orchestrator coordinating other agents, the orchestrator
+MUST NOT perform step work itself; it routes, applies the lowest-of rule, and enforces stop
+conditions. An orchestrator that both steers and executes accumulates the union of every
+step's scope, and the per-step bounds become advisory. An implementation that must execute
+locally does so as an orchestrator plus a co-located enacting agent with its own declared
+scope — the requirement is a distinct bound subject, not a distinct machine.
+
+This requirement binds an actor rather than a field, so no validator can check it.
+
+#### Conformance
+
+- A validator MUST error when a `kind: playbook` unit declares no `steps` or an empty list.
+- A validator MUST error when a step declares neither `uses` nor `action`.
+- A validator MUST error when step ids are not unique within the playbook.
+- A validator MUST error when the `depends_on` graph contains a cycle or names an unknown step.
+- A validator MUST error when `uses` does not resolve to a declared unit.
+- A validator MUST error when `uses` names a `kind: playbook` unit — nesting is not yet
+  specified (RFC-0027 Open Question 1), and permitting it would let a combined `depends_on`
+  graph escape the per-playbook cycle check.
+- A validator MUST report the number of inline (`action`) steps.
+- A validator MUST report a declared `action_scope` as unverified where the union is not computable.
+- A validator SHOULD warn when `uses` resolves to a unit that is not `kind: skill`.
+- A validator SHOULD warn when a step omits `authority_level` while its `uses` unit declares
+  a mutating `action_scope`.
 
 ### 4.4 `intent`
 

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.28.0</version>
+    <version>0.29.0</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.28.0"
+version = "0.29.0"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Developer CLI for the Knowledge Context Protocol \u2014 init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.28.0
+    `\nKCP Developer CLI — v0.29.0
 
 Usage: kcp <command> [options]
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -224,7 +224,7 @@ function yamlQuote(s: string): string {
 
 // Scaffolded manifests declare the spec version this CLI release implements.
 // Guarded against the validator's known-version list in consistency.test.ts.
-export const SCAFFOLD_KCP_VERSION = "0.28";
+export const SCAFFOLD_KCP_VERSION = "0.29";
 
 function writeManifest(
   outputPath: string,

--- a/cli/src/playbook.test.ts
+++ b/cli/src/playbook.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import { parseDict } from "../../shared/src/parser.js";
+import { validate } from "../../shared/src/validator.js";
+
+/**
+ * kind: playbook — §4.3b (v0.29, RFC-0027).
+ *
+ * The conformance rules here are the ones the RFC states as MUST, and several exist
+ * because the adversarial review found them missing. Two in particular are tested
+ * from the attack direction rather than the happy path:
+ *
+ *  - an unresolvable `uses` must be an ERROR, not a warning. A resolvable `uses` is
+ *    the entire justification for playbook being a distinct kind rather than
+ *    `executable` plus metadata; a dangling reference that lints clean removes the
+ *    only thing the new kind buys.
+ *  - nesting must be an ERROR pending RFC-0027 OQ1. Left as a warning it is no guard:
+ *    nested playbooks form a combined depends_on graph that the per-playbook cycle
+ *    check never sees.
+ */
+
+function manifest(units: unknown[], extra: Record<string, unknown> = {}) {
+  return parseDict({
+    project: "example",
+    version: "1.0.0",
+    kcp_version: "0.29",
+    units,
+    ...extra,
+  });
+}
+
+const SKILL = {
+  id: "run-test-suite",
+  kind: "skill",
+  path: "skills/run.md",
+  intent: "How do I run the suite?",
+  scope: "project",
+  audience: ["agent"],
+  action_scope: { tools: ["bash"], paths: ["test/**"] },
+};
+
+function playbook(steps: unknown[], extra: Record<string, unknown> = {}) {
+  return {
+    id: "promote",
+    kind: "playbook",
+    path: "playbooks/promote.md",
+    intent: "How do we promote a build?",
+    scope: "project",
+    audience: ["agent"],
+    steps,
+    ...extra,
+  };
+}
+
+describe("parsing", () => {
+  it("parses steps with every declared field", () => {
+    const m = manifest([
+      SKILL,
+      playbook([
+        {
+          id: "verify",
+          uses: "run-test-suite",
+          depends_on: [],
+          authority_level: "observe",
+          escalation: ["requires_approval"],
+          success_condition: "zero failures",
+          on_failure: "abort",
+          timeout: "PT10M",
+        },
+      ]),
+    ]);
+    const step = m.units[1]!.steps![0]!;
+    expect(step.id).toBe("verify");
+    expect(step.uses).toBe("run-test-suite");
+    expect(step.authority_level).toBe("observe");
+    expect(step.escalation).toEqual(["requires_approval"]);
+    expect(step.success_condition).toBe("zero failures");
+    expect(step.on_failure).toBe("abort");
+    expect(step.timeout).toBe("PT10M");
+  });
+
+  it("normalises a bare escalation string to a single-element list", () => {
+    // §4.3b calls the triggers disjunctive, so a scalar and a one-element list mean
+    // the same thing. Normalising at parse time means no consumer has to handle both.
+    const m = manifest([SKILL, playbook([{ id: "a", uses: "run-test-suite", escalation: "requires_approval" }])]);
+    expect(m.units[1]!.steps![0]!.escalation).toEqual(["requires_approval"]);
+  });
+
+  it("absent steps is undefined, not an empty list", () => {
+    // "declares no steps" and "declares an empty composition" are different
+    // statements; the validator rejects both for a playbook, but the parser must
+    // keep them distinguishable.
+    const m = manifest([{ ...SKILL, action_scope: undefined }]);
+    expect(m.units[0]!.steps).toBeUndefined();
+  });
+
+  it("drops steps that are not objects or carry no id", () => {
+    // A step without an identity cannot be named by depends_on, so it cannot take
+    // part in the graph at all. Half-parsing it would put an id-less entry into a
+    // structure that is indexed by id.
+    const m = manifest([SKILL, playbook(["not-an-object", { uses: "run-test-suite" }, { id: "ok", action: "x" }])]);
+    expect(m.units[1]!.steps!.map((s) => s.id)).toEqual(["ok"]);
+  });
+
+  it("a malformed steps block does not take down the parse", () => {
+    const m = manifest([SKILL, playbook("steps" as unknown as unknown[])]);
+    expect(m.units[1]!.steps).toBeUndefined();
+    expect(m.units[1]!.id).toBe("promote");
+  });
+});
+
+describe("validation — structure", () => {
+  it("accepts a well-formed playbook with no errors", () => {
+    const r = validate(
+      manifest([SKILL, playbook([{ id: "verify", uses: "run-test-suite", authority_level: "observe" }])],
+        { authority_level_scale: ["observe", "explain", "suggest", "prepare", "commit"] })
+    );
+    expect(r.errors).toEqual([]);
+  });
+
+  it("errors when a playbook declares no steps", () => {
+    const r = validate(manifest([{ ...playbook([]), steps: undefined }]));
+    expect(r.errors.some((e) => /MUST declare a non-empty 'steps'/.test(e))).toBe(true);
+  });
+
+  it("errors on an empty steps list", () => {
+    const r = validate(manifest([playbook([])]));
+    expect(r.errors.some((e) => /non-empty 'steps'/.test(e))).toBe(true);
+  });
+
+  it("errors when a step declares neither uses nor action", () => {
+    const r = validate(manifest([playbook([{ id: "orphan" }])]));
+    expect(r.errors.some((e) => /MUST declare either 'uses' or 'action'/.test(e))).toBe(true);
+  });
+
+  it("errors on duplicate step ids", () => {
+    const r = validate(manifest([SKILL, playbook([
+      { id: "a", uses: "run-test-suite" },
+      { id: "a", action: "again" },
+    ])]));
+    expect(r.errors.some((e) => /duplicate step id 'a'/.test(e))).toBe(true);
+  });
+
+  it("errors on an unknown on_failure value", () => {
+    const r = validate(manifest([SKILL, playbook([{ id: "a", uses: "run-test-suite", on_failure: "retry" }])]));
+    expect(r.errors.some((e) => /'on_failure' must be one of/.test(e))).toBe(true);
+  });
+});
+
+describe("validation — uses resolution", () => {
+  it("ERRORS on an unresolvable uses, rather than warning", () => {
+    const r = validate(manifest([playbook([{ id: "a", uses: "nonexistent" }])]));
+    expect(r.errors.some((e) => /not declared in this manifest/.test(e))).toBe(true);
+    expect(r.warnings.some((w) => /nonexistent/.test(w))).toBe(false);
+  });
+
+  it("resolves a uses that names a unit declared LATER in the manifest", () => {
+    // The check is a second pass for exactly this reason: unitIds is incomplete
+    // mid-loop, so an inline check would reject a legal forward reference.
+    const r = validate(manifest([playbook([{ id: "a", uses: "run-test-suite" }]), SKILL]));
+    expect(r.errors).toEqual([]);
+  });
+
+  it("ERRORS when uses names another playbook (nesting is forbidden, OQ1)", () => {
+    const inner = { ...playbook([{ id: "x", action: "inner" }]), id: "inner" };
+    const outer = { ...playbook([{ id: "a", uses: "inner" }]), id: "outer" };
+    const r = validate(manifest([inner, outer]));
+    expect(r.errors.some((e) => /nesting is not permitted/.test(e))).toBe(true);
+  });
+
+  it("warns — not errors — when uses names a resolvable non-skill unit", () => {
+    const doc = { id: "notes", kind: "knowledge", path: "n.md", intent: "x", scope: "project", audience: ["agent"] };
+    const r = validate(manifest([doc, playbook([{ id: "a", uses: "notes" }])]));
+    expect(r.errors).toEqual([]);
+    expect(r.warnings.some((w) => /SHOULD name a kind: skill unit/.test(w))).toBe(true);
+  });
+});
+
+describe("validation — the depends_on graph", () => {
+  it("errors on a dangling depends_on", () => {
+    const r = validate(manifest([SKILL, playbook([{ id: "a", uses: "run-test-suite", depends_on: ["ghost"] }])]));
+    expect(r.errors.some((e) => /depends_on names unknown step 'ghost'/.test(e))).toBe(true);
+  });
+
+  it("errors on a two-step cycle", () => {
+    const r = validate(manifest([SKILL, playbook([
+      { id: "a", uses: "run-test-suite", depends_on: ["b"] },
+      { id: "b", uses: "run-test-suite", depends_on: ["a"] },
+    ])]));
+    expect(r.errors.some((e) => /contains a cycle/.test(e))).toBe(true);
+  });
+
+  it("errors on a longer cycle and names the path", () => {
+    const r = validate(manifest([SKILL, playbook([
+      { id: "a", uses: "run-test-suite", depends_on: ["c"] },
+      { id: "b", uses: "run-test-suite", depends_on: ["a"] },
+      { id: "c", uses: "run-test-suite", depends_on: ["b"] },
+    ])]));
+    const cycle = r.errors.find((e) => /contains a cycle/.test(e));
+    expect(cycle).toBeDefined();
+    expect(cycle).toMatch(/->/);
+  });
+
+  it("errors on a self-dependency", () => {
+    const r = validate(manifest([SKILL, playbook([{ id: "a", uses: "run-test-suite", depends_on: ["a"] }])]));
+    expect(r.errors.some((e) => /contains a cycle/.test(e))).toBe(true);
+  });
+
+  it("accepts a diamond — shared dependencies are not cycles", () => {
+    // The classic false positive for a naive visited-set walk: d is reached twice by
+    // distinct paths, which is convergence, not a cycle.
+    const r = validate(manifest([SKILL, playbook([
+      { id: "a", uses: "run-test-suite" },
+      { id: "b", uses: "run-test-suite", depends_on: ["a"] },
+      { id: "c", uses: "run-test-suite", depends_on: ["a"] },
+      { id: "d", uses: "run-test-suite", depends_on: ["b", "c"] },
+    ])]));
+    expect(r.errors).toEqual([]);
+  });
+
+  it("does not stack-overflow on a long chain", () => {
+    // Untrusted input: a deep chain must report cleanly, not crash the validator.
+    const steps = Array.from({ length: 5000 }, (_, i) => ({
+      id: `s${i}`, uses: "run-test-suite", depends_on: i > 0 ? [`s${i - 1}`] : [],
+    }));
+    const r = validate(manifest([SKILL, playbook(steps)]));
+    expect(r.errors.filter((e) => /cycle/.test(e))).toEqual([]);
+  });
+});
+
+describe("validation — scope verifiability", () => {
+  it("warns that inline steps are bounded only by authority_level", () => {
+    const r = validate(manifest([playbook([{ id: "a", action: "do the thing" }])]));
+    expect(r.warnings.some((w) => /inline .*bounded only by its authority_level/.test(w))).toBe(true);
+  });
+
+  it("reports a declared action_scope as UNVERIFIED when any step is inline", () => {
+    // §4.3b: an unverifiable declaration that lints clean is worse than none,
+    // because it reads as checked.
+    const r = validate(manifest([
+      SKILL,
+      playbook([{ id: "a", uses: "run-test-suite" }, { id: "b", action: "inline" }],
+        { action_scope: { tools: ["bash"] } }),
+    ]));
+    expect(r.warnings.some((w) => /UNVERIFIED/.test(w))).toBe(true);
+  });
+
+  it("reports UNVERIFIED when a referenced unit declares no action_scope", () => {
+    const scopeless = { ...SKILL, id: "bare", action_scope: undefined };
+    const r = validate(manifest([
+      scopeless,
+      playbook([{ id: "a", uses: "bare" }], { action_scope: { tools: ["bash"] } }),
+    ]));
+    expect(r.warnings.some((w) => /UNVERIFIED/.test(w))).toBe(true);
+  });
+
+  it("does not report UNVERIFIED when every step resolves to a scoped unit", () => {
+    const r = validate(manifest([
+      SKILL,
+      playbook([{ id: "a", uses: "run-test-suite" }], { action_scope: { tools: ["bash"] } }),
+    ]));
+    expect(r.warnings.some((w) => /UNVERIFIED/.test(w))).toBe(false);
+  });
+
+  it("warns when a mutating step omits authority_level", () => {
+    const r = validate(manifest([SKILL, playbook([{ id: "a", uses: "run-test-suite" }])]));
+    expect(r.warnings.some((w) => /omits 'authority_level'/.test(w))).toBe(true);
+  });
+});
+
+describe("validation — non-playbook units", () => {
+  it("warns when a non-playbook declares steps", () => {
+    const r = validate(manifest([{ ...SKILL, steps: [{ id: "a", action: "x" }] }]));
+    expect(r.warnings.some((w) => /steps are only enacted for kind: playbook/.test(w))).toBe(true);
+  });
+
+  it("playbook is a recognised kind and does not warn as unknown", () => {
+    const r = validate(manifest([SKILL, playbook([{ id: "a", uses: "run-test-suite" }])]));
+    expect(r.warnings.some((w) => /unknown kind/.test(w))).toBe(false);
+  });
+});

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.28.0";
+export const RENDERER_VERSION = "kcp-cli 0.29.0";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -8,6 +8,7 @@ import no.cantara.kcp.model.Compliance;
 import no.cantara.kcp.model.ContentHash;
 import no.cantara.kcp.model.ContentStructure;
 import no.cantara.kcp.model.ActionScope;
+import no.cantara.kcp.model.PlaybookStep;
 import no.cantara.kcp.model.Spend;
 import no.cantara.kcp.model.Delegation;
 import no.cantara.kcp.model.Discovery;
@@ -47,6 +48,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -226,7 +228,8 @@ public class KcpParser {
                 parseContentHash(u.get("content_hash")),
                 parseTemporal((Map<String, Object>) u.get("temporal")),
                 (String) u.get("authority_level"),
-                parseActionScope(u.get("action_scope"))
+                parseActionScope(u.get("action_scope")),
+                parseSteps(u.get("steps"))
         );
     }
 
@@ -311,6 +314,51 @@ public class KcpParser {
                 cap instanceof Number n ? n.doubleValue() : null,
                 asStringList(d.get("allowed_vendors")),
                 (String) d.get("currency"));
+    }
+
+    /**
+     * §4.3b (v0.29, RFC-0027): the ordered composition a {@code kind: playbook} declares.
+     *
+     * <p>Anything that is not a list yields null, matching {@link #parseActionScope}: a
+     * malformed block must not fail the whole parse, and null reads as "declares no
+     * steps", which the validator then rejects for a playbook. Entries that are not maps,
+     * or carry no {@code id}, are dropped rather than half-parsed — a step with no
+     * identity cannot be named by {@code depends_on}, so it cannot join the graph at all.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<PlaybookStep> parseSteps(Object raw) {
+        if (!(raw instanceof List<?> list)) return null;
+        List<PlaybookStep> steps = new ArrayList<>();
+        for (Object item : list) {
+            if (!(item instanceof Map<?, ?> m)) continue;
+            Map<String, Object> d = (Map<String, Object>) m;
+            if (d.get("id") == null) continue;
+            steps.add(new PlaybookStep(
+                    String.valueOf(d.get("id")),
+                    asString(d.get("uses")),
+                    asString(d.get("action")),
+                    asStringList(d.get("depends_on")),
+                    asString(d.get("authority_level")),
+                    parseEscalation(d.get("escalation")),
+                    asString(d.get("success_condition")),
+                    asString(d.get("on_failure")),
+                    asString(d.get("timeout"))));
+        }
+        return steps;
+    }
+
+    /**
+     * §4.3b: {@code escalation} accepts a single trigger or a list; both normalise to a
+     * list, since the triggers are disjunctive and a scalar means a list of one.
+     */
+    private static List<String> parseEscalation(Object raw) {
+        if (raw == null) return null;
+        if (raw instanceof String s) return List.of(s);
+        return asStringList(raw);
+    }
+
+    private static String asString(Object raw) {
+        return raw != null ? String.valueOf(raw) : null;
     }
 
     @SuppressWarnings("unchecked")

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -68,7 +68,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -12,7 +12,9 @@ import no.cantara.kcp.model.GrantCeiling;
 import no.cantara.kcp.model.GrantCeilingSource;
 import no.cantara.kcp.model.HumanInTheLoop;
 import no.cantara.kcp.model.KnowledgeManifest;
+import no.cantara.kcp.model.ActionScope;
 import no.cantara.kcp.model.KnowledgeUnit;
+import no.cantara.kcp.model.PlaybookStep;
 import no.cantara.kcp.model.AgentIdentity;
 import no.cantara.kcp.model.ManifestRef;
 import no.cantara.kcp.model.Payment;
@@ -36,6 +38,9 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +58,8 @@ public class KcpValidator {
     private static final Set<String> VALID_SCOPES = Set.of("global", "project", "module");
     private static final Set<String> VALID_AUDIENCES = Set.of("human", "agent", "developer", "operator", "architect", "devops");
     private static final Set<String> VALID_RELATIONSHIP_TYPES = Set.of("enables", "context", "supersedes", "contradicts", "depends_on", "governs");
-    private static final Set<String> VALID_KINDS = Set.of("knowledge", "schema", "service", "policy", "executable", "skill");
+    private static final Set<String> VALID_KINDS = Set.of("knowledge", "schema", "service", "policy", "executable", "skill", "playbook");
+    private static final Set<String> VALID_ON_FAILURE = Set.of("abort", "continue", "escalate");
     private static final Set<String> VALID_FORMATS = Set.of(
             "markdown", "pdf", "openapi", "json-schema", "jupyter",
             "html", "asciidoc", "rst", "vtt", "yaml", "json", "csv", "text");
@@ -281,6 +287,146 @@ public class KcpValidator {
             // validate recomputes and compares"). A stale hash is an error, not a
             // warning: signing over it would brick the unit for every consumer.
             validateContentHash(unit.contentHash(), unit.path(), manifestDir, p, errors);
+        }
+
+        // --- kind: playbook — §4.3b (v0.29, RFC-0027) ---
+        //
+        // Deliberately a second pass over the units. `uses` may name a unit declared
+        // later in the manifest, so resolving it inside the loop above would reject
+        // forward references the spec permits.
+        Map<String, String> unitKinds = new LinkedHashMap<>();
+        Map<String, KnowledgeUnit> unitsById = new LinkedHashMap<>();
+        for (KnowledgeUnit u : manifest.units()) {
+            unitKinds.put(u.id(), u.kind() != null ? u.kind() : "knowledge");
+            unitsById.put(u.id(), u);
+        }
+        Set<String> declaredLevels = manifest.authorityLevelScale() != null
+                ? new HashSet<>(manifest.authorityLevelScale()) : Set.of();
+
+        for (KnowledgeUnit unit : manifest.units()) {
+            String ctx = "unit '" + unit.id() + "'";
+            String kind = unit.kind() != null ? unit.kind() : "knowledge";
+
+            if (!"playbook".equals(kind)) {
+                // steps on a non-playbook is a category error, not a silent no-op: the
+                // author declared a composition the protocol will never enact.
+                if (unit.steps() != null) {
+                    warnings.add(ctx + ": declares 'steps' but kind is '" + kind
+                            + "'; steps are only enacted for kind: playbook (§4.3b)");
+                }
+                continue;
+            }
+
+            // A playbook MUST declare steps, and the list MUST be non-empty. An empty
+            // composition is not a degenerate executable — it is a manifest error.
+            if (unit.steps() == null || unit.steps().isEmpty()) {
+                errors.add(ctx + ": kind 'playbook' MUST declare a non-empty 'steps' list (§4.3b)");
+                continue;
+            }
+
+            Set<String> stepIds = new HashSet<>();
+            for (PlaybookStep step : unit.steps()) {
+                String sctx = ctx + " step '" + step.id() + "'";
+
+                if (!stepIds.add(step.id())) {
+                    errors.add(ctx + ": duplicate step id '" + step.id() + "' (§4.3b)");
+                }
+
+                if (step.uses() == null && step.action() == null) {
+                    errors.add(sctx + ": MUST declare either 'uses' or 'action' (§4.3b)");
+                }
+
+                if (step.uses() != null) {
+                    String target = unitKinds.get(step.uses());
+                    if (target == null) {
+                        // An error, not a warning: a resolvable `uses` is the whole
+                        // justification for playbook being a distinct kind. A dangling
+                        // reference that lints clean reduces the playbook to an
+                        // executable with worse ergonomics.
+                        errors.add(sctx + ": 'uses' names unit '" + step.uses()
+                                + "', which is not declared in this manifest (§4.3b)");
+                    } else if ("playbook".equals(target)) {
+                        // Nesting is forbidden pending RFC-0027 OQ1. As a warning it
+                        // would be no guard: nested playbooks form a combined
+                        // depends_on graph the per-playbook cycle check never sees.
+                        errors.add(sctx + ": 'uses' names playbook '" + step.uses()
+                                + "'; playbook nesting is not permitted (§4.3b, RFC-0027 OQ1)");
+                    } else if (!"skill".equals(target)) {
+                        warnings.add(sctx + ": 'uses' names '" + step.uses() + "' of kind '"
+                                + target + "'; SHOULD name a kind: skill unit (§4.3b)");
+                    }
+                }
+
+                if (step.onFailure() != null && !VALID_ON_FAILURE.contains(step.onFailure())) {
+                    errors.add(sctx + ": 'on_failure' must be one of [abort, continue, escalate], got '"
+                            + step.onFailure() + "'");
+                }
+
+                // Checked against the manifest's declared scale rather than a hardcoded
+                // vocabulary — §3.13 makes authority_level_scale a per-manifest
+                // declaration, and the v0.27 check already works that way.
+                if (step.authorityLevel() != null && !declaredLevels.isEmpty()
+                        && !declaredLevels.contains(step.authorityLevel())) {
+                    warnings.add(sctx + ": 'authority_level' value '" + step.authorityLevel()
+                            + "' is not in the declared 'authority_level_scale' (§3.13)");
+                }
+
+                // A step whose unit can mutate but which declares no ceiling is bounded
+                // only by the enacting agent's own grant — looser than intended (§4.3b).
+                if (step.authorityLevel() == null && step.uses() != null) {
+                    KnowledgeUnit target = unitsById.get(step.uses());
+                    ActionScope scope = target != null ? target.actionScope() : null;
+                    boolean mutating = scope != null
+                            && ((scope.paths() != null && !scope.paths().isEmpty())
+                                || scope.spend() != null);
+                    if (mutating) {
+                        warnings.add(sctx + ": omits 'authority_level' while '" + step.uses()
+                                + "' declares a mutating action_scope; the step is bounded"
+                                + " only by the enacting agent (§4.3b)");
+                    }
+                }
+            }
+
+            for (PlaybookStep step : unit.steps()) {
+                if (step.dependsOn() == null) continue;
+                for (String dep : step.dependsOn()) {
+                    if (!stepIds.contains(dep)) {
+                        errors.add(ctx + " step '" + step.id()
+                                + "': depends_on names unknown step '" + dep + "' (§4.3b)");
+                    }
+                }
+            }
+
+            List<String> cycle = findStepCycle(unit.steps());
+            if (cycle != null) {
+                errors.add(ctx + ": 'depends_on' graph contains a cycle: "
+                        + String.join(" -> ", cycle) + " (§4.3b)");
+            }
+
+            // §4.3b: the step-scope union is computable only when every step uses a unit
+            // and every such unit declares an action_scope. Report a declared scope as
+            // unverified rather than passing it silently — a declaration that lints
+            // clean reads as checked.
+            long inline = unit.steps().stream().filter(s -> s.uses() == null).count();
+            if (inline > 0) {
+                warnings.add(ctx + ": " + inline + " of " + unit.steps().size()
+                        + " step(s) are inline ('action'); an inline step has no action_scope"
+                        + " and is bounded only by its authority_level (§4.3b)");
+            }
+            if (unit.actionScope() != null) {
+                long scopeless = unit.steps().stream()
+                        .filter(s -> s.uses() != null)
+                        .filter(s -> {
+                            KnowledgeUnit t2 = unitsById.get(s.uses());
+                            return t2 == null || t2.actionScope() == null;
+                        }).count();
+                if (inline > 0 || scopeless > 0) {
+                    warnings.add(ctx + ": declared 'action_scope' is UNVERIFIED — the"
+                            + " step-scope union is not computable (" + inline
+                            + " inline step(s), " + scopeless
+                            + " step(s) whose unit declares no action_scope) (§4.3b)");
+                }
+            }
         }
 
         // Root-level delegation validation
@@ -1092,5 +1238,63 @@ public class KcpValidator {
 
     private static List<String> sorted(Set<String> set) {
         return set.stream().sorted().toList();
+    }
+
+    /**
+     * §4.3b (v0.29): find a cycle in a playbook's explicit {@code depends_on} graph,
+     * returning the cycle path for the error message, or null if the graph is acyclic.
+     *
+     * <p>Only explicit edges are walked. The implicit "after the previous step in
+     * declaration order" default cannot produce a cycle — declaration order is total —
+     * so materialising it would add edges that are never a defect and would obscure
+     * which edges the author actually wrote.
+     *
+     * <p>Iterative rather than recursive: a manifest is untrusted input, and a deep
+     * chain must report a cycle rather than exhaust the stack.
+     */
+    private static List<String> findStepCycle(List<PlaybookStep> steps) {
+        Map<String, List<String>> edges = new LinkedHashMap<>();
+        for (PlaybookStep s : steps) {
+            edges.put(s.id(), s.dependsOn() != null ? s.dependsOn() : List.of());
+        }
+        final int WHITE = 0, GREY = 1, BLACK = 2;
+        Map<String, Integer> colour = new HashMap<>();
+        for (PlaybookStep s : steps) colour.put(s.id(), WHITE);
+
+        for (PlaybookStep root : steps) {
+            if (colour.get(root.id()) != WHITE) continue;
+            Deque<String> path = new ArrayDeque<>();
+            Deque<int[]> cursor = new ArrayDeque<>();
+            path.addLast(root.id());
+            cursor.addLast(new int[]{0});
+            colour.put(root.id(), GREY);
+            while (!path.isEmpty()) {
+                String current = path.peekLast();
+                int[] idx = cursor.peekLast();
+                List<String> deps = edges.getOrDefault(current, List.of());
+                if (idx[0] >= deps.size()) {
+                    colour.put(current, BLACK);
+                    path.removeLast();
+                    cursor.removeLast();
+                    continue;
+                }
+                String dep = deps.get(idx[0]++);
+                if (!edges.containsKey(dep)) continue;  // dangling; reported separately
+                int c = colour.get(dep);
+                if (c == GREY) {
+                    // Grey means dep is on the current path — slice from it.
+                    List<String> asList = new ArrayList<>(path);
+                    List<String> out = new ArrayList<>(asList.subList(asList.indexOf(dep), asList.size()));
+                    out.add(dep);
+                    return out;
+                }
+                if (c == WHITE) {
+                    colour.put(dep, GREY);
+                    path.addLast(dep);
+                    cursor.addLast(new int[]{0});
+                }
+            }
+        }
+        return null;
     }
 }

--- a/parsers/java/src/main/java/no/cantara/kcp/model/KnowledgeUnit.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/KnowledgeUnit.java
@@ -46,10 +46,12 @@ public record KnowledgeUnit(
         ContentHash contentHash,
         Temporal temporal,
         String authorityLevel,  // RFC-0025 / §4.23 (v0.27) — ceiling on the root authority_level_scale
-        ActionScope actionScope  // §4.3a (v0.26.1) — what a kind: skill procedure may touch
+        ActionScope actionScope,  // §4.3a (v0.26.1) — what a kind: skill procedure may touch
+        List<PlaybookStep> steps  // §4.3b (v0.29) — ordered composition; required for kind: playbook
 ) {
     public KnowledgeUnit {
         audience = audience != null ? List.copyOf(audience) : List.of();
+        steps = steps != null ? List.copyOf(steps) : null;
         dependsOn = dependsOn != null ? List.copyOf(dependsOn) : List.of();
         triggers = triggers != null ? List.copyOf(triggers) : List.of();
         externalDependsOn = externalDependsOn != null ? List.copyOf(externalDependsOn) : List.of();

--- a/parsers/java/src/main/java/no/cantara/kcp/model/PlaybookStep.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/PlaybookStep.java
@@ -1,0 +1,37 @@
+package no.cantara.kcp.model;
+
+import java.util.List;
+
+/**
+ * One step of a {@code kind: playbook} composition. See SPEC.md §4.3b (v0.29, RFC-0027).
+ *
+ * <p>The step — not the playbook — is the unit of governance. {@code authorityLevel} is a
+ * ceiling on this step alone; effective authority is the minimum across it, the playbook's,
+ * the task-type grant_ceiling, any tenant ceiling, and the enacting agent's own grant. A
+ * playbook can therefore never raise authority: composing units cannot grant what neither
+ * the units nor the grants allow.
+ *
+ * <p>{@code escalation} is a list even when the manifest declares a bare string. The
+ * triggers are disjunctive — any one firing suspends the step — so a scalar and a
+ * one-element list mean the same thing, and normalising at parse time means no consumer
+ * has to handle both shapes.
+ *
+ * <p>Mirrors {@code shared/src/parser.ts} {@code parseSteps} and the Python
+ * {@code PlaybookStep} dataclass.
+ */
+public record PlaybookStep(
+        String id,                // unique within the playbook
+        String uses,              // unit id this step enacts; SHOULD name a kind: skill unit
+        String action,            // inline description, when no unit exists yet
+        List<String> dependsOn,   // step ids that must complete successfully first
+        String authorityLevel,    // RFC-0025 scale; ceiling semantics — at most this level
+        List<String> escalation,  // RFC-0026 triggers; disjunctive, evaluated pre-enactment
+        String successCondition,  // prose assertion; the protocol never evaluates it
+        String onFailure,         // abort | continue | escalate; default abort
+        String timeout            // ISO 8601 duration; elapsing constitutes failure
+) {
+    public PlaybookStep {
+        dependsOn = dependsOn != null ? List.copyOf(dependsOn) : null;
+        escalation = escalation != null ? List.copyOf(escalation) : null;
+    }
+}

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpPlaybookTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpPlaybookTest.java
@@ -1,0 +1,354 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.KnowledgeManifest;
+import no.cantara.kcp.model.PlaybookStep;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@code kind: playbook} — §4.3b (v0.29, RFC-0027).
+ *
+ * <p>Mirrors cli/src/playbook.test.ts and parsers/python/tests/test_playbook.py case for
+ * case, so the three implementations can be compared by reading them side by side.
+ *
+ * <p>Two rules are tested from the attack direction rather than the happy path, because
+ * the adversarial review on RFC-0027 found both stated as advice while being load-bearing:
+ *
+ * <ul>
+ *   <li>an unresolvable {@code uses} must be an ERROR. A resolvable {@code uses} is the
+ *       entire justification for playbook being a distinct kind rather than
+ *       {@code executable} plus a metadata block; a dangling reference that lints clean
+ *       removes the only thing the new kind buys.
+ *   <li>nesting must be an ERROR pending RFC-0027 OQ1. As a warning it is no guard at
+ *       all: nested playbooks form a combined depends_on graph the per-playbook cycle
+ *       check never sees.
+ * </ul>
+ */
+class KcpPlaybookTest {
+
+    private static Map<String, Object> skill() {
+        Map<String, Object> u = new LinkedHashMap<>();
+        u.put("id", "run-test-suite");
+        u.put("kind", "skill");
+        u.put("path", "skills/run.md");
+        u.put("intent", "How do I run the suite?");
+        u.put("scope", "project");
+        u.put("audience", List.of("agent"));
+        u.put("action_scope", Map.of("tools", List.of("bash"), "paths", List.of("test/**")));
+        return u;
+    }
+
+    private static Map<String, Object> playbook(Object steps) {
+        Map<String, Object> u = new LinkedHashMap<>();
+        u.put("id", "promote");
+        u.put("kind", "playbook");
+        u.put("path", "playbooks/promote.md");
+        u.put("intent", "How do we promote a build?");
+        u.put("scope", "project");
+        u.put("audience", List.of("agent"));
+        if (steps != null) u.put("steps", steps);
+        return u;
+    }
+
+    private static Map<String, Object> step(String id, String... kv) {
+        Map<String, Object> s = new LinkedHashMap<>();
+        s.put("id", id);
+        for (int i = 0; i < kv.length; i += 2) s.put(kv[i], kv[i + 1]);
+        return s;
+    }
+
+    private static KnowledgeManifest manifest(List<Map<String, Object>> units) {
+        return manifest(units, Map.of());
+    }
+
+    private static KnowledgeManifest manifest(List<Map<String, Object>> units,
+                                              Map<String, Object> extra) {
+        Map<String, Object> raw = new HashMap<>();
+        raw.put("project", "example");
+        raw.put("version", "1.0.0");
+        raw.put("kcp_version", "0.29");
+        raw.put("units", units);
+        raw.putAll(extra);
+        return KcpParser.fromMap(raw);
+    }
+
+    private static List<String> errors(List<Map<String, Object>> units) {
+        return KcpValidator.validate(manifest(units)).errors();
+    }
+
+    private static List<String> warnings(List<Map<String, Object>> units) {
+        return KcpValidator.validate(manifest(units)).warnings();
+    }
+
+    private static boolean any(List<String> messages, String fragment) {
+        return messages.stream().anyMatch(m -> m.contains(fragment));
+    }
+
+    // --- parsing ---------------------------------------------------------------
+
+    @Test
+    void parsesEveryStepField() {
+        Map<String, Object> s = step("verify",
+                "uses", "run-test-suite",
+                "authority_level", "observe",
+                "success_condition", "zero failures",
+                "on_failure", "abort",
+                "timeout", "PT10M");
+        s.put("depends_on", List.of());
+        s.put("escalation", List.of("requires_approval"));
+
+        var m = manifest(List.of(skill(), playbook(List.of(s))));
+        PlaybookStep parsed = m.units().get(1).steps().get(0);
+        assertEquals("verify", parsed.id());
+        assertEquals("run-test-suite", parsed.uses());
+        assertEquals("observe", parsed.authorityLevel());
+        assertEquals(List.of("requires_approval"), parsed.escalation());
+        assertEquals("zero failures", parsed.successCondition());
+        assertEquals("abort", parsed.onFailure());
+        assertEquals("PT10M", parsed.timeout());
+    }
+
+    @Test
+    void bareEscalationStringNormalisesToAList() {
+        // §4.3b calls the triggers disjunctive, so a scalar and a one-element list mean
+        // the same thing. Normalising at parse time means no consumer handles both.
+        var m = manifest(List.of(skill(), playbook(List.of(
+                step("a", "uses", "run-test-suite", "escalation", "requires_approval")))));
+        assertEquals(List.of("requires_approval"), m.units().get(1).steps().get(0).escalation());
+    }
+
+    @Test
+    void absentStepsIsNullNotEmpty() {
+        // "declares no steps" and "declares an empty composition" are different
+        // statements. The validator rejects both for a playbook, but the parser must
+        // keep them distinguishable.
+        assertNull(manifest(List.of(skill())).units().get(0).steps());
+    }
+
+    @Test
+    void stepsWithoutAnIdAreDropped() {
+        // A step with no identity cannot be named by depends_on, so it cannot join the
+        // graph. Half-parsing would put an id-less entry into a structure keyed by id.
+        List<Object> steps = new ArrayList<>();
+        steps.add("not-a-map");
+        steps.add(Map.of("uses", "run-test-suite"));
+        steps.add(Map.of("id", "ok", "action", "x"));
+        var m = manifest(List.of(skill(), playbook(steps)));
+        assertEquals(List.of("ok"), m.units().get(1).steps().stream().map(PlaybookStep::id).toList());
+    }
+
+    @Test
+    void malformedStepsBlockDoesNotBreakTheParse() {
+        var m = manifest(List.of(skill(), playbook("steps")));
+        assertNull(m.units().get(1).steps());
+        assertEquals("promote", m.units().get(1).id());
+    }
+
+    // --- validation: structure -------------------------------------------------
+
+    @Test
+    void wellFormedPlaybookHasNoErrors() {
+        var m = manifest(
+                List.of(skill(), playbook(List.of(
+                        step("verify", "uses", "run-test-suite", "authority_level", "observe")))),
+                Map.of("authority_level_scale",
+                        List.of("observe", "explain", "suggest", "prepare", "commit")));
+        assertEquals(List.of(), KcpValidator.validate(m).errors());
+    }
+
+    @Test
+    void playbookWithoutStepsErrors() {
+        assertTrue(any(errors(List.of(playbook(null))), "non-empty 'steps'"));
+    }
+
+    @Test
+    void emptyStepsListErrors() {
+        assertTrue(any(errors(List.of(playbook(List.of()))), "non-empty 'steps'"));
+    }
+
+    @Test
+    void stepWithNeitherUsesNorActionErrors() {
+        assertTrue(any(errors(List.of(playbook(List.of(step("orphan"))))),
+                "either 'uses' or 'action'"));
+    }
+
+    @Test
+    void duplicateStepIdsError() {
+        var errs = errors(List.of(skill(), playbook(List.of(
+                step("a", "uses", "run-test-suite"),
+                step("a", "action", "again")))));
+        assertTrue(any(errs, "duplicate step id 'a'"));
+    }
+
+    @Test
+    void unknownOnFailureErrors() {
+        var errs = errors(List.of(skill(), playbook(List.of(
+                step("a", "uses", "run-test-suite", "on_failure", "retry")))));
+        assertTrue(any(errs, "'on_failure' must be one of"));
+    }
+
+    // --- validation: uses resolution -------------------------------------------
+
+    @Test
+    void unresolvableUsesIsAnErrorNotAWarning() {
+        var r = KcpValidator.validate(manifest(List.of(
+                playbook(List.of(step("a", "uses", "nonexistent"))))));
+        assertTrue(any(r.errors(), "not declared in this manifest"));
+        assertFalse(any(r.warnings(), "nonexistent"));
+    }
+
+    @Test
+    void usesResolvesAgainstAUnitDeclaredLater() {
+        // The check is a second pass for exactly this reason: an inline check would
+        // reject a legal forward reference, the id set being incomplete mid-loop.
+        assertEquals(List.of(), errors(List.of(
+                playbook(List.of(step("a", "uses", "run-test-suite"))), skill())));
+    }
+
+    @Test
+    void nestingIsAnError() {
+        Map<String, Object> inner = playbook(List.of(step("x", "action", "inner")));
+        inner.put("id", "inner");
+        Map<String, Object> outer = playbook(List.of(step("a", "uses", "inner")));
+        outer.put("id", "outer");
+        assertTrue(any(errors(List.of(inner, outer)), "nesting is not permitted"));
+    }
+
+    @Test
+    void usesNamingAResolvableNonSkillUnitWarnsOnly() {
+        Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("id", "notes");
+        doc.put("kind", "knowledge");
+        doc.put("path", "n.md");
+        doc.put("intent", "x");
+        doc.put("scope", "project");
+        doc.put("audience", List.of("agent"));
+        var r = KcpValidator.validate(manifest(List.of(doc,
+                playbook(List.of(step("a", "uses", "notes"))))));
+        assertEquals(List.of(), r.errors());
+        assertTrue(any(r.warnings(), "SHOULD name a kind: skill unit"));
+    }
+
+    // --- validation: the depends_on graph --------------------------------------
+
+    private static Map<String, Object> dependentStep(String id, String... deps) {
+        Map<String, Object> s = step(id, "uses", "run-test-suite");
+        s.put("depends_on", List.of(deps));
+        return s;
+    }
+
+    @Test
+    void danglingDependsOnErrors() {
+        assertTrue(any(errors(List.of(skill(), playbook(List.of(dependentStep("a", "ghost"))))),
+                "depends_on names unknown step 'ghost'"));
+    }
+
+    @Test
+    void twoStepCycleErrors() {
+        var errs = errors(List.of(skill(), playbook(List.of(
+                dependentStep("a", "b"), dependentStep("b", "a")))));
+        assertTrue(any(errs, "contains a cycle"));
+    }
+
+    @Test
+    void longerCycleReportsThePath() {
+        var errs = errors(List.of(skill(), playbook(List.of(
+                dependentStep("a", "c"), dependentStep("b", "a"), dependentStep("c", "b")))));
+        var cycle = errs.stream().filter(e -> e.contains("contains a cycle")).findFirst();
+        assertTrue(cycle.isPresent());
+        assertTrue(cycle.get().contains("->"));
+    }
+
+    @Test
+    void selfDependencyIsACycle() {
+        assertTrue(any(errors(List.of(skill(), playbook(List.of(dependentStep("a", "a"))))),
+                "contains a cycle"));
+    }
+
+    @Test
+    void diamondIsNotACycle() {
+        // The classic false positive for a naive visited-set walk: d is reached twice by
+        // distinct paths, which is convergence, not a cycle.
+        assertEquals(List.of(), errors(List.of(skill(), playbook(List.of(
+                step("a", "uses", "run-test-suite"),
+                dependentStep("b", "a"),
+                dependentStep("c", "a"),
+                dependentStep("d", "b", "c"))))));
+    }
+
+    @Test
+    void longChainDoesNotExhaustTheStack() {
+        // Untrusted input: a deep chain must report cleanly, not overflow the stack.
+        List<Object> steps = new ArrayList<>();
+        for (int i = 0; i < 5000; i++) {
+            steps.add(i == 0 ? step("s0", "uses", "run-test-suite")
+                    : dependentStep("s" + i, "s" + (i - 1)));
+        }
+        var errs = KcpValidator.validate(manifest(List.of(skill(), playbook(steps)))).errors();
+        assertTrue(errs.stream().noneMatch(e -> e.contains("cycle")));
+    }
+
+    // --- validation: scope verifiability ---------------------------------------
+
+    @Test
+    void inlineStepsWarnTheyAreScopeUnbounded() {
+        assertTrue(any(warnings(List.of(playbook(List.of(step("a", "action", "do it"))))),
+                "bounded only by its authority_level"));
+    }
+
+    @Test
+    void declaredScopeIsUnverifiedWhenAStepIsInline() {
+        // §4.3b: an unverifiable declaration that lints clean is worse than none,
+        // because it reads as checked.
+        Map<String, Object> pb = playbook(List.of(
+                step("a", "uses", "run-test-suite"), step("b", "action", "inline")));
+        pb.put("action_scope", Map.of("tools", List.of("bash")));
+        assertTrue(any(warnings(List.of(skill(), pb)), "UNVERIFIED"));
+    }
+
+    @Test
+    void declaredScopeIsUnverifiedWhenAReferencedUnitHasNoScope() {
+        Map<String, Object> bare = skill();
+        bare.put("id", "bare");
+        bare.remove("action_scope");
+        Map<String, Object> pb = playbook(List.of(step("a", "uses", "bare")));
+        pb.put("action_scope", Map.of("tools", List.of("bash")));
+        assertTrue(any(warnings(List.of(bare, pb)), "UNVERIFIED"));
+    }
+
+    @Test
+    void scopeIsVerifiedWhenEveryStepResolvesToAScopedUnit() {
+        Map<String, Object> pb = playbook(List.of(step("a", "uses", "run-test-suite")));
+        pb.put("action_scope", Map.of("tools", List.of("bash")));
+        assertFalse(any(warnings(List.of(skill(), pb)), "UNVERIFIED"));
+    }
+
+    @Test
+    void mutatingStepWithoutAuthorityLevelWarns() {
+        assertTrue(any(warnings(List.of(skill(),
+                playbook(List.of(step("a", "uses", "run-test-suite"))))),
+                "omits 'authority_level'"));
+    }
+
+    // --- validation: non-playbook units ----------------------------------------
+
+    @Test
+    void stepsOnANonPlaybookWarns() {
+        Map<String, Object> s = skill();
+        s.put("steps", List.of(Map.of("id", "a", "action", "x")));
+        assertTrue(any(warnings(List.of(s)), "only enacted for kind: playbook"));
+    }
+
+    @Test
+    void playbookIsARecognisedKind() {
+        assertFalse(any(warnings(List.of(skill(),
+                playbook(List.of(step("a", "uses", "run-test-suite"))))), "unknown 'kind'"));
+    }
+}

--- a/parsers/python/kcp/model.py
+++ b/parsers/python/kcp/model.py
@@ -154,6 +154,28 @@ class ActionScope:
 
 
 @dataclass
+class PlaybookStep:
+    """One step of a ``kind: playbook`` composition. See SPEC.md §4.3b (v0.29, RFC-0027).
+
+    The step — not the playbook — is the unit of governance. ``authority_level`` is a
+    ceiling on this step alone; effective authority is the minimum across it, the
+    playbook's, the task-type grant_ceiling, any tenant ceiling, and the enacting
+    agent's own grant, so a playbook can never raise authority.
+
+    Mirrors ``shared/src/parser.ts`` ``parseSteps`` and the Java ``PlaybookStep`` record.
+    """
+    id: str
+    uses: Optional[str] = None  # unit id this step enacts; SHOULD name a kind: skill unit
+    action: Optional[str] = None  # inline description, when no unit exists yet
+    depends_on: Optional[List[str]] = None  # step ids that must succeed first
+    authority_level: Optional[str] = None  # RFC-0025 scale; ceiling semantics
+    escalation: Optional[List[str]] = None  # RFC-0026 triggers; disjunctive, pre-enactment
+    success_condition: Optional[str] = None  # prose assertion; never evaluated by the protocol
+    on_failure: Optional[str] = None  # abort | continue | escalate; default abort
+    timeout: Optional[str] = None  # ISO 8601 duration; elapsing constitutes failure
+
+
+@dataclass
 class KnowledgeUnit:
     id: str
     path: str
@@ -194,6 +216,7 @@ class KnowledgeUnit:
     content_hash: Optional[ContentHash] = None  # RFC-0019 (draft)
     temporal: Optional[Temporal] = None  # RFC-0010 / §4.22 (v0.19)
     action_scope: Optional[ActionScope] = None  # §4.3a (v0.26.1) — what a kind: skill procedure may touch
+    steps: Optional[List["PlaybookStep"]] = None  # §4.3b (v0.29) — ordered composition; required for kind: playbook
     authority_level: Optional[str] = None  # RFC-0025 / §4.23 (v0.27) — ceiling on the root authority_level_scale
 
 

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -1,18 +1,19 @@
 from datetime import date
 from pathlib import Path, PurePosixPath
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import yaml
 
 from .model import (
+    ActionScope,
     Agent, AgentIdentity, Auth, AuthMethod, Authority, Compliance, ContentHash, ContentStructure,
     Delegation, Discovery, ExternalDependency, ExternalRelationship, FreshnessPolicy,
     GrantCeiling, GrantCeilingSource, KnowledgeManifest, KnowledgeUnit, ManifestRef, Payment,
     PaymentMethod, Serving, RateLimit, RateLimits, RateLimitHeaders, RateLimitTokens,
+    PlaybookStep,
     RateLimitTokensTier, Relationship, TaskType,
-    Trust, TrustAudit, TrustAgentRequirements, TrustProvenance, Visibility,
-    ActionScope,
     Spend,
+    Trust, TrustAudit, TrustAgentRequirements, TrustProvenance, Visibility,
 )
 
 
@@ -113,6 +114,52 @@ def _parse_spend(data: Optional[dict]) -> Optional["Spend"]:
         allowed_vendors=data.get("allowed_vendors"),
         currency=data.get("currency"),
     )
+
+
+def _parse_steps(data) -> Optional[List["PlaybookStep"]]:
+    """§4.3b (v0.29, RFC-0027): the ordered composition a ``kind: playbook`` declares.
+
+    Anything that is not a list yields None, matching ``_parse_action_scope``: a
+    malformed block must not take down the whole parse, and None reads as "declares no
+    steps", which the validator then rejects for a playbook. Entries that are not
+    mappings, or carry no ``id``, are dropped rather than half-parsed — a step with no
+    identity cannot be named by ``depends_on``, so it cannot join the graph at all.
+    """
+    if not isinstance(data, list):
+        return None
+    steps: List["PlaybookStep"] = []
+    for item in data:
+        if not isinstance(item, dict) or item.get("id") is None:
+            continue
+        steps.append(
+            PlaybookStep(
+                id=str(item["id"]),
+                uses=item.get("uses"),
+                action=item.get("action"),
+                depends_on=item.get("depends_on"),
+                authority_level=item.get("authority_level"),
+                escalation=_parse_escalation(item.get("escalation")),
+                success_condition=item.get("success_condition"),
+                on_failure=item.get("on_failure"),
+                timeout=item.get("timeout"),
+            )
+        )
+    return steps
+
+
+def _parse_escalation(raw) -> Optional[List[str]]:
+    """§4.3b: a bare string is shorthand for a single-element list.
+
+    The triggers are disjunctive, so a scalar and a one-element list mean the same
+    thing. Normalising here means no consumer has to handle both shapes.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return [str(x) for x in raw]
+    return None
 
 
 def _parse_action_scope(data: Optional[dict]) -> Optional["ActionScope"]:
@@ -484,6 +531,7 @@ def parse_dict(data: dict) -> KnowledgeManifest:
             payment=_parse_payment(u.get("payment")),
             rate_limits=_parse_rate_limits(u.get("rate_limits")),
             action_scope=_parse_action_scope(u.get("action_scope")),
+            steps=_parse_steps(u.get("steps")),
             delegation=_parse_delegation(u.get("delegation")),
             compliance=_parse_compliance(u.get("compliance")),
             auth=_parse_auth(u.get("auth")),

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -95,7 +95,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -84,7 +84,8 @@ def compute_content_digest(target: str, algorithm: str) -> Optional[str]:
 VALID_SCOPES = {"global", "project", "module"}
 VALID_AUDIENCES = {"human", "agent", "developer", "operator", "architect", "devops"}
 VALID_RELATIONSHIP_TYPES = {"enables", "context", "supersedes", "contradicts", "depends_on", "governs"}
-VALID_KINDS = {"knowledge", "schema", "service", "policy", "executable", "skill"}
+VALID_KINDS = {"knowledge", "schema", "service", "policy", "executable", "skill", "playbook"}
+VALID_ON_FAILURE = {"abort", "continue", "escalate"}
 VALID_FORMATS = {
     "markdown", "pdf", "openapi", "json-schema", "jupyter",
     "html", "asciidoc", "rst", "vtt", "yaml", "json", "csv", "text",
@@ -157,6 +158,49 @@ def _detect_cycles(units: list) -> set[tuple[str, str]]:
             dfs(uid, set())
 
     return cycle_edges
+
+
+def _find_step_cycle(steps) -> Optional[list]:
+    """§4.3b (v0.29): find a cycle in a playbook's explicit ``depends_on`` graph.
+
+    Returns the cycle path for the error message, or None if the graph is acyclic.
+
+    Only explicit edges are walked. The implicit "after the previous step in
+    declaration order" default cannot produce a cycle — declaration order is total —
+    so materialising it here would add edges that are never a defect and would obscure
+    which edges the author actually wrote.
+
+    Iterative rather than recursive: a manifest is untrusted input, and a deep chain
+    must report a cycle rather than exhaust the stack.
+    """
+    edges = {s.id: (s.depends_on or []) for s in steps}
+    WHITE, GREY, BLACK = 0, 1, 2
+    colour = {s.id: WHITE for s in steps}
+
+    for root in steps:
+        if colour[root.id] != WHITE:
+            continue
+        stack = [[root.id, 0]]
+        colour[root.id] = GREY
+        while stack:
+            frame = stack[-1]
+            deps = edges.get(frame[0], [])
+            if frame[1] >= len(deps):
+                colour[frame[0]] = BLACK
+                stack.pop()
+                continue
+            dep = deps[frame[1]]
+            frame[1] += 1
+            if dep not in edges:
+                continue  # dangling; reported separately
+            if colour[dep] == GREY:
+                # Grey means dep is on the current stack — slice from it for the path.
+                start = next(i for i, f in enumerate(stack) if f[0] == dep)
+                return [f[0] for f in stack[start:]] + [dep]
+            if colour[dep] == WHITE:
+                colour[dep] = GREY
+                stack.append([dep, 0])
+    return None
 
 
 def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) -> ValidationResult:
@@ -385,6 +429,143 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
                         )
 
     # Root-level delegation validation
+    # --- kind: playbook — §4.3b (v0.29, RFC-0027) ---
+    #
+    # Deliberately a second pass over the units. `uses` may name a unit declared later
+    # in the manifest, so resolving it inside the loop above would reject forward
+    # references the spec permits.
+    unit_kinds = {u.id: (u.kind or "knowledge") for u in manifest.units}
+    units_by_id = {u.id: u for u in manifest.units}
+    declared_levels = set(manifest.authority_level_scale or [])
+
+    for unit in manifest.units:
+        ctx = f"unit '{unit.id}'"
+
+        if (unit.kind or "knowledge") != "playbook":
+            # steps on a non-playbook is a category error, not a silent no-op: the
+            # author declared a composition the protocol will never enact.
+            if unit.steps is not None:
+                warnings.append(
+                    f"{ctx}: declares 'steps' but kind is "
+                    f"'{unit.kind or 'knowledge'}'; steps are only enacted for "
+                    f"kind: playbook (§4.3b)"
+                )
+            continue
+
+        # A playbook MUST declare steps, and the list MUST be non-empty. An empty
+        # composition is not a degenerate executable — it is a manifest error.
+        if not unit.steps:
+            errors.append(
+                f"{ctx}: kind 'playbook' MUST declare a non-empty 'steps' list (§4.3b)"
+            )
+            continue
+
+        step_ids: set[str] = set()
+        for step in unit.steps:
+            sctx = f"{ctx} step '{step.id}'"
+
+            if step.id in step_ids:
+                errors.append(f"{ctx}: duplicate step id '{step.id}' (§4.3b)")
+            step_ids.add(step.id)
+
+            if step.uses is None and step.action is None:
+                errors.append(f"{sctx}: MUST declare either 'uses' or 'action' (§4.3b)")
+
+            if step.uses is not None:
+                target = unit_kinds.get(step.uses)
+                if target is None:
+                    # An error, not a warning: a resolvable `uses` is the whole
+                    # justification for playbook being a distinct kind. A dangling
+                    # reference that lints clean reduces the playbook to an
+                    # executable with worse ergonomics.
+                    errors.append(
+                        f"{sctx}: 'uses' names unit '{step.uses}', which is not "
+                        f"declared in this manifest (§4.3b)"
+                    )
+                elif target == "playbook":
+                    # Nesting is forbidden pending RFC-0027 OQ1. As a warning it
+                    # would be no guard: nested playbooks form a combined depends_on
+                    # graph that the per-playbook cycle check never sees.
+                    errors.append(
+                        f"{sctx}: 'uses' names playbook '{step.uses}'; playbook "
+                        f"nesting is not permitted (§4.3b, RFC-0027 OQ1)"
+                    )
+                elif target != "skill":
+                    warnings.append(
+                        f"{sctx}: 'uses' names '{step.uses}' of kind '{target}'; "
+                        f"SHOULD name a kind: skill unit (§4.3b)"
+                    )
+
+            if step.on_failure is not None and step.on_failure not in VALID_ON_FAILURE:
+                errors.append(
+                    f"{sctx}: 'on_failure' must be one of "
+                    f"[abort, continue, escalate], got '{step.on_failure}'"
+                )
+
+            # Checked against the manifest's declared scale rather than a hardcoded
+            # vocabulary — §3.13 makes authority_level_scale a per-manifest
+            # declaration, and the v0.27 check below already works that way.
+            if (
+                step.authority_level is not None
+                and declared_levels
+                and step.authority_level not in declared_levels
+            ):
+                warnings.append(
+                    f"{sctx}: 'authority_level' value '{step.authority_level}' is "
+                    f"not in the declared 'authority_level_scale' (§3.13)"
+                )
+
+            # A step whose unit can mutate but which declares no ceiling is bounded
+            # only by the enacting agent's own grant — looser than intended (§4.3b).
+            if step.authority_level is None and step.uses is not None:
+                scope = getattr(units_by_id.get(step.uses), "action_scope", None)
+                if scope is not None and (scope.paths or scope.spend is not None):
+                    warnings.append(
+                        f"{sctx}: omits 'authority_level' while '{step.uses}' "
+                        f"declares a mutating action_scope; the step is bounded "
+                        f"only by the enacting agent (§4.3b)"
+                    )
+
+        for step in unit.steps:
+            for dep in step.depends_on or []:
+                if dep not in step_ids:
+                    errors.append(
+                        f"{ctx} step '{step.id}': depends_on names unknown step "
+                        f"'{dep}' (§4.3b)"
+                    )
+
+        cycle = _find_step_cycle(unit.steps)
+        if cycle:
+            errors.append(
+                f"{ctx}: 'depends_on' graph contains a cycle: "
+                f"{' -> '.join(cycle)} (§4.3b)"
+            )
+
+        # §4.3b: the step-scope union is computable only when every step uses a unit
+        # and every such unit declares an action_scope. Report a declared scope as
+        # unverified rather than passing it silently — a declaration that lints clean
+        # reads as checked.
+        inline = sum(1 for s in unit.steps if s.uses is None)
+        if inline:
+            warnings.append(
+                f"{ctx}: {inline} of {len(unit.steps)} step(s) are inline "
+                f"('action'); an inline step has no action_scope and is bounded "
+                f"only by its authority_level (§4.3b)"
+            )
+        if unit.action_scope is not None:
+            scopeless = sum(
+                1
+                for s in unit.steps
+                if s.uses is not None
+                and getattr(units_by_id.get(s.uses), "action_scope", None) is None
+            )
+            if inline or scopeless:
+                warnings.append(
+                    f"{ctx}: declared 'action_scope' is UNVERIFIED — the step-scope "
+                    f"union is not computable ({inline} inline step(s), {scopeless} "
+                    f"step(s) whose unit declares no action_scope) (§4.3b)"
+                )
+
     if manifest.delegation is not None:
         hitl = manifest.delegation.human_in_the_loop
         if hitl is not None and not isinstance(hitl, dict):

--- a/parsers/python/tests/test_playbook.py
+++ b/parsers/python/tests/test_playbook.py
@@ -1,0 +1,295 @@
+"""kind: playbook — §4.3b (v0.29, RFC-0027).
+
+Mirrors cli/src/playbook.test.ts and KcpPlaybookTest.java case for case, so the three
+implementations can be compared by reading them side by side.
+
+Two rules are tested from the attack direction rather than the happy path, because the
+adversarial review on RFC-0027 found both stated as advice when they are load-bearing:
+
+  - an unresolvable ``uses`` must be an ERROR. A resolvable ``uses`` is the entire
+    justification for playbook being a distinct kind rather than ``executable`` plus a
+    metadata block; a dangling reference that lints clean removes the only thing the
+    new kind buys.
+  - nesting must be an ERROR pending RFC-0027 OQ1. As a warning it is no guard at all:
+    nested playbooks form a combined depends_on graph that the per-playbook cycle check
+    never sees.
+"""
+
+from kcp.parser import parse_dict
+from kcp.validator import validate
+
+SKILL = {
+    "id": "run-test-suite",
+    "kind": "skill",
+    "path": "skills/run.md",
+    "intent": "How do I run the suite?",
+    "scope": "project",
+    "audience": ["agent"],
+    "action_scope": {"tools": ["bash"], "paths": ["test/**"]},
+}
+
+
+def _manifest(units, **extra):
+    raw = {
+        "project": "example",
+        "version": "1.0.0",
+        "kcp_version": "0.29",
+        "units": units,
+    }
+    raw.update(extra)
+    return parse_dict(raw)
+
+
+def _playbook(steps, **extra):
+    unit = {
+        "id": "promote",
+        "kind": "playbook",
+        "path": "playbooks/promote.md",
+        "intent": "How do we promote a build?",
+        "scope": "project",
+        "audience": ["agent"],
+        "steps": steps,
+    }
+    unit.update(extra)
+    return unit
+
+
+def _errors(units, **extra):
+    return validate(_manifest(units, **extra)).errors
+
+
+def _warnings(units, **extra):
+    return validate(_manifest(units, **extra)).warnings
+
+
+# --- parsing -----------------------------------------------------------------
+
+
+def test_parses_every_step_field():
+    m = _manifest([SKILL, _playbook([{
+        "id": "verify",
+        "uses": "run-test-suite",
+        "depends_on": [],
+        "authority_level": "observe",
+        "escalation": ["requires_approval"],
+        "success_condition": "zero failures",
+        "on_failure": "abort",
+        "timeout": "PT10M",
+    }])])
+    s = m.units[1].steps[0]
+    assert s.id == "verify"
+    assert s.uses == "run-test-suite"
+    assert s.authority_level == "observe"
+    assert s.escalation == ["requires_approval"]
+    assert s.success_condition == "zero failures"
+    assert s.on_failure == "abort"
+    assert s.timeout == "PT10M"
+
+
+def test_bare_escalation_string_normalises_to_a_list():
+    # §4.3b calls the triggers disjunctive, so a scalar and a one-element list mean the
+    # same thing. Normalising at parse time means no consumer handles both shapes.
+    m = _manifest([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite", "escalation": "requires_approval"}
+    ])])
+    assert m.units[1].steps[0].escalation == ["requires_approval"]
+
+
+def test_absent_steps_is_none_not_empty_list():
+    # "declares no steps" and "declares an empty composition" are different statements.
+    # The validator rejects both for a playbook, but the parser keeps them distinct.
+    m = _manifest([SKILL])
+    assert m.units[0].steps is None
+
+
+def test_steps_without_an_id_are_dropped():
+    # A step with no identity cannot be named by depends_on, so it cannot join the
+    # graph. Half-parsing would put an id-less entry into a structure indexed by id.
+    m = _manifest([SKILL, _playbook(
+        ["not-a-mapping", {"uses": "run-test-suite"}, {"id": "ok", "action": "x"}]
+    )])
+    assert [s.id for s in m.units[1].steps] == ["ok"]
+
+
+def test_malformed_steps_block_does_not_break_the_parse():
+    m = _manifest([SKILL, _playbook("steps")])
+    assert m.units[1].steps is None
+    assert m.units[1].id == "promote"
+
+
+# --- validation: structure ---------------------------------------------------
+
+
+def test_well_formed_playbook_has_no_errors():
+    assert _errors(
+        [SKILL, _playbook([{"id": "verify", "uses": "run-test-suite",
+                            "authority_level": "observe"}])],
+        authority_level_scale=["observe", "explain", "suggest", "prepare", "commit"],
+    ) == []
+
+
+def test_playbook_without_steps_errors():
+    unit = _playbook([])
+    del unit["steps"]
+    assert any("non-empty 'steps'" in e for e in _errors([unit]))
+
+
+def test_empty_steps_list_errors():
+    assert any("non-empty 'steps'" in e for e in _errors([_playbook([])]))
+
+
+def test_step_with_neither_uses_nor_action_errors():
+    assert any("either 'uses' or 'action'" in e for e in _errors([_playbook([{"id": "orphan"}])]))
+
+
+def test_duplicate_step_ids_error():
+    errs = _errors([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite"},
+        {"id": "a", "action": "again"},
+    ])])
+    assert any("duplicate step id 'a'" in e for e in errs)
+
+
+def test_unknown_on_failure_errors():
+    errs = _errors([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite", "on_failure": "retry"}
+    ])])
+    assert any("'on_failure' must be one of" in e for e in errs)
+
+
+# --- validation: uses resolution ---------------------------------------------
+
+
+def test_unresolvable_uses_is_an_error_not_a_warning():
+    r = validate(_manifest([_playbook([{"id": "a", "uses": "nonexistent"}])]))
+    assert any("not declared in this manifest" in e for e in r.errors)
+    assert not any("nonexistent" in w for w in r.warnings)
+
+
+def test_uses_resolves_against_a_unit_declared_later():
+    # The check is a second pass for exactly this reason: an inline check would reject
+    # a legal forward reference, because the id set is incomplete mid-loop.
+    assert _errors([_playbook([{"id": "a", "uses": "run-test-suite"}]), SKILL]) == []
+
+
+def test_nesting_is_an_error():
+    inner = dict(_playbook([{"id": "x", "action": "inner"}]), id="inner")
+    outer = dict(_playbook([{"id": "a", "uses": "inner"}]), id="outer")
+    assert any("nesting is not permitted" in e for e in _errors([inner, outer]))
+
+
+def test_uses_naming_a_resolvable_non_skill_unit_warns_only():
+    doc = {"id": "notes", "kind": "knowledge", "path": "n.md", "intent": "x",
+           "scope": "project", "audience": ["agent"]}
+    r = validate(_manifest([doc, _playbook([{"id": "a", "uses": "notes"}])]))
+    assert r.errors == []
+    assert any("SHOULD name a kind: skill unit" in w for w in r.warnings)
+
+
+# --- validation: the depends_on graph ----------------------------------------
+
+
+def test_dangling_depends_on_errors():
+    errs = _errors([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite", "depends_on": ["ghost"]}
+    ])])
+    assert any("depends_on names unknown step 'ghost'" in e for e in errs)
+
+
+def test_two_step_cycle_errors():
+    errs = _errors([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite", "depends_on": ["b"]},
+        {"id": "b", "uses": "run-test-suite", "depends_on": ["a"]},
+    ])])
+    assert any("contains a cycle" in e for e in errs)
+
+
+def test_longer_cycle_reports_the_path():
+    errs = _errors([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite", "depends_on": ["c"]},
+        {"id": "b", "uses": "run-test-suite", "depends_on": ["a"]},
+        {"id": "c", "uses": "run-test-suite", "depends_on": ["b"]},
+    ])])
+    cycle = [e for e in errs if "contains a cycle" in e]
+    assert cycle and "->" in cycle[0]
+
+
+def test_self_dependency_is_a_cycle():
+    errs = _errors([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite", "depends_on": ["a"]}
+    ])])
+    assert any("contains a cycle" in e for e in errs)
+
+
+def test_diamond_is_not_a_cycle():
+    # The classic false positive for a naive visited-set walk: d is reached twice by
+    # distinct paths, which is convergence, not a cycle.
+    assert _errors([SKILL, _playbook([
+        {"id": "a", "uses": "run-test-suite"},
+        {"id": "b", "uses": "run-test-suite", "depends_on": ["a"]},
+        {"id": "c", "uses": "run-test-suite", "depends_on": ["a"]},
+        {"id": "d", "uses": "run-test-suite", "depends_on": ["b", "c"]},
+    ])]) == []
+
+
+def test_long_chain_does_not_exhaust_the_stack():
+    # Untrusted input: a deep chain must report cleanly, not blow the recursion limit.
+    steps = [
+        {"id": f"s{i}", "uses": "run-test-suite",
+         "depends_on": [f"s{i - 1}"] if i else []}
+        for i in range(5000)
+    ]
+    errs = _errors([SKILL, _playbook(steps)])
+    assert not [e for e in errs if "cycle" in e]
+
+
+# --- validation: scope verifiability -----------------------------------------
+
+
+def test_inline_steps_warn_they_are_scope_unbounded():
+    warns = _warnings([_playbook([{"id": "a", "action": "do the thing"}])])
+    assert any("bounded only by its authority_level" in w for w in warns)
+
+
+def test_declared_scope_is_unverified_when_a_step_is_inline():
+    # §4.3b: an unverifiable declaration that lints clean is worse than none, because
+    # it reads as checked.
+    warns = _warnings([SKILL, _playbook(
+        [{"id": "a", "uses": "run-test-suite"}, {"id": "b", "action": "inline"}],
+        action_scope={"tools": ["bash"]},
+    )])
+    assert any("UNVERIFIED" in w for w in warns)
+
+
+def test_declared_scope_is_unverified_when_a_referenced_unit_has_no_scope():
+    bare = dict(SKILL, id="bare")
+    del bare["action_scope"]
+    warns = _warnings([bare, _playbook(
+        [{"id": "a", "uses": "bare"}], action_scope={"tools": ["bash"]}
+    )])
+    assert any("UNVERIFIED" in w for w in warns)
+
+
+def test_scope_is_verified_when_every_step_resolves_to_a_scoped_unit():
+    warns = _warnings([SKILL, _playbook(
+        [{"id": "a", "uses": "run-test-suite"}], action_scope={"tools": ["bash"]}
+    )])
+    assert not any("UNVERIFIED" in w for w in warns)
+
+
+def test_mutating_step_without_authority_level_warns():
+    warns = _warnings([SKILL, _playbook([{"id": "a", "uses": "run-test-suite"}])])
+    assert any("omits 'authority_level'" in w for w in warns)
+
+
+# --- validation: non-playbook units ------------------------------------------
+
+
+def test_steps_on_a_non_playbook_warns():
+    warns = _warnings([dict(SKILL, steps=[{"id": "a", "action": "x"}])])
+    assert any("only enacted for kind: playbook" in w for w in warns)
+
+
+def test_playbook_is_a_recognised_kind():
+    warns = _warnings([SKILL, _playbook([{"id": "a", "uses": "run-test-suite"}])])
+    assert not any("unknown 'kind'" in w for w in warns)

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "kcp_version": {
       "type": "string",
-      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.28\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.27\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
-      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28"]
+      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.29\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.28\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
+      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29"]
     },
     "project": {
       "type": "string",
@@ -190,9 +190,29 @@
         },
         "kind": {
           "type": "string",
-          "description": "Type of artifact. Default: knowledge. Values: knowledge (documentation), schema (machine-readable definition), service (callable endpoint), policy (authoritative rules), executable (runnable artifact), skill (governed executable procedure/playbook whose selection is gated like knowledge; declares an action_scope). See SPEC.md §4.3a.",
-          "enum": ["knowledge", "schema", "service", "policy", "executable", "skill"],
+          "description": "Type of artifact. Default: knowledge. Values: knowledge (documentation), schema (machine-readable definition), service (callable endpoint), policy (authoritative rules), executable (runnable artifact), skill (governed executable procedure whose selection is gated like knowledge; declares an action_scope), playbook (ordered composition of units, governed per step).  See SPEC.md §4.3a.",
+          "enum": ["knowledge", "schema", "service", "policy", "executable", "skill", "playbook"],
           "default": "knowledge"
+        },
+        "steps": {
+          "type": "array",
+          "description": "Ordered composition a kind: playbook declares. REQUIRED and non-empty for kind: playbook. See SPEC.md §4.3b.",
+          "items": {
+            "type": "object",
+            "required": ["id"],
+            "anyOf": [{"required": ["uses"]}, {"required": ["action"]}],
+            "properties": {
+              "id": {"type": "string", "description": "Unique within the playbook."},
+              "uses": {"type": "string", "description": "Unit id this step enacts; SHOULD name a kind: skill unit. MUST resolve to a declared unit, and MUST NOT name another playbook."},
+              "action": {"type": "string", "description": "Inline description, when no unit exists yet. An inline step has no action_scope and is bounded only by its authority_level."},
+              "depends_on": {"type": "array", "items": {"type": "string"}, "description": "Step ids that must complete successfully first. The graph MUST be acyclic. Absent means the preceding step in declaration order."},
+              "authority_level": {"type": "string", "description": "§3.13 scale. Ceiling semantics: at most this level."},
+              "escalation": {"oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}], "description": "§3.14 trigger(s), evaluated before enactment. Disjunctive: any one firing suspends the step."},
+              "success_condition": {"type": "string", "description": "Prose assertion. The protocol defines no evaluation mechanism; outcomes are confirmed | not_confirmed | not_evaluated."},
+              "on_failure": {"enum": ["abort", "continue", "escalate"], "description": "Default abort. 'continue' continues the run but does NOT permit dependent steps to proceed."},
+              "timeout": {"type": "string", "description": "ISO 8601 duration. Elapsing constitutes failure; the clock pauses while a step is suspended awaiting a grant."}
+            }
+          }
         },
         "action_scope": {
           "type": "object",

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -81,6 +81,7 @@ export interface KnowledgeUnit {
   audience: string[];
   kind?: string;           // "knowledge" | "schema" | "service" | "policy" | "executable" | "skill"
   action_scope?: ActionScope;  // §4.3a (v0.26) — tools/paths/capabilities a kind: skill procedure may touch
+  steps?: PlaybookStep[];      // §4.3b (v0.29) — ordered composition; REQUIRED and non-empty for kind: playbook
   format?: string;         // "markdown" | "pdf" | "openapi" | "json-schema" | etc.
   content_type?: string;
   language?: string;
@@ -128,6 +129,26 @@ export interface ActionScope {
   paths?: string[];         // file-system paths (globs permitted) the procedure may read/write
   capabilities?: string[];  // named capabilities the procedure requires or exercises
   spend?: Spend;            // purchases the procedure may make (per-purchase cap + vendor allowlist)
+}
+
+/**
+ * One step of a `kind: playbook` composition. See SPEC.md §4.3b (v0.29, RFC-0027).
+ *
+ * The step — not the playbook — is the unit of governance: `authority_level` is a
+ * ceiling on this step alone, and effective authority is the minimum across it, the
+ * playbook's, the task-type grant_ceiling, any tenant ceiling, and the agent's own
+ * grant. A playbook can therefore never raise authority.
+ */
+export interface PlaybookStep {
+  id: string;                  // unique within the playbook
+  uses?: string;               // id of the unit this step enacts; SHOULD name a kind: skill unit
+  action?: string;             // inline description, when no unit exists yet
+  depends_on?: string[];       // step ids that must complete successfully first
+  authority_level?: string;    // RFC-0025 scale; ceiling semantics — at most this level
+  escalation?: string[];       // RFC-0026 triggers; disjunctive, evaluated before enactment
+  success_condition?: string;  // prose assertion; the protocol never evaluates it
+  on_failure?: string;         // "abort" | "continue" | "escalate"; default "abort"
+  timeout?: string;            // ISO 8601 duration; elapsing constitutes failure
 }
 
 export interface Relationship {

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import yaml from "js-yaml";
 import type {
   ActionScope,
+  PlaybookStep,
   Spend,
   Auth,
   AuthMethod,
@@ -111,6 +112,7 @@ function parseUnit(raw: RawMap): KnowledgeUnit {
     audience: asStringArray(raw["audience"]),
     kind: raw["kind"] !== undefined ? String(raw["kind"]) : undefined,
     action_scope: parseActionScope(raw["action_scope"]),
+    steps: parseSteps(raw["steps"]),
     format: raw["format"] !== undefined ? String(raw["format"]) : undefined,
     content_type:
       raw["content_type"] !== undefined
@@ -451,6 +453,50 @@ function parseActionScope(raw: unknown): ActionScope | undefined {
     capabilities: stringListOrUndefined(d["capabilities"]),
     spend: parseSpend(d["spend"]),
   };
+}
+
+/**
+ * §4.3b (v0.29, RFC-0027): the ordered composition a `kind: playbook` declares.
+ *
+ * Returns undefined for anything that is not a list, matching parseActionScope: a
+ * malformed block must not take down the whole parse, and undefined reads as
+ * "declares no steps" — which a validator then rejects for kind: playbook. Steps
+ * that are not objects, or carry no `id`, are dropped rather than half-parsed; a
+ * step without an identity cannot be referenced by depends_on and so cannot
+ * participate in the graph at all.
+ */
+function parseSteps(raw: unknown): PlaybookStep[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const steps: PlaybookStep[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const d = item as RawMap;
+    if (d["id"] === undefined) continue;
+    steps.push({
+      id: String(d["id"]),
+      uses: d["uses"] !== undefined ? String(d["uses"]) : undefined,
+      action: d["action"] !== undefined ? String(d["action"]) : undefined,
+      depends_on: stringListOrUndefined(d["depends_on"]),
+      authority_level:
+        d["authority_level"] !== undefined ? String(d["authority_level"]) : undefined,
+      // §4.3b: a bare string is shorthand for a single-element list. Normalising here
+      // means every consumer sees one shape; the triggers are disjunctive, so a list
+      // of one and a scalar mean the same thing.
+      escalation: parseEscalation(d["escalation"]),
+      success_condition:
+        d["success_condition"] !== undefined ? String(d["success_condition"]) : undefined,
+      on_failure: d["on_failure"] !== undefined ? String(d["on_failure"]) : undefined,
+      timeout: d["timeout"] !== undefined ? String(d["timeout"]) : undefined,
+    });
+  }
+  return steps;
+}
+
+/** §4.3b: `escalation` accepts a single trigger or a list; both normalise to a list. */
+function parseEscalation(raw: unknown): string[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw === "string") return [raw];
+  return stringListOrUndefined(raw);
 }
 
 /** §4.3a (v0.26): purchases a `kind: skill` procedure may make. */

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -160,6 +160,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.26",
   "0.27",
   "0.28",
+  "0.29",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -54,6 +54,55 @@ export function computeContentDigest(target: string, algorithm: string): string 
   }
 }
 
+/**
+ * §4.3b (v0.29): find a cycle in a playbook's explicit `depends_on` graph, returning
+ * the cycle path for the error message, or null if the graph is acyclic.
+ *
+ * Only explicit edges are walked. The implicit "after the previous step in declaration
+ * order" default cannot produce a cycle — declaration order is total — so materialising
+ * it here would add edges that are never a defect and would mask which edges the author
+ * actually wrote.
+ *
+ * Iterative rather than recursive: a manifest is untrusted input, and a deep chain
+ * should report a cycle, not overflow the stack.
+ */
+function findStepCycle(steps: { id: string; depends_on?: string[] }[]): string[] | null {
+  const edges = new Map<string, string[]>();
+  for (const s of steps) edges.set(s.id, s.depends_on ?? []);
+
+  const WHITE = 0, GREY = 1, BLACK = 2;
+  const colour = new Map<string, number>();
+  for (const s of steps) colour.set(s.id, WHITE);
+
+  for (const root of steps) {
+    if (colour.get(root.id) !== WHITE) continue;
+    const stack: { id: string; next: number }[] = [{ id: root.id, next: 0 }];
+    colour.set(root.id, GREY);
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]!;
+      const deps = edges.get(frame.id) ?? [];
+      if (frame.next >= deps.length) {
+        colour.set(frame.id, BLACK);
+        stack.pop();
+        continue;
+      }
+      const dep = deps[frame.next++]!;
+      if (!edges.has(dep)) continue;  // dangling; reported separately
+      const c = colour.get(dep);
+      if (c === GREY) {
+        // Grey means dep is on the current stack — slice from it for the path.
+        const from = stack.findIndex((f) => f.id === dep);
+        return [...stack.slice(from).map((f) => f.id), dep];
+      }
+      if (c === WHITE) {
+        colour.set(dep, GREY);
+        stack.push({ id: dep, next: 0 });
+      }
+    }
+  }
+  return null;
+}
+
 const VALID_SCOPES = new Set(["global", "project", "module"]);
 // Alias character rule (§4.2a, v0.26): lowercase letters/digits, then dots/hyphens/underscores.
 const ALIAS_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
@@ -64,7 +113,9 @@ const VALID_KINDS = new Set([
   "policy",
   "executable",
   "skill",
+  "playbook",
 ]);
+const VALID_ON_FAILURE = new Set(["abort", "continue", "escalate"]);
 const VALID_REL_TYPES = new Set([
   "enables",
   "context",
@@ -419,6 +470,140 @@ export function validate(
         errors.push(`${ctx}: path traversal rejected: '${unit.path}'`);
       } else if (!existsSync(resolved)) {
         warnings.push(`${ctx}: file not found on disk: '${unit.path}'`);
+      }
+    }
+  }
+
+  // --- kind: playbook — §4.3b (v0.29, RFC-0027) ---
+  //
+  // Deliberately a second pass. `uses` may name a unit declared later in the manifest,
+  // and unitIds is only complete once the loop above has finished; checking inline
+  // would reject forward references that the spec permits.
+  const unitKinds = new Map<string, string>();
+  for (const u of manifest.units) unitKinds.set(u.id, u.kind ?? "knowledge");
+  const declaredLevels = new Set(manifest.authority_level_scale ?? []);
+
+  for (const unit of manifest.units) {
+    const ctx = `Unit '${unit.id}'`;
+
+    if (unit.kind !== "playbook") {
+      // steps on a non-playbook is a category error, not a silent no-op: the author
+      // declared a composition the protocol will never enact.
+      if (unit.steps !== undefined) {
+        warnings.push(
+          `${ctx}: declares 'steps' but kind is '${unit.kind ?? "knowledge"}'; steps are only enacted for kind: playbook (§4.3b)`
+        );
+      }
+      continue;
+    }
+
+    // A playbook MUST declare steps, and the list MUST be non-empty. An empty
+    // composition is not a degenerate executable — it is a manifest error.
+    if (unit.steps === undefined || unit.steps.length === 0) {
+      errors.push(`${ctx}: kind 'playbook' MUST declare a non-empty 'steps' list (§4.3b)`);
+      continue;
+    }
+
+    const stepIds = new Set<string>();
+    for (const step of unit.steps) {
+      const sctx = `${ctx} step '${step.id}'`;
+
+      if (stepIds.has(step.id)) {
+        errors.push(`${ctx}: duplicate step id '${step.id}' (§4.3b)`);
+      }
+      stepIds.add(step.id);
+
+      if (step.uses === undefined && step.action === undefined) {
+        errors.push(`${sctx}: MUST declare either 'uses' or 'action' (§4.3b)`);
+      }
+
+      if (step.uses !== undefined) {
+        const target = unitKinds.get(step.uses);
+        if (target === undefined) {
+          // An error, not a warning: a resolvable `uses` is the whole justification
+          // for playbook being a distinct kind. A dangling reference that lints clean
+          // reduces the playbook to an executable with worse ergonomics.
+          errors.push(
+            `${sctx}: 'uses' names unit '${step.uses}', which is not declared in this manifest (§4.3b)`
+          );
+        } else if (target === "playbook") {
+          // Nesting is forbidden pending RFC-0027 Open Question 1. Left as a warning
+          // it would be no guard at all: nested playbooks form a combined depends_on
+          // graph that the per-playbook cycle check below never sees.
+          errors.push(
+            `${sctx}: 'uses' names playbook '${step.uses}'; playbook nesting is not permitted (§4.3b, RFC-0027 OQ1)`
+          );
+        } else if (target !== "skill") {
+          warnings.push(
+            `${sctx}: 'uses' names '${step.uses}' of kind '${target}'; SHOULD name a kind: skill unit (§4.3b)`
+          );
+        }
+      }
+
+      if (step.on_failure !== undefined && !VALID_ON_FAILURE.has(step.on_failure)) {
+        errors.push(
+          `${sctx}: 'on_failure' must be one of [abort, continue, escalate], got '${step.on_failure}'`
+        );
+      }
+
+      // Checked against the manifest's declared scale, not a hardcoded vocabulary —
+      // §3.13 makes authority_level_scale a per-manifest declaration, and the v0.27
+      // check at the bottom of this function already works that way. A warning, for
+      // the same reason it is one there: a manifest that declares no scale has not
+      // made an error, it has declined to constrain.
+      if (step.authority_level !== undefined && declaredLevels.size > 0
+          && !declaredLevels.has(step.authority_level)) {
+        warnings.push(
+          `${sctx}: 'authority_level' value '${step.authority_level}' is not in the declared 'authority_level_scale' (§3.13)`
+        );
+      }
+
+      // A step whose unit can mutate but which declares no ceiling is bounded only by
+      // the agent's own grant — looser than the author probably intended (§4.3b).
+      if (step.authority_level === undefined && step.uses !== undefined) {
+        const target = manifest.units.find((u) => u.id === step.uses);
+        const scope = target?.action_scope;
+        if (scope && ((scope.paths?.length ?? 0) > 0 || (scope.spend !== undefined))) {
+          warnings.push(
+            `${sctx}: omits 'authority_level' while '${step.uses}' declares a mutating action_scope; the step is bounded only by the enacting agent (§4.3b)`
+          );
+        }
+      }
+    }
+
+    // depends_on must reference declared steps, and the graph must be acyclic.
+    for (const step of unit.steps) {
+      for (const dep of step.depends_on ?? []) {
+        if (!stepIds.has(dep)) {
+          errors.push(
+            `${ctx} step '${step.id}': depends_on names unknown step '${dep}' (§4.3b)`
+          );
+        }
+      }
+    }
+    const cycle = findStepCycle(unit.steps);
+    if (cycle) {
+      errors.push(`${ctx}: 'depends_on' graph contains a cycle: ${cycle.join(" -> ")} (§4.3b)`);
+    }
+
+    // §4.3b: the step-scope union is computable only when every step uses a unit and
+    // every such unit declares an action_scope. Report the declared scope as
+    // unverified rather than passing it silently — a declaration that lints clean
+    // reads as checked.
+    const inline = unit.steps.filter((s) => s.uses === undefined).length;
+    if (inline > 0) {
+      warnings.push(
+        `${ctx}: ${inline} of ${unit.steps.length} step(s) are inline ('action'); an inline step has no action_scope and is bounded only by its authority_level (§4.3b)`
+      );
+    }
+    if (unit.action_scope !== undefined) {
+      const scopeless = unit.steps.filter(
+        (s) => s.uses !== undefined && !manifest.units.find((u) => u.id === s.uses)?.action_scope
+      ).length;
+      if (inline > 0 || scopeless > 0) {
+        warnings.push(
+          `${ctx}: declared 'action_scope' is UNVERIFIED — the step-scope union is not computable (${inline} inline step(s), ${scopeless} step(s) whose unit declares no action_scope) (§4.3b)`
+        );
       }
     }
   }


### PR DESCRIPTION
Implements [RFC-0027](https://github.com/Cantara/knowledge-context-protocol/blob/main/RFC-0027-Playbooks.md), merged in #143 as a design document. This is the code.

## What it adds

`kind: playbook` — an ordered composition of units, governed **per step**.

The gap: `kind: executable` is governed at invocation and opaque thereafter, so a procedure that reads state, proposes a change, waits for a human, then commits must declare one authority level for all four phases — over-granting the reading steps or blocking the committing one. RFC-0025 supplied the authority scale, RFC-0026 the escalation vocabulary; neither had a step to attach to.

| Layer | Change |
|---|---|
| **SPEC.md** | New §4.3b; `playbook` in both kind tables; version → 0.29 |
| **schema** | `kind` enum, `kcp_version` enum, full `steps` definition |
| **TS / Python / Java** | `PlaybookStep` model, `steps` parsing, 10 conformance rules each |
| **Tests** | 28 per language, mirroring case for case |

## Two rules are errors, not warnings

Both were warnings in the RFC draft until adversarial review showed they were load-bearing:

- **Unresolvable `uses` → error.** A resolvable `uses` is the entire justification for a distinct kind — the RFC's own *Alternatives Considered* concedes that without it, `executable` plus a metadata block would do. A dangling reference that lints clean removes the only thing the kind buys.
- **Nesting → error**, pending RFC-0027 OQ1. As a warning it was no guard: nested playbooks form a combined `depends_on` graph the per-playbook cycle check never sees.

## Implementation notes

**`uses` resolution is a second pass.** The unit-id set is incomplete mid-loop, so an inline check would reject a forward reference the spec permits. Tested explicitly.

**The cycle detector walks only explicit edges.** The implicit "after the previous step" default cannot produce a cycle — declaration order is total — so materialising it would add edges that are never a defect. Iterative in all three languages; a 5000-step chain is tested, because a manifest is untrusted input.

**Step `authority_level` checks against the manifest's declared scale**, not a hardcoded vocabulary. §3.13 makes the scale a per-manifest declaration and the v0.27 code already worked that way; hardcoding would have created a second source of truth.

## Verification

Tests were mutation-checked rather than assumed: downgrading the unresolvable-`uses` rule to a warning fails 1, removing the nesting ban fails 1, stubbing the cycle detector fails 3.

End-to-end, through the built CLI — the RFC's Complete Example extracted verbatim:

```
knowledge.yaml (4 units, kcp_version: 0.29)
⚠ 1 warning: manifest: 'version' not declared
```

Removing `complete-promotion` reintroduces the exact defect the RFC draft shipped:

```
✗ Unit 'promote-release' step 'promote': 'uses' names unit
  'complete-promotion', which is not declared in this manifest (§4.3b)
```

And a cycle names its path: `verify -> promote -> prepare-change -> verify`.

**Suites:** TS 154 · Python 223 · Java parser 208 · Java bridge 175.

The cross-language consistency guard caught the incomplete version bump (schema enum, `cli/package.json`, `SCAFFOLD_KCP_VERSION`). That test was broken through the entire 0.26→0.28 drift; this is the first release where it worked as designed.

## Known gaps, stated rather than hidden

- `uses` resolves by unit id, not signed hash — superseding a referenced unit with a broader `action_scope` silently widens an approved playbook (OQ2).
- The orchestrator-MUST-NOT-execute rule binds an actor with no schema representation, so no validator can check it.
- Nesting, per-step evidence, run-level budget, cross-step temporal drift: open (OQ1, 3, 6, 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)