### PR TITLE
chore(release): v0.30.1 — diagnostics and parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.30.1] — 2026-07-28 — Diagnostics and parity
+
+No spec surface changes; `SPEC.md` stays at 0.30 and no manifest changes meaning.
+
+### Added
+
+- **`parse_diagnostics` on the manifest** (#166, resolves RFC-0028 OQ4). Three manifests
+  — a correct grant, a malformed value, and a misspelled field name — were
+  indistinguishable to their author:
+
+  ```
+  load_eligible: true    → ✓ Valid — no errors or warnings
+  load_eligible: ture    → ✓ Valid — no errors or warnings
+  laod_eligible: true    → ✓ Valid — no errors or warnings
+  ```
+
+  Only the first granted anything; the other two produced a unit that failed closed
+  forever, silently. Both causes live at the parse boundary — §2.1 drops a non-boolean
+  and §2 discards an unknown field — so neither was visible to a validator. Now recorded
+  where the information still exists and surfaced as warnings.
+
+  **Forward compatibility is preserved.** §2 requires unknown fields to be ignored, which
+  is what lets a v0.31 manifest be read by a v0.30 parser; ignoring a field is not the
+  same as being unable to mention it. Only keys within two edits of a known field are
+  reported, so a genuinely future field stays silent. Diagnostics never rescue: a
+  malformed value still reads as undeclared, pinned by a conformance fixture.
+
+### Fixed
+
+- **Bridge parity** (#161). The three MCP bridges exposed different unit metadata — the
+  Java bridge emitted neither `kind` nor `action_scope`, so a client could not tell a
+  governed procedure from a document. Not an enaction path (bridges expose a fixed tool
+  set and units as readable resources), but it handed back a manifest with the governance
+  filed off. All four of `kind`, `action_scope`, `load_eligible` and `steps` now cross all
+  three.
+
+- **Parser artifact versions** (#163). Three artifacts sat at `0.1.0`, `0.1.0` and
+  `0.21.0` while the spec reached 0.30, and `bridge/java` depended on `kcp-parser:0.1.0` —
+  the only version that had ever existed — so a bridge could not express "I need a parser
+  that knows `action_scope`". All three now track the spec, and the consistency guard
+  gained five assertions so they cannot drift again.
+
+
+---
+
 ## [0.30.0] — 2026-07-28 — Eligibility grants
 
 Implements **RFC-0028**, promoted to SPEC.md §4.3c. Playbooks were shipped in 0.29 with

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.30.0</version>
+    <version>0.30.1</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.30.0"
+version = "0.30.1"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Developer CLI for the Knowledge Context Protocol \u2014 init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.30.0
+    `\nKCP Developer CLI — v0.30.1
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.30.0";
+export const RENDERER_VERSION = "kcp-cli 0.30.1";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 


### PR DESCRIPTION
A **patch**. No spec surface changes — `SPEC.md` stays at 0.30, the schema is untouched, no manifest changes meaning. Parser artifact versions stay at 0.30.0; the consistency guard compares on the **minor**, so a package patch does not require moving them.

## `parse_diagnostics` (#166) — resolves RFC-0028 OQ4

A correct grant, a malformed value, and a misspelled field were indistinguishable:

```
load_eligible: true    → ✓ Valid — no errors or warnings
load_eligible: ture    → ✓ Valid — no errors or warnings
laod_eligible: true    → ✓ Valid — no errors or warnings
```

Only the first granted anything. Both causes live at the **parse boundary** — §2.1 drops a non-boolean, §2 discards an unknown field — so neither was visible to a validator.

Forward compatibility preserved and verified: only keys within two edits of a known field are reported, so a genuinely future field stays silent. Diagnostics never rescue.

## Bridge parity (#161)

The Java bridge emitted neither `kind` nor `action_scope` — an MCP client could not tell a governed procedure from a document. All four governance fields now cross all three bridges.

## Parser artifact versions (#163)

Three artifacts at `0.1.0`, `0.1.0` and `0.21.0` while the spec reached 0.30, with `bridge/java` depending on the only version that had ever existed. Now tracked, with five new guard assertions.

**188 TS tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)