### PR TITLE
docs: bring the guide, README and site current with v0.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ units:
 
 **Five minutes to Level 1.** See [adopting KCP in existing projects](./guides/adopting-kcp-in-existing-projects.md).
 
+**Current version: 0.30** — adds `load_eligible` (§4.3c), the eligibility grant, and the rule that eligibility does not compose. See the [changelog](./CHANGELOG.md).
+
 **New here?** Start with [the KCP universe](./guides/start-here-the-kcp-universe.md) — the
 three kinds of unit, the tooling around the spec, and how the RFC process works.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2175,7 +2175,7 @@ relationships:
       <div class="section-header reveal">
         <span class="section-label">Roadmap</span>
         <h2>Where KCP is headed</h2>
-        <p>v0.25 is the current release. Fields are promoted from RFC proposals to core as they accumulate real-world validation. Remaining RFCs are open for community feedback through 2026.</p>
+        <p>v0.30 is the current release. Fields are promoted from RFC proposals to core as they accumulate real-world validation. Remaining RFCs are open for community feedback through 2026.</p>
       </div>
 
       <div class="roadmap-core reveal">
@@ -2468,7 +2468,7 @@ relationships:
 
       <div class="roadmap-core reveal">
         <div class="roadmap-core__info">
-          <span class="roadmap-core__badge">v0.25 — Current</span>
+          <span class="roadmap-core__badge">v0.25 — Shipped</span>
           <h3>Economic Metadata</h3>
           <p>An agent should know what access costs and how much it can consume <em>before</em> it issues a request. <code>payment.methods[]</code> declares accepted mechanisms in publisher-preference order — <code>free</code>, <code>x402</code> stablecoin micropayments (currency, per-request price, settlement networks, wallet), <code>meter</code>, and <code>subscription</code> — and <code>rate_limits</code> discloses per-tier budgets (<code>default</code>/<code>authenticated</code>/<code>premium</code>), token limits, and a backoff strategy. The agent picks a method it supports and budgets up front. Advisory — KCP declares the economics and settles nothing. Promoted from RFC-0005.</p>
         </div>
@@ -2477,6 +2477,62 @@ relationships:
           <span class="roadmap-field-pill">x402</span>
           <span class="roadmap-field-pill">rate_limits tiers</span>
           <span class="roadmap-field-pill">RFC-0005</span>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">v0.26 &mdash; Shipped</span>
+            <h3>Governed Procedures</h3>
+            <p>The first kind that <em>acts</em>. A <code>kind: skill</code> unit is a procedure an agent may enact, not prose it may read &mdash; and it carries an <code>action_scope</code> bounding the tools, paths and capabilities it may touch. Skills <strong>fail closed</strong>: absent an explicit grant, a skill renders as a pointer an agent may read but not run. Also ships <code>serving</code> (&sect;3.12) and unit aliases. Promoted from RFC-0024 and RFC-0023.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">kind: skill</span>
+            <span class="roadmap-field-pill">action_scope</span>
+            <span class="roadmap-field-pill">serving</span>
+            <span class="roadmap-field-pill">RFC-0024</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">v0.27 / v0.28 &mdash; Shipped</span>
+            <h3>Authority and Escalation</h3>
+            <p>An ordinal ladder &mdash; <code>observe &rarr; explain &rarr; suggest &rarr; prepare &rarr; commit</code> &mdash; with <code>grant_ceiling</code> resolved as a <strong>minimum across sources</strong>, never a maximum. v0.28 adds escalation: an agent needing authority it does not hold raises a grant request rather than proceeding, and <code>grant_request_events</code> records every transition, so &ldquo;how long was this pending&rdquo; and &ldquo;was it denied before it was granted&rdquo; are answerable. Promoted from RFC-0025 and RFC-0026.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">authority_level</span>
+            <span class="roadmap-field-pill">grant_ceiling</span>
+            <span class="roadmap-field-pill">escalation</span>
+            <span class="roadmap-field-pill">RFC-0025/0026</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">v0.29 &mdash; Shipped</span>
+            <h3>Playbooks</h3>
+            <p>A promotion procedure reads state, proposes a change, waits for a human, then commits &mdash; four phases, four different risks. A single skill declares <em>one</em> authority level for all of them, so an author either over-grants the reading steps or blocks the committing one. <code>kind: playbook</code> makes the <strong>step</strong> the unit of governance. A step's <code>uses</code> names another unit rather than describing it in prose, so a checker can resolve the reference &mdash; and effective authority is the minimum across five sources, so a playbook can never <em>raise</em> authority. Promoted from RFC-0027.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">kind: playbook</span>
+            <span class="roadmap-field-pill">steps[].uses</span>
+            <span class="roadmap-field-pill">per-step ceilings</span>
+            <span class="roadmap-field-pill">RFC-0027</span>
+          </div>
+        </div>
+
+        <div class="roadmap-core reveal">
+          <div class="roadmap-core__info">
+            <span class="roadmap-core__badge">v0.30 &mdash; Current</span>
+            <h3>Eligibility Grants</h3>
+            <p>The grant that decides whether a governed procedure may act at all. &sect;16.3 C4 had required &ldquo;an explicit eligibility grant&rdquo; since v0.18 without ever saying what an author writes; <code>load_eligible</code> now specifies it, and absent means <strong>not</strong> eligible. Critically, <strong>eligibility does not compose</strong>: a grant on a playbook does not reach the units its steps name. Otherwise one grant on a composition would make any skill in the manifest reachable by naming it in a step &mdash; including one deliberately withheld. Promoted from RFC-0028.</p>
+          </div>
+          <div class="roadmap-core__fields">
+            <span class="roadmap-field-pill">load_eligible</span>
+            <span class="roadmap-field-pill">does not compose</span>
+            <span class="roadmap-field-pill">&sect;4.3c</span>
+            <span class="roadmap-field-pill">RFC-0028</span>
+          </div>
         </div>
       </div>
 

