### PR TITLE
chore(release): v0.30.3 — CI repair and dependency currency

### DIFF
--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.30.2</version>
+    <version>0.30.3</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.30.2"
+version = "0.30.3"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.30.2",
+      "version": "0.30.3",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^13.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.30.2
+    `\nKCP Developer CLI — v0.30.3
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.30.2";
+export const RENDERER_VERSION = "kcp-cli 0.30.3";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 


### PR DESCRIPTION
**Patch.** `SPEC.md` is unchanged since v0.30.2 — nothing in the protocol moved.

| PR | What |
|---|---|
| **#175** | Python bridge pinned `mcp<2` — the unbounded floor broke every `python-bridge-tests` job |
| #172 | The spec repo's own manifest was four releases behind its own spec and failed `kcp validate` |
| #173 | better-sqlite3 v13, TypeScript v7, sqlite-jdbc, setup-python v7 |
| #174 | better-sqlite3 v13.0.2 |

#175 is the one that mattered. `mcp 2.0.0` was published and CI picked it up unbounded; `main` looked green only because it hadn't run since the day before. Pinned after measuring what 2.x actually costs — **103 of 170 tests fail**, 102 with the same `AttributeError`, because the `Server` handler-registration API the bridge is built on was replaced. Migration tracked in #176.

Version stamps moved together across all six sites: `cli/package.json`, the CLI help banner, `RENDERER_VERSION`, and the three bridge manifests (python/java/typescript).

```
190 tests pass · kcp validate knowledge.yaml → ✓ Valid
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)