### PR TITLE
fix: bump the spec repo's own manifest to 0.30 and gate it against drift

### DIFF
--- a/cli/src/consistency.test.ts
+++ b/cli/src/consistency.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from "vitest";
 import { lstatSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { SCAFFOLD_KCP_VERSION } from "./init.js";
+import { load as parseYaml } from "js-yaml";
+import { computeContentDigest } from "./validator.js";
 
 const REPO = resolve(process.cwd(), "..");
 const r = (p: string) => resolve(REPO, p);
@@ -81,6 +83,35 @@ describe("version-drift guard", () => {
 
   it("cli/package.json version matches the SPEC.md minor", () => {
     expect(cliPkgVersion.startsWith(specMinor + "."), `cli ${cliPkgVersion} vs SPEC ${specMinor}`).toBe(true);
+  });
+
+  // This repository publishes a manifest describing its own spec and RFCs, and it is the
+  // one manifest nobody thinks to re-run the fleet bump against. It sat at 0.26 through
+  // four releases while every consumer repo tracked 0.30 — the spec was the least current
+  // artifact in its own ecosystem, and nothing failed to say so.
+  const ownManifest = (() => {
+    const text = readFileSync(r("knowledge.yaml"), "utf8");
+    return { text, doc: parseYaml(text) as any };
+  })();
+
+  it("the repo's own knowledge.yaml declares the current SPEC minor", () => {
+    expect(
+      String(ownManifest.doc.kcp_version),
+      `knowledge.yaml declares ${ownManifest.doc.kcp_version}, SPEC.md is ${specMinor}`,
+    ).toBe(specMinor);
+  });
+
+  // Editing SPEC.md without refreshing its digest leaves a manifest that fails its own
+  // `kcp validate`. Both digests here were stale for exactly that reason.
+  it("every declared content_hash matches the content on disk", () => {
+    const stale: string[] = [];
+    for (const unit of ownManifest.doc.units ?? []) {
+      const declared = unit?.content_hash?.value;
+      if (!declared) continue;
+      const actual = computeContentDigest(r(unit.path), unit.content_hash.algorithm ?? "sha256");
+      if (actual && actual !== declared) stale.push(`${unit.id} (${unit.path})`);
+    }
+    expect(stale, `stale digests — run kcp sign --update-hashes: ${stale.join(", ")}`).toEqual([]);
   });
 
   it("RENDERER_VERSION matches the cli package version", () => {

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -32,7 +32,7 @@ signing:
   signature: https://cantara.github.io/knowledge-context-protocol/knowledge.yaml.sig
 
 # Legacy header fields (preserved for consumers that read them directly)
-kcp_version: "0.26"
+kcp_version: "0.30"
 project: knowledge-context-protocol
 spec_version: 0.21.0
 updated: "2026-06-13"
@@ -59,7 +59,7 @@ units:
     triggers: [ spec, specification, fields, validation, conformance, yaml, format ]
     content_hash:
       algorithm: sha256
-      value: 25a6cf98687ee4fca5c11ab9e495d893308c33208f851cc8adb4deb727f39837
+      value: c85b51b6daa37918ab074c14cda74e3f5b053e274650189e059c486a9a78e2ea
 
   - id: proposal
     path: PROPOSAL.md
@@ -369,7 +369,7 @@ units:
       ]
     content_hash:
       algorithm: sha256
-      value: b8008e278fd33f1bc5fc03567329e1eced6464bcab6413e7dd61e11fe777185d
+      value: 9dbc939eacdacbfeed46c671c823287354bd0b00ae782a0bc03752bca082ab76
 
   - id: rfc-0015
     path: RFC-0015-Negative-Space-Declarations.md


### PR DESCRIPTION
Closes the dogfooding gap found in the fleet status sweep: the spec repo was the least current artifact in its own ecosystem.

## What was wrong

| | |
|---|---|
| declared | `kcp_version: "0.26"` |
| spec | 0.30 (four releases on) |
| `kcp validate` | **fails** — `spec` and `rfc-0017` digests stale |
| every other repo | 0.30, validating clean |

## The gate

Two assertions added to the `version-drift guard` block:

- the repo's own `knowledge.yaml` declares the current SPEC.md minor
- every declared `content_hash` matches content on disk

Per `verify-the-gate-not-the-code`, both were run against the **actual** broken manifest first:

```
1. the repo's own knowledge.yaml declares the current SPEC minor
   AssertionError: knowledge.yaml declares 0.26, SPEC.md is 0.30
2. every declared content_hash matches the content on disk
   AssertionError: stale digests: spec (SPEC.md), rfc-0017 (RFC-0017-Observability-Hooks.md)
```

The digest guard is the one with ongoing value — editing the spec without re-digesting is the normal way to author a release, and until now nothing objected.

## Verification

- `190 passed (190)`, 9 files
- `kcp validate knowledge.yaml` → `✓ Valid — no errors or warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)