### PR TITLE
chore(release): v0.29.1 — boolean value parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,54 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.29.1] — 2026-07-28 — Boolean value parity
+
+A patch release, not a minor: no new spec surface. It fixes the three reference parsers
+disagreeing about what a manifest says.
+
+### Fixed
+
+- **`deprecated: no` was `true` in TypeScript** (#151, #152). `shared/src/parser.ts` coerced
+  with `Boolean()`, and `Boolean()` on any non-empty string is `true`. js-yaml implements
+  YAML 1.2 and leaves `yes`/`no`/`on`/`off` as strings, so every **negative became a
+  positive** — and so did every typo: `deprecated: flase` was `true`. 14 call sites shared it.
+- **The Java parser crashed on a malformed boolean** (#153, #154). Twelve `(Boolean)` casts
+  threw `ClassCastException` on any non-Boolean value. A manifest is untrusted input and can
+  arrive over federation (§3.6), so a misspelled boolean was a denial-of-service surface.
+- **The Python parser returned a `str` in a field typed `Optional[bool]`** (#153, #154). Two
+  variants were in use: one with no coercion at all, one using `bool()`, where `bool("flase")`
+  is `True`.
+
+All three now share one rule: a real boolean passes through, the YAML 1.1 words resolve to
+their intended value, and anything else reads as **undeclared** so the unit falls back to its
+documented default rather than silently switching a flag on.
+
+### Added
+
+- **A `values` assertion in the conformance suite** (#154), with a fixture covering boolean
+  semantics. The runners compared `valid`, `errors`, `unit_count`, `relationship_count` and
+  `warnings` — never *what a field parsed to*. A boolean read as `true` in one language and
+  `false` in another leaves the manifest equally valid with identical counts, so no fixture
+  could have caught this. It was not a missing test; it was a missing kind of assertion.
+- **[guides/start-here-the-kcp-universe.md](./guides/start-here-the-kcp-universe.md)** (#155)
+  — an entry point for newcomers: the `knowledge` → `skill` → `playbook` progression, the
+  tooling around the spec, and how the RFC process works.
+- **RFC-0028: Eligibility Grants and Their Composition** — merged as a **Draft**. It targets
+  v0.30 and nothing here implements it. It specifies the eligibility grant §16.3 C4 requires
+  but never names, and rules that eligibility does not compose from a playbook to its steps.
+
+### Known issue
+
+The coercion rule above resolves the YAML 1.1 words (`yes`/`no`/`on`/`off`) as booleans, while
+§2 mandates YAML 1.2, where those are **strings**. js-yaml is the conformant loader; PyYAML and
+SnakeYAML are not, and resolve them before any KCP code runs — so this cannot be fixed by
+coercion alone. Whether the spec should permit them or the implementations should move to 1.2
+loaders is **#156**, and the rule belongs in SPEC.md either way. This release makes the three
+parsers agree; it does not settle which answer they should agree on.
+
+
+---
+
 ## [0.29.0] — 2026-07-27 — Playbooks
 
 Adds `kind: playbook` (RFC-0027): an ordered composition of units, governed **per step**.

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.29.0</version>
+    <version>0.29.1</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.29.0"
+version = "0.29.1"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.26.1",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.26.1",
+      "version": "0.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Developer CLI for the Knowledge Context Protocol \u2014 init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.29.0
+    `\nKCP Developer CLI — v0.29.1
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.29.0";
+export const RENDERER_VERSION = "kcp-cli 0.29.1";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 


### PR DESCRIPTION
A **patch**, not a minor: no new spec surface. `SPEC.md` stays at 0.29, the schema and `SCAFFOLD_KCP_VERSION` are untouched; only package versions move.

## What it fixes

The three reference parsers disagreed about what a manifest says.

| Parser | `deprecated: no` | `deprecated: flase` |
|---|---|---|
| TypeScript | **`true`** ⚠️ | **`true`** ⚠️ |
| Python | `False` | **`'flase'`** — a `str` in an `Optional[bool]` |
| Java | `false` | **`ClassCastException`** |

Java crashing matters beyond robustness: a manifest is untrusted input and can arrive over federation (§3.6), so a misspelled boolean was a denial-of-service surface.

## The part that makes this class findable

The conformance runners compared `valid`, `errors`, `unit_count`, `relationship_count`, `warnings` — **never what a field parsed to**. A boolean read as `true` in one language and `false` in another leaves the manifest equally valid with identical counts.

It wasn't a missing test. It was a missing **kind of assertion**. `values` now exists in all three runners.

## Also in this release

- The [newcomer guide](./guides/start-here-the-kcp-universe.md)
- **RFC-0028** merged as a **Draft** — it targets v0.30 and nothing here implements it. Merging records design consensus, which is the distinction the new guide exists partly to teach.

## Known issue, recorded rather than omitted

The coercion resolves `yes`/`no`/`on`/`off` as booleans, while **§2 mandates YAML 1.2**, where those are *strings*. js-yaml is the conformant loader; PyYAML and SnakeYAML resolve them before any KCP code runs, so coercion alone cannot fix it.

**[#156](https://github.com/Cantara/knowledge-context-protocol/issues/156)** tracks whether the spec should permit them or the implementations should move to 1.2 loaders. This release makes the three parsers **agree**; it does not settle which answer they should agree on.

184 TS tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)