--- a/guides/start-here-the-kcp-universe.md
+++ b/guides/start-here-the-kcp-universe.md
@@ -5,7 +5,7 @@ matter, the tools around it, and how the RFC process actually works.
 
 **Time:** ~15 minutes reading, ~10 running the example. **Prerequisites:** Node 20+.
 
-Every command below was run against `@cantara.no/kcp@0.29` and shows its real output.
+Every command below was run against `@cantara.no/kcp@0.30` and shows its real output.
 
 ---
 
@@ -33,6 +33,9 @@ and three carry the weight for most authors. They form a progression.
 | `knowledge` | *What is true?* | reads it |
 | `skill` | *How do I do this one thing?* | enacts it, bounded by an `action_scope` |
 | `playbook` | *How do we do this whole thing?* | enacts it **step by step**, each with its own ceiling |
+
+Both `skill` and `playbook` also need an explicit **grant** — `load_eligible: true` — before
+anything may enact them. Absent means no.
 
 The default is `knowledge`, and most units are that. The other two are newer — `skill`
 arrived in v0.26, `playbook` in v0.29 — and they are where the governance lives.
@@ -63,8 +66,8 @@ Nothing here can act. An agent selects it by intent and reads it.
 ```
 
 Two things changed. `action_scope` bounds what the procedure may touch — a firewall rule,
-not a description. And **a skill fails closed**: absent an explicit eligibility grant it
-renders as a pointer an agent may read but not run.
+not a description. And **a skill fails closed**: `load_eligible` is the grant (§4.3c), and
+absent means *not* eligible — the unit renders as a pointer an agent may read but not run.
 
 That default is the point. A procedure that acts should require someone to have said yes.
 
@@ -111,6 +114,31 @@ Three rules worth knowing before you write one ([§4.3b]):
 - **`on_failure: continue` continues the run, not the dependents.** A step is never
   enacted unless everything it depends on succeeded.
 
+### Eligibility does not compose
+
+One rule catches people out, and it is worth knowing before you write a playbook.
+
+**A grant on a playbook does not reach the units its steps name.** Both the playbook and
+every unit its steps `uses` must carry their own `load_eligible: true`:
+
+```yaml
+- id: cut-release
+  kind: playbook
+  load_eligible: true        # grants the composition...
+  steps:
+    - id: verify
+      uses: run-tests        # ...but run-tests needs its own grant too
+```
+
+Without that, `load_eligible: true` on a playbook would be a **universal grant** — any
+unit in the manifest becomes reachable by naming it in a step, including one someone
+deliberately withheld. `kcp validate` reports it, and the planner refuses to offer such a
+playbook at all.
+
+The cost is real and worth knowing: a skill cannot currently be "enactable only within an
+approved playbook". Granting it for playbook use also makes it independently invocable.
+Scoped grants are an open question (RFC-0028 OQ1).
+
 ### Which one am I writing?
 
 > If your steps all sit inside one procedure's `action_scope`, they are prose, and you
@@ -133,7 +161,7 @@ echo "# Cut release"     > playbooks/cut-release.md
 Write `knowledge.yaml` with the three units from §2 plus a `publish-package` skill, then:
 
 ```bash
-npx @cantara.no/kcp@0.29 validate knowledge.yaml
+npx @cantara.no/kcp@0.30 validate knowledge.yaml
 ```
 
 ```
@@ -180,7 +208,7 @@ that consumes it.
 
 | | What it is | Install |
 |---|---|---|
-| [`kcp`][cli] | The CLI: `init`, `validate`, `sign`, `render`, `query` | `npx @cantara.no/kcp@0.29` |
+| [`kcp`][cli] | The CLI: `init`, `validate`, `sign`, `render`, `query` | `npx @cantara.no/kcp@0.30` |
 | [kcp-agent] | A deterministic planner — given a task, decides which units an agent may load, through a 14-gate cascade. No LLM. | `npm i kcp-agent` |
 | [kcp-harness] | An MCP compliance proxy between an agent and its tools. Fail-closed: what it cannot verify, the agent does not get. | `npm i kcp-harness` |
 


### PR DESCRIPTION
The code reached 0.30; the documentation did not.

## The newcomer guide was the worst of it

It is the designated entry point, and it still told readers to run `@cantara.no/kcp@0.29`. Worse, it showed `load_eligible: true` in its skill example **without ever explaining what the field is** — it was written the morning before §4.3c specified it.

Now it says the grant is `load_eligible`, that absent means **not** eligible, and carries the rule most likely to catch a playbook author out:

> **A grant on a playbook does not reach the units its steps name.** Both need their own.

Without that, one grant on a composition would make any unit in the manifest reachable by naming it in a step — including one someone deliberately withheld. The cost is stated too: a skill cannot currently be "enactable only within an approved playbook" (RFC-0028 OQ1).

Every command and error message was **re-run against the built CLI at 0.30**, including both deliberate breakages — the dangling `uses` and the `depends_on` cycle still produce the messages the guide quotes.

## The public site was five releases behind

`docs/index.html` mentioned `playbook` **zero times**, and its roadmap read "v0.25 — Current" while the spec was at 0.30. It gains cards for:

| | |
|---|---|
| v0.26 | Governed procedures — `kind: skill`, `action_scope`, fail-closed |
| v0.27 / v0.28 | Authority ladder and escalation |
| v0.29 | Playbooks — the step as the unit of governance |
| v0.30 | Eligibility grants — and that they do not compose |

## README

Gains a version banner, which it had none of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)