### PR TITLE
fix(bridge/python): pin mcp below 2.0 — the unbounded floor broke CI

### DIFF
--- a/bridge/python/kcp_mcp/server.py
+++ b/bridge/python/kcp_mcp/server.py
@@ -10,7 +10,10 @@ from datetime import timezone as _timezone
 from pathlib import Path
 
 from mcp.server import Server
-from mcp.server.lowlevel.server import ReadResourceContents
+# helper_types, not server: mcp 2.0.0 dropped the re-export from
+# mcp.server.lowlevel.server. helper_types has carried the class in both 1.x and 2.x,
+# so this import works across the major.
+from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.types import (
     Annotations,
     GetPromptResult,

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -12,7 +12,11 @@ license = {text = "Apache-2.0"}
 keywords = ["kcp", "mcp", "knowledge", "ai-agents"]
 dependencies = [
     "kcp>=0.30.0",
-    "mcp>=1.0.0",
+    # Bounded below 2.0: mcp 2.0.0 replaced the Server handler-registration API
+    # (Server.list_resources and friends), which fails 103 of this bridge's 170 tests.
+    # The unbounded ">=1.0.0" let that major in silently and broke CI. Lifting the bound
+    # is a migration, tracked separately.
+    "mcp>=1.0.0,<2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`main` is about to go red. The Python bridge declared `"mcp>=1.0.0"` with **no upper bound**, mcp 2.0.0 was published, and every `python-bridge-tests` job (3.10–3.13) now fails at collection:

```
ImportError: cannot import name 'ReadResourceContents'
             from 'mcp.server.lowlevel.server'
```

This surfaced on #174 (a `better-sqlite3` patch), which has nothing to do with it. `main` looks green only because it hasn't run since yesterday.

## That import is not the real problem

Moving it to `helper_types` — where the class lives in **both** 1.x and 2.x — unblocks collection and reveals the actual damage:

| mcp | Result |
|---|---|
| 1.29.0 | **170 passed** |
| 2.0.0 | **103 failed**, 67 passed |

**102 of the 103** are `AttributeError: 'Server' object has no attribute 'list_resources'`. mcp 2.0.0 replaced the handler-registration API this bridge is built on. Supporting it is a migration, not a fix.

So: pinned `<2` to restore CI. Verified the pin bites — installing into an env that already had 2.0.0 resolves it back to 1.29.0.

The import move is kept regardless: `helper_types` is the stable location across both majors and where the class has always been defined.

## Worth noting

This is the **second** MCP-SDK major to break a bridge in this repo. `renovate.json` already caps the TypeScript SDK at `<1.26.0` for the same class of reason:

> SDK >=1.26 (hono transport rewrite) breaks kcp-mcp's reused stateless StreamableHTTPServerTransport

The Python side had no equivalent bound. It does now.

I'll open a follow-up issue for the mcp 2.x migration with these numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)