### PR TITLE
chore(release): v0.30.2 — documentation current at v0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.30.2] — 2026-07-28 — Documentation current at v0.30
+
+A documentation release. No spec surface changes: `SPEC.md` stays at 0.30, the schema and
+all three parsers are untouched, and no manifest changes meaning.
+
+The code reached 0.30 across the fleet before the documentation did — this closes that.
+
+### Changed
+
+- **[The newcomer guide](./guides/start-here-the-kcp-universe.md)** was the worst of it,
+  being the designated entry point. It told readers to run `@cantara.no/kcp@0.29`, and it
+  showed `load_eligible: true` in its skill example **without explaining what the field
+  is** — it was written the morning before §4.3c specified it.
+
+  It now names the grant, states that absent means *not* eligible, and carries the rule
+  most likely to catch a playbook author out: **eligibility does not compose.** A grant on
+  a playbook does not reach the units its steps name, so both need their own; otherwise
+  one grant on a composition would make any unit in the manifest reachable by naming it in
+  a step, including one someone deliberately withheld. The cost is stated too — a skill
+  cannot currently be "enactable only within an approved playbook" (RFC-0028 OQ1).
+
+  Every command and error message was re-run against the built CLI at 0.30, including both
+  deliberate breakages.
+
+- **The public site** mentioned `playbook` zero times and its roadmap read
+  "v0.25 — Current" while the spec was at 0.30. It gains cards for v0.26 (governed
+  procedures), v0.27/0.28 (authority and escalation), v0.29 (playbooks) and v0.30
+  (eligibility grants).
+
+- **README** gains a version banner, which it had none of.
+
+### Elsewhere in the ecosystem
+
+Not part of this package, but shipped alongside it:
+
+- **[kcp-playground](https://github.com/Cantara/kcp-playground)** gains **station 12, The
+  Composition Escape** — the in-browser demonstration of §4.3c. It demonstrated nothing
+  from the last two spec releases before this. All three of its presets were checked
+  against kcp-agent 0.21.0's real planner rather than assumed faithful.
+- **kcp-agent 0.21.0** stopped the planner offering compositions the v0.30 validator
+  rejects.
+- All eight `kcp-*` and `pi-kcp` manifests now declare `kcp_version: "0.30"` and validate
+  clean.
+
+
+---
+
 ## [0.30.1] — 2026-07-28 — Diagnostics and parity
 
 No spec surface changes; `SPEC.md` stays at 0.30 and no manifest changes meaning.

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.30.1</version>
+    <version>0.30.2</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.30.1"
+version = "0.30.2"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Developer CLI for the Knowledge Context Protocol \u2014 init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.30.1
+    `\nKCP Developer CLI — v0.30.2
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.30.1";
+export const RENDERER_VERSION = "kcp-cli 0.30.2";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 


### PR DESCRIPTION
A **documentation release**. No spec surface changes — `SPEC.md` stays at 0.30, the schema and all three parsers are untouched, no manifest changes meaning.

**Deliberately not 0.31.** A minor implies spec content, and the diff against `SPEC.md`, `schema/` and the parsers is empty.

The code reached 0.30 across the fleet before the documentation did. This closes that, and ships alongside **kcp-playground station 12** — the in-browser demonstration of §4.3c, whose presets were checked against kcp-agent 0.21.0's real planner.

188 TS tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)