### PR TITLE
Declare the four protocol skills as governed procedures

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1312,6 +1312,7 @@
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
       "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -983,6 +983,87 @@ units:
     validated: "2026-02-25"
     triggers: [ license, apache, open source, terms ]
 
+  # The procedural plane (§4.3a, RFC-0028). The repository that defines governed
+  # procedures shipped four of them undeclared, so the planner called each one "not a
+  # governed procedure" — and any repo federating this manifest received none.
+  #
+  # These four are the portable core: adopt a manifest, author units, navigate by intent,
+  # and render untrusted input safely. They are the ones worth carrying into every
+  # consuming repo.
+  #
+  # Tool names are Claude Code's, the runtime that adjudicates these skills. A tool
+  # vocabulary only means anything to whoever enforces it.
+
+  - id: skill-kcp-adopt
+    path: skills/kcp-adopt/SKILL.md
+    kind: skill
+    intent: "How does an agent add a knowledge.yaml to a codebase or docs set so agents navigate by intent instead of exploring blindly?"
+    scope: global
+    audience: [ agent ]
+    validated: "2026-07-30"
+    triggers: [ adopt, add kcp, knowledge.yaml, onboard, init, greenfield ]
+    load_eligible: true
+    action_scope:
+      tools: [ Bash, Read, Write ]
+      paths: [ "knowledge.yaml" ]
+      capabilities: [ "kcp.adopt", "kcp.validate" ]
+    content_hash:
+      algorithm: sha256
+      value: 0b2b1554de7525323c52958e9ab6d32c085352f4d2cf585c91ec018a7afce5cb
+
+  - id: skill-kcp-author
+    path: skills/kcp-author/SKILL.md
+    kind: skill
+    intent: "How does an agent write or improve manifest units — intents, triggers, relationships, audience, not_for, temporal validity — and validate the result?"
+    scope: global
+    audience: [ agent ]
+    validated: "2026-07-30"
+    triggers: [ author, improve, intent, triggers, not_for, temporal, unit ]
+    load_eligible: true
+    action_scope:
+      tools: [ Bash, Read, Edit, Write ]
+      paths: [ "knowledge.yaml" ]
+      capabilities: [ "kcp.author", "kcp.validate" ]
+    content_hash:
+      algorithm: sha256
+      value: b6ec6b67f5aa515395d435ddc6b9d4628d48998a980c26bdd5229d4ec23b466a
+
+  - id: skill-kcp-navigate
+    path: skills/kcp-navigate/SKILL.md
+    kind: skill
+    intent: "How does an agent use an existing knowledge.yaml to load only what a task needs, instead of exploring a repository blind?"
+    scope: global
+    audience: [ agent ]
+    validated: "2026-07-30"
+    triggers: [ navigate, plan, load, relevant, find knowledge, explore ]
+    load_eligible: true
+    action_scope:
+      # Navigation reads and plans. It never edits the manifest it is navigating.
+      tools: [ Bash, Read ]
+      capabilities: [ "kcp.navigate" ]
+    content_hash:
+      algorithm: sha256
+      value: bcf766c00ed27596d95abdd3c1c0336cffe14b8c4bee993c8287f1b18288a957
+
+  - id: skill-kcp-render
+    path: skills/kcp-render/SKILL.md
+    kind: skill
+    intent: "How does an agent safely ingest a third-party or untrusted knowledge.yaml, running the trusted render pipeline before any of its content reaches the model?"
+    scope: global
+    audience: [ agent ]
+    validated: "2026-07-30"
+    triggers: [ render, untrusted, third-party, ingest, sanitize, foreign manifest ]
+    load_eligible: true
+    action_scope:
+      # The trust boundary: this skill exists precisely because the input is untrusted.
+      # It renders through the trusted pipeline and never grants write access — a
+      # sanitiser that can edit is not a sanitiser.
+      tools: [ Bash, Read ]
+      capabilities: [ "kcp.render", "kcp.ingest-untrusted" ]
+    content_hash:
+      algorithm: sha256
+      value: bbf038b09f2ce04d54376fc7d72cdc9961ff21bd400e9ae0f2b379e128d39a21
+
 relationships:
   # The spec is the foundation everything builds on
   - from: spec


### PR DESCRIPTION
The repository that defines governed procedures shipped four of them undeclared.

`kcp-adopt`, `kcp-author`, `kcp-navigate` and `kcp-render` existed as `SKILL.md` files with no
manifest units. The planner called each one **"not a governed procedure"** — correctly — and any
repo federating this manifest received none of them.

## What changed

All four now carry `kind: skill`, an explicit `load_eligible` grant, an `action_scope`, and a
`content_hash`.

Verified against the real planner:

```
skill-kcp-adopt        selected  kind: skill with explicit eligibility grant
skill-kcp-author       skipped   kind: skill with explicit eligibility grant
skill-kcp-navigate     skipped   kind: skill with explicit eligibility grant
skill-kcp-render       selected  kind: skill with explicit eligibility grant
```

(The two `skipped` are budget/max-units decisions, not eligibility — the grant is confirmed in
the gate detail either way.)

`kcp-agent validate` → `ok: true, findings: []`. The repo's own 34 consistency gates pass,
including the #172 drift guards.

## Scopes

Drawn from what each skill does, not from what the repo can do:

| Skill | Tools | Why |
|---|---|---|
| `kcp-navigate` | Bash, Read | navigates and plans; never edits what it reads |
| `kcp-render` | Bash, Read | the trust boundary — a sanitiser that can write is not a sanitiser |
| `kcp-adopt` | Bash, Read, Write | creates the manifest |
| `kcp-author` | Bash, Read, Edit, Write | improves units in place |

## Why these four, and why here first

They are the **portable core** — adopt, author, navigate, render safely. Useful in every
consuming repo, not only this one. Declaring them here is the prerequisite for carrying them
outward.

## A note for anyone copying the pattern

Tool names here are Claude Code's, because that is the runtime that adjudicates these skills.
kcp-agent's own `navigator-skill` declares `shell.exec` and is right to. A tool vocabulary only
means something to whoever enforces it — copying one runtime's vocabulary into another's manifest
produces a scope that matches nothing and blocks everything.

## Related

- Refs #180 — the published copy at `docs/knowledge.yaml` is still at `kcp_version: 0.21` and
  will not carry these skills until it is refreshed. Federation consumers read that copy, not
  this one.
- Part of #28's procedural-plane work. `pi-kcp` (3 skills) and `kcp-triage` (9) are already
  governed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
