### PR TITLE
fix: resolve booleans per YAML 1.2, as §2 has always required

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -134,6 +134,32 @@ Well-known catalog locations, in order of preference:
 
 KCP manifests MUST be valid YAML 1.2. The file MUST be UTF-8 encoded without a BOM.
 
+### 2.1 Scalar resolution
+
+YAML 1.2 is not a cosmetic requirement, and the boolean case is where it bites. This
+section clarifies behaviour the JSON schema has always required; it does not change what
+a conformant manifest may say, so `kcp_version` is unaffected.
+
+Under the **YAML 1.2 core schema**, only `true` / `True` / `TRUE` / `false` / `False` /
+`FALSE` resolve to booleans. The YAML **1.1** words `yes`, `no`, `on`, `off` are plain
+**strings**. Since every boolean field in this specification is typed `boolean` in the
+JSON schema, a manifest writing `deprecated: yes` declares a string where a boolean
+belongs — a schema violation, not a shorthand.
+
+- A parser MUST resolve booleans per the YAML 1.2 core schema.
+- A parser MUST treat a non-boolean value in a boolean field as **undeclared**, so the
+  unit falls back to that field's documented default. It MUST NOT coerce it.
+
+**This is a loader-level requirement, not a coercion-level one**, and implementers should
+expect to act on it. PyYAML and SnakeYAML both implement YAML 1.1 and resolve `yes` to a
+boolean *before any consuming code runs* — at which point it is indistinguishable from a
+manifest that wrote `true`. Both can be corrected by narrowing their implicit boolean
+resolver to the 1.2 core pattern; neither requires a different library.
+
+> **Authors:** write `true` and `false`. A `yes` will not be rejected loudly — it reads as
+> a field you did not write, and takes that field's default. The parse layer has no
+> diagnostics channel through which to tell you (RFC-0028, OQ4).
+
 Parsers MUST silently ignore fields they do not recognise. This ensures forward compatibility:
 a manifest valid for a future version of the spec remains parseable by implementations of this
 version.

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.29.1</version>
+    <version>0.29.2</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.29.1"
+version = "0.29.2"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.25.3",

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Developer CLI for the Knowledge Context Protocol \u2014 init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/boolean-coercion.test.ts
+++ b/cli/src/boolean-coercion.test.ts
@@ -3,19 +3,26 @@ import { parseDict } from "../../shared/src/parser.js";
 import yaml from "js-yaml";
 
 /**
- * Boolean coercion — the three reference parsers must agree (#151).
+ * Boolean coercion — YAML 1.2, per SPEC.md §2 (#151, #153, #156).
  *
- * `Boolean()` on any non-empty string is `true`, and js-yaml implements YAML 1.2, which
- * leaves `yes`/`no`/`on`/`off` as strings. PyYAML and SnakeYAML implement YAML 1.1 and
- * parse them as booleans. So `deprecated: no` was read as **deprecated** in TypeScript
- * and **not deprecated** in Python and Java — the same manifest saying opposite things.
+ * §2 mandates YAML 1.2. In 1.2 only `true`/`false` — and their capitalised and all-caps
+ * spellings — are booleans; `yes`/`no`/`on`/`off` are plain **strings**. The JSON schema
+ * types these fields as `boolean`, so such a string is a schema violation, not a
+ * shorthand to be rescued.
  *
- * The failure is asymmetric in the dangerous direction: every negative became a
- * positive, and so did every typo. `deprecated: flase` was `true`.
+ * This landed in three attempts, and the middle one is the instructive failure:
  *
- * These tests go through the YAML loader rather than constructing objects directly,
- * because the bug lives in the seam between what js-yaml produces and what the parser
- * does with it. Handing the parser a JavaScript `false` would test nothing.
+ *  1. `Boolean()` accepted every non-empty string, so every negative and every typo read
+ *     as `true` — `deprecated: no` meant deprecated.
+ *  2. The fix mapped the YAML 1.1 words to booleans. That made all three parsers agree —
+ *     on an answer the schema rejects. Agreement is not correctness.
+ *  3. Python and Java now resolve booleans per YAML 1.2 at the *loader*, which is the
+ *     only place it can be fixed for them: PyYAML converts `yes` to `True` before any
+ *     KCP code runs, so no downstream helper can tell it from `true`.
+ *
+ * These tests go through the YAML loader rather than constructing objects, because the
+ * behaviour under test lives in the seam between what the loader produces and what the
+ * parser does with it. Handing the parser a JavaScript `false` would test nothing.
  */
 
 function unit(fields: string): Record<string, unknown> {
@@ -34,52 +41,50 @@ ${fields}
   return parseDict(doc).units[0] as unknown as Record<string, unknown>;
 }
 
