### PR TITLE
chore: stop Renovate re-raising mcp v2 until the bridge is migrated

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,17 @@
   "packageRules": [
     {
       "description": "SDK >=1.26 (hono transport rewrite) breaks kcp-mcp's reused stateless StreamableHTTPServerTransport: every HTTP request after initialize returns an empty 500. Pinned in PR #128. Lift once cli.ts adopts the per-request transport pattern (issue #131).",
-      "matchPackageNames": ["@modelcontextprotocol/sdk"],
+      "matchPackageNames": [
+        "@modelcontextprotocol/sdk"
+      ],
       "allowedVersions": "<1.26.0"
+    },
+    {
+      "description": "mcp 2.0.0 replaced the Server handler-registration API the Python bridge is built on: 103 of its 170 tests fail on it, 102 with AttributeError on Server.list_resources. Pinned in PR #175 after the unbounded '>=1.0.0' let the major in and broke every python-bridge-tests job. Lift once the bridge is migrated (issue #176).",
+      "matchPackageNames": [
+        "mcp"
+      ],
+      "allowedVersions": "<2.0.0"
     }
   ]
 }


### PR DESCRIPTION
#177 proposed the exact upgrade #175 pinned against, and it fails — **103 of 170** Python bridge tests, 102 with `AttributeError: 'Server' object has no attribute 'list_resources'`.

Renovate will keep raising it every cycle. A permanently-red dependency PR trains people to ignore the queue, which is worse than the pin.

Capped at `<2.0.0` with the reason and the tracking issue (#176) written into the rule — matching how `@modelcontextprotocol/sdk` is already handled in this file for the same class of breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)