### PR TITLE
fix: parser artifact versions track the spec, and a guard keeps them there

### DIFF
--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>no.cantara.kcp</groupId>
             <artifactId>kcp-parser</artifactId>
-            <version>0.1.0</version>
+            <version>0.30.0</version>
         </dependency>
 
         <!-- MCP Java SDK: core + Jackson 3 bundle -->

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 keywords = ["kcp", "mcp", "knowledge", "ai-agents"]
 dependencies = [
-    "kcp>=0.1.0",
+    "kcp>=0.30.0",
     "mcp>=1.0.0",
 ]
 

--- a/cli/src/consistency.test.ts
+++ b/cli/src/consistency.test.ts
@@ -280,3 +280,52 @@ describe("composition + temporal spec invariants (RFC-0022)", () => {
     expect(spec).toContain("`valid_until` is earlier than `valid_from`");
   });
 });
+
+/**
+ * The parser artifacts a bridge depends on (#163).
+ *
+ * These went unguarded and drifted furthest of anything in the repository: two sat at
+ * `0.1.0` since the modules were created and one at `0.21.0`, while the spec reached
+ * 0.30. The cost is not cosmetic — `bridge/java` depends on `kcp-parser:0.1.0`, which is
+ * the only version that has ever existed, so a bridge could not express "I need a parser
+ * that knows action_scope". It resolves whatever was last installed locally, which is how
+ * correct mapper code came to fail with `cannot find symbol: actionScope()`.
+ */
+describe("parser artifact versions track the spec (#163)", () => {
+  const specMinor = (() => {
+    const m = readFileSync(r("SPEC.md"), "utf8").match(/\*\*Version:\*\*\s*([\d.]+)/);
+    return m![1];
+  })();
+
+  const artifacts: Array<[string, string, RegExp]> = [
+    ["parsers/java", "parsers/java/pom.xml", /<version>([\d.]+)<\/version>/],
+    ["parsers/python", "parsers/python/pyproject.toml", /^version\s*=\s*"([\d.]+)"/m],
+    ["shared", "shared/package.json", /"version":\s*"([\d.]+)"/],
+  ];
+
+  for (const [name, file, pattern] of artifacts) {
+    it(`${name} is on the current spec minor`, () => {
+      const m = readFileSync(r(file), "utf8").match(pattern);
+      expect(m, `no version found in ${file}`).toBeTruthy();
+      // Compared on the minor only: the artifact may carry a patch the spec does not.
+      const minor = m![1].split(".").slice(0, 2).join(".");
+      expect(minor, `${file} is ${m![1]}, spec is ${specMinor}`).toBe(specMinor);
+    });
+  }
+
+  it("the Java bridge requires a parser that can satisfy it", () => {
+    // The dependency must name a version that actually knows the fields the mapper
+    // reads. Pinning 0.1.0 forever means the requirement is unstatable.
+    const pom = readFileSync(r("bridge/java/pom.xml"), "utf8");
+    const dep = pom.match(/<artifactId>kcp-parser<\/artifactId>\s*<version>([\d.]+)<\/version>/);
+    expect(dep, "kcp-parser dependency not found in bridge/java/pom.xml").toBeTruthy();
+    expect(dep![1].split(".").slice(0, 2).join(".")).toBe(specMinor);
+  });
+
+  it("the Python bridge requires a parser that can satisfy it", () => {
+    const toml = readFileSync(r("bridge/python/pyproject.toml"), "utf8");
+    const dep = toml.match(/"kcp>=([\d.]+)"/);
+    expect(dep, "kcp dependency not found in bridge/python/pyproject.toml").toBeTruthy();
+    expect(dep![1].split(".").slice(0, 2).join(".")).toBe(specMinor);
+  });
+});

--- a/parsers/java/pom.xml
+++ b/parsers/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-parser</artifactId>
-    <version>0.1.0</version>
+    <version>0.30.0</version>
     <packaging>jar</packaging>
 
     <name>KCP Reference Parser</name>

--- a/parsers/python/pyproject.toml
+++ b/parsers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp"
-version = "0.1.0"
+version = "0.30.0"
 description = "Knowledge Context Protocol — reference parser and validator"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kcp/shared",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.30.0",
   "type": "module",
   "dependencies": {
     "js-yaml": "^4.1.0"


### PR DESCRIPTION
Closes #163.

Three parser artifacts, three different stale versions, none tracking anything:

| artifact | was | spec |
|---|---|---|
| `parsers/java` | **0.1.0** — since the module was created | 0.30 |
| `parsers/python` | **0.1.0** — since the module was created | 0.30 |
| `shared` (npm) | **0.21.0** | 0.30 |

These had drifted further than anything else in the repository, because **nothing was watching them**.

## The cost is not cosmetic

`bridge/java` depends on `kcp-parser:0.1.0` — the only version that has ever existed. So a bridge **cannot express** "I need a parser that knows `action_scope`". It resolves whatever was last `mvn install`ed locally, which is how correct mapper code in #164 came to fail with:

```
cannot find symbol: method actionScope()
```

against a months-old jar. `bridge/python` has the same shape with `kcp>=0.1.0`, satisfied by every version there has ever been.

CI was unaffected — it installs the parser before building a bridge — so this bit only locally, silently, and in the direction of **making correct code look wrong**.

## The durable part is the guard, not the bump

`cli/src/consistency.test.ts` already watched sixteen version markers and **none of them were these**. It gains five assertions — the three artifacts and both bridge requirements — comparing on the minor, so an artifact may carry a patch the spec does not.

Written test-first: all five failed before the bump.

| | |
|---|---|
| revert `parsers/java` to 0.1.0 | 1 assertion fails ✓ |
| restore | green ✓ |

Coordinates verified to still resolve: the Java parser installs at 0.30.0 and the bridge compiles against it; the Python parser installs and imports.

**188 TS tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)