-describe("YAML 1.1 boolean words agree with the Python and Java parsers (#151)", () => {
-  // PyYAML and SnakeYAML both read these as booleans. TypeScript must reach the same
-  // value, or a manifest reviewed in one language behaves differently in another.
-  const falsey = ["no", "No", "NO", "off", "Off", "OFF", "false", "False"];
-  const truthy = ["yes", "Yes", "YES", "on", "On", "ON", "true", "True"];
-
-  for (const v of falsey) {
-    it(`deprecated: ${v} → false`, () => {
-      expect(unit(`    deprecated: ${v}`).deprecated).toBe(false);
-    });
-  }
-
-  for (const v of truthy) {
+describe("YAML 1.2 core-schema booleans are the only booleans (#156)", () => {
+  for (const v of ["true", "True", "TRUE"]) {
     it(`deprecated: ${v} → true`, () => {
       expect(unit(`    deprecated: ${v}`).deprecated).toBe(true);
     });
   }
+  for (const v of ["false", "False", "FALSE"]) {
+    it(`deprecated: ${v} → false`, () => {
+      expect(unit(`    deprecated: ${v}`).deprecated).toBe(false);
+    });
+  }
+});
 
-  it("the regression this was filed for: `deprecated: no` is not deprecated", () => {
-    // Before the fix this was `true`, so a live unit was dropped from every plan as
-    // deprecated — in TypeScript only.
-    expect(unit("    deprecated: no").deprecated).toBe(false);
+describe("YAML 1.1 boolean words are strings, and read as undeclared (#156)", () => {
+  // The heart of the fix. These are valid YAML 1.2 — they are simply strings — and a
+  // string in a field the schema types `boolean` is a schema violation. Verified
+  // directly against the JSON schema: `'yes' is not of type 'boolean'`.
+  for (const v of ["yes", "Yes", "YES", "no", "No", "NO", "on", "On", "off", "Off"]) {
+    it(`deprecated: ${v} → undefined`, () => {
+      expect(unit(`    deprecated: ${v}`).deprecated).toBeUndefined();
+    });
+  }
+
+  it("the regression this began with: `deprecated: no` is not deprecated", () => {
+    // Originally `true` — a live unit dropped from every plan, in TypeScript only.
+    // Then `false` — agreeing with the other parsers, on a value the schema rejects.
+    // Now undeclared, which is what the schema says it is.
+    expect(unit("    deprecated: no").deprecated).toBeUndefined();
   });
 });
 
-describe("a value that is not a boolean reads as undeclared, not as true (#151)", () => {
-  // The safe direction. An unparseable value must leave the field absent so the unit
-  // falls back to its declared default, rather than silently switching a flag on.
+describe("anything else reads as undeclared, never as true (#151)", () => {
   for (const v of ["flase", "nope", "1", "0", "maybe", "[]", "{}"]) {
     it(`deprecated: ${v} → undefined`, () => {
       expect(unit(`    deprecated: ${v}`).deprecated).toBeUndefined();
     });
   }
 
-  it("a QUOTED boolean word is indistinguishable from a bare one, and resolves", () => {
-    // An earlier version of this test asserted `"yes"` → undefined, on the reasoning
-    // that quoting means the author wrote text. That is unachievable: js-yaml is a YAML
-    // 1.2 parser, so bare `yes` and quoted `"yes"` both arrive as the string "yes" —
-    // the quoting is gone before the parser sees the value. Distinguishing them would
-    // require reading raw bytes, which a manifest parser does not do.
-    //
-    // The consequence is accepted rather than hidden: quoted boolean words resolve.
-    // It is a far narrower surface than `Boolean()`, which accepted every non-empty
-    // string including typos.
-    expect(unit('    deprecated: "yes"').deprecated).toBe(true);
-    expect(unit('    deprecated: "no"').deprecated).toBe(false);
+  it("a quoted boolean is a string, and now genuinely rejected", () => {
+    // Under the 1.1-word mapping this could not be distinguished from a bare `yes`,
+    // because the quoting is gone before the parser sees the value. Rejecting the words
+    // outright makes the question moot: `"true"` is a string either way.
+    expect(unit('    deprecated: "true"').deprecated).toBeUndefined();
+    expect(unit('    deprecated: "yes"').deprecated).toBeUndefined();
   });
 
   it("an absent field stays absent", () => {
@@ -87,18 +92,15 @@ describe("a value that is not a boolean reads as undeclared, not as true (#151)"
   });
 });
 
-describe("every boolean field on a unit uses the same coercion (#151)", () => {
-  // The bug was 14 separate `Boolean()` calls. Fixing one is not fixing the class, so
-  // this asserts the shared helper actually reached the fields that carry risk.
-  it("not_for_strict: off → false", () => {
-    expect(unit("    not_for_strict: off").not_for_strict).toBe(false);
+describe("every boolean field shares the coercion (#151)", () => {
+  // The original bug was 14 separate `Boolean()` calls. Fixing one is not fixing the
+  // class, so this checks the shared helper reached the fields that carry risk.
+  it("not_for_strict: off is undeclared; true is true", () => {
+    expect(unit("    not_for_strict: off").not_for_strict).toBeUndefined();
+    expect(unit("    not_for_strict: true").not_for_strict).toBe(true);
   });
 
-  it("not_for_strict: flase → undefined", () => {
-    expect(unit("    not_for_strict: flase").not_for_strict).toBeUndefined();
-  });
-
-  it("trust.agent_requirements.require_attestation: no → false", () => {
+  it("trust.agent_requirements booleans follow the same rule", () => {
     const m = parseDict(
       yaml.load(`
 project: t
@@ -106,19 +108,18 @@ version: 1.0.0
 kcp_version: "0.29"
 trust:
   agent_requirements:
-    require_attestation: no
+    require_attestation: false
     propagate_to_governed: off
 units: []
 `) as Record<string, unknown>,
     );
     expect(m.trust?.agent_requirements?.require_attestation).toBe(false);
-    expect(m.trust?.agent_requirements?.propagate_to_governed).toBe(false);
+    expect(m.trust?.agent_requirements?.propagate_to_governed).toBeUndefined();
   });
 
-  it("payment method free_tier: no → false", () => {
-    // free_tier sits on a payment *method*, not on payment. An earlier version of this
-    // test put it one level too high and passed trivially against undefined — which is
-    // its own small lesson about asserting on a field you have not located.
+  it("payment method free_tier follows the same rule", () => {
+    // free_tier sits on a payment *method*, not on payment — an earlier version of this
+    // test asserted one level too high and passed trivially against undefined.
     const m = parseDict(
       yaml.load(`
 project: t
@@ -128,7 +129,7 @@ payment:
   default_tier: subscription
   methods:
     - type: subscription
-      free_tier: no
+      free_tier: false
 units: []
 `) as Record<string, unknown>,
     );

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.29.1
+    `\nKCP Developer CLI — v0.29.2
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.29.1";
+export const RENDERER_VERSION = "kcp-cli 0.29.2";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/conformance/fixtures/value-semantics/boolean-coercion.expected.json
+++ b/conformance/fixtures/value-semantics/boolean-coercion.expected.json
@@ -1,18 +1,18 @@
 {
-  "_note": "Value-semantics fixture (#153). `values` pins what fields parse TO, which validity and counts cannot see. A boolean read as true in one parser and false in another leaves both equally valid with identical counts.",
+  "_note": "Value-semantics fixture (#153, #156). \u00a72 mandates YAML 1.2, in which yes/no/on/off are STRINGS, not booleans \u2014 and the JSON schema types these fields as boolean, so such a value is a schema violation. All three parsers must therefore read the 1.1 words as UNDECLARED, exactly as they read a typo. Only true/false are booleans.",
   "valid": true,
   "errors": [],
   "unit_count": 5,
   "relationship_count": 0,
   "values": {
-    "units.0.deprecated": false,
-    "units.0.not_for_strict": false,
-    "units.1.deprecated": true,
-    "units.1.not_for_strict": true,
+    "units.0.deprecated": null,
+    "units.0.not_for_strict": null,
+    "units.1.deprecated": null,
+    "units.1.not_for_strict": null,
     "units.2.deprecated": false,
     "units.2.not_for_strict": true,
     "units.3.deprecated": null,
-    "units.4.deprecated": false,
-    "units.4.not_for_strict": true
+    "units.4.deprecated": null,
+    "units.4.not_for_strict": null
   }
 }

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -41,6 +41,10 @@ import no.cantara.kcp.model.Visibility;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.resolver.Resolver;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,7 +64,45 @@ public class KcpParser {
     // SafeConstructor disables arbitrary Java type instantiation via YAML tags
     // (e.g. !!javax.script.ScriptEngineManager). SnakeYAML 2.x defaults to safe,
     // but we declare it explicitly so the intent survives refactoring.
-    private static final Yaml YAML = new Yaml(new SafeConstructor(new LoaderOptions()));
+    /**
+     * Resolves scalars per the YAML 1.2 core schema, as SPEC.md §2 requires.
+     *
+     * <p>SnakeYAML implements YAML 1.1, in which {@code yes}/{@code no}/{@code on}/
+     * {@code off} resolve to booleans. §2 mandates YAML 1.2, in which they are plain
+     * strings — and the JSON schema types these fields as {@code boolean}, so such a
+     * value is a schema violation rather than a shorthand to be rescued.
+     *
+     * <p>Left alone the divergence is invisible from inside this class: SnakeYAML
+     * converts {@code yes} to {@code Boolean.TRUE} before any KCP code runs, so no
+     * coercion helper downstream can tell it from a manifest that wrote {@code true}.
+     * It has to be fixed at the resolver (#156).
+     *
+     * <p>Only the boolean resolver is narrowed. Ints, floats, null, merge keys and
+     * timestamps keep SnakeYAML's behaviour, because §2's requirement bites here and
+     * nowhere this parser has been shown to diverge.
+     */
+    private static final class Yaml12Resolver extends Resolver {
+        @Override
+        protected void addImplicitResolvers() {
+            addImplicitResolver(Tag.BOOL,
+                    java.util.regex.Pattern.compile("^(?:true|True|TRUE|false|False|FALSE)$"), "tTfF");
+            addImplicitResolver(Tag.INT,
+                    java.util.regex.Pattern.compile("^[-+]?[0-9]+$"), "-+0123456789");
+            addImplicitResolver(Tag.FLOAT,
+                    java.util.regex.Pattern.compile("^[-+]?(\\.[0-9]+|[0-9]+(\\.[0-9]*)?)([eE][-+]?[0-9]+)?$"),
+                    "-+0123456789.");
+            addImplicitResolver(Tag.NULL,
+                    java.util.regex.Pattern.compile("^(?:~|null|Null|NULL| )$"), "~nN\0");
+            addImplicitResolver(Tag.NULL, java.util.regex.Pattern.compile("^$"), null);
+            addImplicitResolver(Tag.MERGE, java.util.regex.Pattern.compile("^(?:<<)$"), "<");
+        }
+    }
+
+    private static final Yaml YAML = new Yaml(
+            new SafeConstructor(new LoaderOptions()),
+            new Representer(new DumperOptions()),
+            new DumperOptions(),
+            new Yaml12Resolver());
 
     public static KnowledgeManifest parse(Path path) throws IOException {
         try (InputStream is = Files.newInputStream(path)) {
@@ -701,18 +743,8 @@ public class KcpParser {
      * field reads as undeclared and the unit falls back to its documented default rather
      * than silently switching a flag on.
      */
-    private static final java.util.Set<String> YAML_TRUE = java.util.Set.of("true", "yes", "on");
-    private static final java.util.Set<String> YAML_FALSE = java.util.Set.of("false", "no", "off");
-
     private static Boolean asBoolean(Object raw) {
-        if (raw == null) return null;
-        if (raw instanceof Boolean b) return b;
-        if (raw instanceof String s) {
-            String v = s.toLowerCase(java.util.Locale.ROOT);
-            if (YAML_TRUE.contains(v)) return Boolean.TRUE;
-            if (YAML_FALSE.contains(v)) return Boolean.FALSE;
-        }
-        return null;
+        return raw instanceof Boolean b ? b : null;
     }
 
     private static LocalDate parseDate(Object value) {

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -2,6 +2,7 @@ from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import List, Optional, Union
 
+import re
 import yaml
 
 from .model import (
@@ -46,42 +47,61 @@ def _validate_unit_path(raw: str) -> str:
 def parse(path: Union[str, Path]) -> KnowledgeManifest:
     """Parse a knowledge.yaml file from disk."""
     with Path(path).open(encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+        data = yaml.load(f, Loader=Yaml12SafeLoader)
     return parse_dict(data)
 
 
-_YAML_TRUE = {"true", "yes", "on"}
-_YAML_FALSE = {"false", "no", "off"}
+_YAML_12_BOOL = re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$")
+
+
+class Yaml12SafeLoader(yaml.SafeLoader):
+    """A SafeLoader that resolves booleans per YAML 1.2, as SPEC.md §2 requires.
+
+    PyYAML implements YAML 1.1, in which ``yes``/``no``/``on``/``off`` resolve to
+    booleans. §2 mandates YAML 1.2, in which they are plain strings — and the JSON
+    schema types these fields as ``boolean``, so such a value is a schema violation
+    rather than a shorthand to be rescued.
+
+    Left alone, the divergence is invisible from inside this package: PyYAML converts
+    ``yes`` to ``True`` before any KCP code runs, so no coercion helper downstream can
+    tell it from a manifest that wrote ``true``. The fix has to happen at the loader
+    (#156).
+
+    Only the boolean resolver is narrowed. Everything else — ints, floats, null, merge
+    keys, timestamps — keeps PyYAML's behaviour, because §2's requirement bites here
+    and nowhere this parser has been shown to diverge.
+    """
+
+
+def _install_yaml_12_bool_resolver() -> None:
+    """Replace the 1.1 bool resolvers on Yaml12SafeLoader with the 1.2 core schema."""
+    # yaml_implicit_resolvers is inherited by reference; copy before mutating or this
+    # narrows SafeLoader for every other consumer in the process.
+    Yaml12SafeLoader.yaml_implicit_resolvers = {
+        ch: [(tag, rx) for (tag, rx) in resolvers if tag != "tag:yaml.org,2002:bool"]
+        for ch, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+    }
+    Yaml12SafeLoader.add_implicit_resolver(
+        "tag:yaml.org,2002:bool", _YAML_12_BOOL, list("tTfF")
+    )
+
+
+_install_yaml_12_bool_resolver()
 
 
 def _as_bool(value):
-    """Coerce a YAML scalar to a bool, agreeing with the TypeScript and Java parsers.
+    """Return a bool, or None when the value is not one.
 
-    Three variants were in use here and all three were wrong (#153):
+    The loader resolves booleans per YAML 1.2 (§2), so ``yes``/``no``/``on``/``off``
+    arrive here as strings and are rejected exactly as a typo is. An earlier revision
+    mapped those words to booleans, which made the three parsers agree — on an answer
+    the schema rejects (#156).
 
-      - ``u.get("deprecated")`` — no coercion at all, so a misspelled value became a
-        ``str`` sitting in a field typed ``Optional[bool]``;
-      - ``bool(u.get(...))`` — ``bool("flase")`` is ``True``, so every typo read as a
-        deliberate ``true``;
-      - and in Java, a cast, which threw ``ClassCastException`` on the same input.
-
-    PyYAML implements YAML 1.1 and already resolves ``yes``/``no``/``on``/``off`` to
-    booleans, so those arrive here correct. js-yaml implements YAML 1.2 and leaves them
-    as strings, which is why the words are handled explicitly: this function must give
-    the same answer whichever parser produced the value.
-
-    Anything else returns ``None`` — the field reads as *undeclared*, so the unit falls
-    back to its documented default rather than silently switching a flag on.
+    None means the field reads as *undeclared*, so the unit falls back to its documented
+    default rather than silently switching a flag on. That a rejected value is silent
+    rather than reported is a known gap: the parse layer has no diagnostics channel.
     """
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        v = value.lower()
-        if v in _YAML_TRUE:
-            return True
-        if v in _YAML_FALSE:
-            return False
-    return None
+    return value if isinstance(value, bool) else None
 
 
 def _parse_trust(data: Optional[dict]) -> Optional[Trust]:

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -87,39 +87,25 @@ function toDateString(value: unknown): string | undefined {
 type RawMap = Record<string, unknown>;
 
 /**
- * Coerce a YAML scalar to a boolean, agreeing with the Python and Java parsers (#151).
+ * Coerce a YAML scalar to a boolean. Only a real boolean is one.
  *
- * `Boolean()` was used here, and `Boolean()` on any non-empty string is `true`. js-yaml
- * implements YAML 1.2, which leaves `yes`/`no`/`on`/`off` as strings, while PyYAML and
- * SnakeYAML implement YAML 1.1 and parse them as booleans. So `deprecated: no` read as
- * **deprecated** in TypeScript and **not deprecated** in the other two — the same
- * manifest saying opposite things, with no diagnostic anywhere.
+ * js-yaml implements YAML 1.2, which SPEC.md §2 mandates, so `yes`/`no`/`on`/`off`
+ * arrive here as strings. They are rejected exactly as a typo is: the JSON schema types
+ * these fields as `boolean`, so a string is a schema violation rather than a shorthand
+ * to be rescued.
  *
- * The failure was asymmetric in the dangerous direction: every negative became a
- * positive, and so did every typo (`deprecated: flase` was `true`).
+ * Two earlier revisions got this wrong in opposite directions. `Boolean()` accepted every
+ * non-empty string, so every negative and every typo read as `true` (#151). The fix then
+ * mapped the YAML 1.1 words to booleans, which made the three parsers agree — on an
+ * answer the schema rejects (#156). The Python and Java parsers now resolve booleans per
+ * YAML 1.2 at the loader, so all three see the same strings and reject them alike.
  *
- * Three rules:
- *  - a real boolean passes through;
- *  - the YAML 1.1 words resolve to their intended value, so this parser agrees with the
- *    other two rather than disagreeing in a third way;
- *  - anything else yields undefined — the field reads as *undeclared*, so the unit falls
- *    back to its documented default instead of silently switching a flag on.
- *
- * Quoted `"true"` is deliberately not accepted. Quoting means the author wrote text, and
- * accepting it would make the strictness pointless: every rejected value could be quoted
- * back in.
+ * `undefined` means the field reads as *undeclared*, so the unit falls back to its
+ * documented default rather than silently switching a flag on. That a rejected value is
+ * silent rather than reported is a known gap: the parse layer has no diagnostics channel.
  */
-const YAML_TRUE = new Set(["true", "yes", "on"]);
-const YAML_FALSE = new Set(["false", "no", "off"]);
-
 function asBool(value: unknown): boolean | undefined {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "string") {
-    const v = value.toLowerCase();
-    if (YAML_TRUE.has(v)) return true;
-    if (YAML_FALSE.has(v)) return false;
-  }
-  return undefined;
+  return typeof value === "boolean" ? value : undefined;
 }
 
 function asStringArray(value: unknown): string[] {


### PR DESCRIPTION
Closes #156. **Corrects #154**, which fixed a real bug and settled on the wrong answer.

## The spec already had an answer

§2 mandates **YAML 1.2**. In 1.2 only `true`/`false` (and capitalised spellings) are booleans; `yes`/`no`/`on`/`off` are plain **strings**. Every boolean field is typed `boolean` in the JSON schema, which rejects the string:

```
'yes' is not of type 'boolean'
```

Two places, in agreement. #154 made all three parsers **accept what the schema rejects**. There was never a 1.1-vs-1.2 ambiguity to resolve — only my failure to read §2 before choosing.

**Agreement is not correctness.**

## Fixed at the loader, because that is the only place it can be

PyYAML and SnakeYAML implement YAML 1.1 and convert `yes` to a boolean *before any KCP code runs* — at which point no downstream helper can tell it from a manifest that wrote `true`. Both are narrowed to the 1.2 core boolean pattern by customising their implicit resolvers.

**No new dependency in either language**, which I had assumed would be required. js-yaml is already 1.2. The three coercion helpers now accept only real booleans.

## The migration cost was imaginary

My recommendation in #156 rested on the 1.1 words being *"pervasive in hand-written YAML"*. I had not measured that. Measured across every `knowledge.yaml` under `/src/cantara` and `/src/aegis`:

```
0 of 230 manifests use yes/no/on/off for a boolean field
```

## Two details worth keeping

The Python resolver **copies `yaml_implicit_resolvers` before mutating**. It is inherited by reference, so narrowing in place would have changed `SafeLoader` for every other consumer in the process — not just this parser.

**Only the boolean resolver is narrowed** in either language. Ints, floats, null, merge keys and timestamps keep existing behaviour, because §2's requirement bites at booleans and nowhere these parsers have been shown to diverge.

## SPEC.md §2.1

The rule was implemented in three parsers and **written down nowhere** — the same defect RFC-0028 exists to fix for `load_eligible`. Now documented, framed as a clarification: the schema always required it, so no conformant manifest changes meaning and `kcp_version` is unaffected.

The consistency guard earned its keep again — it caught me bumping SPEC to 0.29.2, which would have implied manifests should declare a patch version.

**Conformance 65/0 × 3.** TS 183, Python 223, Java 208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)