### PR TITLE
Populate the v0.27 authority model on our own manifest

### DIFF
--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -33,6 +33,16 @@ signing:
 
 # Legacy header fields (preserved for consumers that read them directly)
 kcp_version: "0.30"
+
+# §3.13 (v0.27): the fixed ordinal authority scale. Declaring it makes every
+# authority_level below a ceiling on this total order — and leaves the planner
+# something to adjudicate rather than a vocabulary nobody populated.
+authority_level_scale:
+  - observe
+  - explain
+  - suggest
+  - prepare
+  - commit
 project: knowledge-context-protocol
 spec_version: 0.21.0
 updated: "2026-06-13"
@@ -1003,6 +1013,8 @@ units:
     validated: "2026-07-30"
     triggers: [ adopt, add kcp, knowledge.yaml, onboard, init, greenfield ]
     load_eligible: true
+    # creates a manifest for a human (or PR gate) to commit
+    authority_level: prepare
     action_scope:
       tools: [ Bash, Read, Write ]
       paths: [ "knowledge.yaml" ]
@@ -1020,6 +1032,8 @@ units:
     validated: "2026-07-30"
     triggers: [ author, improve, intent, triggers, not_for, temporal, unit ]
     load_eligible: true
+    # improves units in place; the commit belongs to review
+    authority_level: prepare
     action_scope:
       tools: [ Bash, Read, Edit, Write ]
       paths: [ "knowledge.yaml" ]
@@ -1037,6 +1051,8 @@ units:
     validated: "2026-07-30"
     triggers: [ navigate, plan, load, relevant, find knowledge, explore ]
     load_eligible: true
+    # navigation reads and plans; it never edits what it reads
+    authority_level: explain
     action_scope:
       # Navigation reads and plans. It never edits the manifest it is navigating.
       tools: [ Bash, Read ]
@@ -1054,6 +1070,8 @@ units:
     validated: "2026-07-30"
     triggers: [ render, untrusted, third-party, ingest, sanitize, foreign manifest ]
     load_eligible: true
+    # the untrusted-input boundary analyzes; a sanitiser that could act on its input would not be a sanitiser
+    authority_level: explain
     action_scope:
       # The trust boundary: this skill exists precisely because the input is untrusted.
       # It renders through the trusted pipeline and never grants write access — a

--- a/knowledge.yaml.sig
+++ b/knowledge.yaml.sig
@@ -2,5 +2,5 @@
   "key_id": "cantara-repos-2026",
   "algorithm": "EdDSA",
   "public_key": "MCowBQYDK2VwAyEAuipgusnqU9vjf3p2yPVLD/DmERT6tBbLOqEETdxAhMU=",
-  "signature": "FNSiHwGQvy8euXoOTFRKGsac9YXFCRQNIBwQLrOIWhkRS60lg14lo+nUqK1EGrmxR704PdY540oMfwcdtVY+Ag=="
+  "signature": "LWGs1f0EB7MClYFgd8x0vGVpH/BPQxJipdawVcxqJX1ZzJ8xMkdoaxfCGS4I9/iRwlwsxEBvdPZgdnkjnvPZDA=="
 }


### PR DESCRIPTION
The fleet audit found `authority_level_scale`, `authority_level`, `grant_ceiling`, `agents` and `task_types` shipped, specced, and used by **nobody — including this repo**. An unpopulated authority scale in a governance protocol was the most quotable gap on the list.

Root now declares the fixed §3.13 scale; each governed skill carries a ceiling derived from what it does:

| Skill | Ceiling | Because |
|---|---|---|
| kcp-navigate | `explain` | reads and plans; never edits what it reads |
| kcp-render | `explain` | a sanitiser that could act on its input would not be a sanitiser |
| kcp-adopt | `prepare` | creates a manifest for review to commit |
| kcp-author | `prepare` | improves units in place; the commit belongs to review |

Nothing claims `commit` — true of how the repo actually works (PR-only). 35 consistency gates green, `kcp-agent validate` ok, manifest re-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)