### PR TITLE
fix(bridge): surface v0.27 root authority model over MCP

### DIFF
--- a/bridge/typescript/src/mapper.ts
+++ b/bridge/typescript/src/mapper.ts
@@ -356,6 +356,19 @@ export function manifestToJson(
     ...(manifest.authority ? { authority: mapAuthority(manifest.authority) } : {}),
     ...(manifest.discovery ? { discovery: mapDiscovery(manifest.discovery) } : {}),
     ...(manifest.visibility ? { visibility: mapVisibility(manifest.visibility) } : {}),
+    // §3.13 (RFC-0025, v0.27): the root authority model. Parsed by parser.ts but
+    // previously dropped here, leaving the whole model invisible over MCP. Without
+    // the ordinal scale a consumer cannot even order two authority levels, and
+    // without grant_ceiling it cannot see the multi-source minimum that decides
+    // whether a governed procedure may act — so it would have to assume the more
+    // permissive reading. Emitted explicitly when declared; task_types/agents
+    // default to [] and are omitted when empty to keep the "declared none" signal.
+    ...(manifest.authority_level_scale
+      ? { authority_level_scale: manifest.authority_level_scale }
+      : {}),
+    ...(manifest.task_types.length > 0 ? { task_types: manifest.task_types } : {}),
+    ...(manifest.agents.length > 0 ? { agents: manifest.agents } : {}),
+    ...(manifest.grant_ceiling ? { grant_ceiling: manifest.grant_ceiling } : {}),
   };
   return JSON.stringify(payload, null, 2);
 }

--- a/bridge/typescript/src/server.ts
+++ b/bridge/typescript/src/server.ts
@@ -13,7 +13,7 @@ import {
   GetPromptRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { parseFile } from "./parser.js";
-import { validate } from "./validator.js";
+import { validate, computeGrantCeiling, applyAuthorityCap } from "./validator.js";
 import {
   toProjectSlug,
   buildUnitResource,
@@ -565,6 +565,31 @@ export function createKcpServer(
         required: [],
       },
     },
+    {
+      name: "resolve_grant_ceiling",
+      description:
+        "Resolve this manifest's effective authority ceiling (§3.13, RFC-0025): the MINIMUM " +
+        "authority_level across all grant_ceiling sources on the declared authority_level_scale, " +
+        "plus the source id(s) that bind it. Optionally supply an action (read | summarize | " +
+        "modify | share_externally | execute) and optionally a unit_id to also return that unit's " +
+        "declared permission capped by the effective level (the stricter of the two, never widened).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          action: {
+            type: "string",
+            description:
+              "Action to cap: read | summarize | modify | share_externally | execute. When given, the response includes the declared and capped permission.",
+          },
+          unit_id: {
+            type: "string",
+            description:
+              "Unit id whose declared authority permission the action is capped against. Defaults to the manifest-root authority when omitted.",
+          },
+        },
+        required: [],
+      },
+    },
   ];
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -886,6 +911,52 @@ export function createKcpServer(
               type: "text" as const,
               text: formatSyntaxBlock(found),
             },
+          ],
+        };
+      }
+
+      case "resolve_grant_ceiling": {
+        // §3.13 (RFC-0025): wire the pure computeGrantCeiling / applyAuthorityCap
+        // functions to the loaded manifest. The MIN across grant_ceiling sources on
+        // the declared scale is the effective ceiling; naming the binding source(s)
+        // gives the audit trail. Fail-closed: a source that resolves outside the
+        // scale, or an entity with no declared ceiling, is non-binding (absence is
+        // not a grant) — that is enforced inside computeGrantCeiling, not here.
+        const { effectiveLevel, bindingSourceIds } = computeGrantCeiling(manifest);
+        const response: Record<string, unknown> = {
+          effective_level: effectiveLevel ?? null,
+          binding_source_ids: bindingSourceIds,
+          authority_level_scale: manifest.authority_level_scale ?? [],
+        };
+
+        const action = args?.["action"] as string | undefined;
+        if (action !== undefined) {
+          const unitId = args?.["unit_id"] as string | undefined;
+          const source =
+            unitId !== undefined
+              ? manifest.units.find((u) => u.id === unitId)?.authority
+              : manifest.authority;
+          if (unitId !== undefined && !manifest.units.some((u) => u.id === unitId)) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ error: "unknown_unit", message: `No unit with id '${unitId}'` }),
+                },
+              ],
+              isError: true,
+            };
+          }
+          const declared = source?.[action];
+          response["action"] = action;
+          response["unit_id"] = unitId ?? null;
+          response["declared"] = declared ?? null;
+          response["capped"] = applyAuthorityCap(declared, action, effectiveLevel) ?? null;
+        }
+
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(response, null, 2) },
           ],
         };
       }

--- a/bridge/typescript/tests/fixtures/authority/knowledge.yaml
+++ b/bridge/typescript/tests/fixtures/authority/knowledge.yaml
@@ -1,0 +1,47 @@
+kcp_version: "0.27"
+project: authority-example
+version: 1.0.0
+updated: "2026-07-30"
+language: en
+
+# RFC-0025 / §3.13 root authority model.
+authority_level_scale: [observe, explain, suggest, prepare, commit]
+
+task_types:
+  - id: change-status
+    intent: "Flip a compliance status flag"
+    authority_level: explain
+  - id: draft-report
+    intent: "Prepare a report for human review"
+    authority_level: prepare
+
+agents:
+  - id: lara
+    name: LARA
+    authority_level: prepare
+
+grant_ceiling:
+  mandatory_sources: [org-risk]
+  sources:
+    - id: org-risk
+      authority_level: prepare
+    - id: org-data
+      authority_level: suggest
+    - id: task-ceiling
+      task_type_ref: change-status
+    - id: agent-ceiling
+      agent_ref: lara
+
+units:
+  - id: status-writer
+    path: status-writer.md
+    intent: "How does the status writer procedure operate?"
+    scope: project
+    audience: [agent]
+    triggers: [status, writer]
+    authority:
+      read: initiative
+      summarize: initiative
+      modify: initiative
+      share_externally: initiative
+      execute: initiative

--- a/bridge/typescript/tests/fixtures/authority/status-writer.md
+++ b/bridge/typescript/tests/fixtures/authority/status-writer.md
@@ -1,0 +1,2 @@
+# How does the status writer procedure operate?
+Placeholder unit content for the authority fixture.

--- a/bridge/typescript/tests/mapper.test.ts
+++ b/bridge/typescript/tests/mapper.test.ts
@@ -458,6 +458,86 @@ describe("manifestToJson — authority, discovery, visibility in unit output", (
   });
 });
 
+describe("manifestToJson — root authority model (§3.13, RFC-0025 v0.27)", () => {
+  // The bridge PARSED authority_level_scale / task_types / agents / grant_ceiling
+  // (parser.ts §765, model.ts §386-389) but the mapper root projection omitted all
+  // four — so the entire root authority model was invisible over MCP. A consumer
+  // could not see the ordinal scale, the declared ceilings, or the multi-source
+  // minimum computation that governs whether a procedure may act. Built through
+  // parseDict so this covers parse -> map, not just map.
+  function authorityManifest() {
+    return parseDict({
+      project: "example",
+      version: "1.0.0",
+      kcp_version: "0.27",
+      authority_level_scale: ["observe", "explain", "suggest", "prepare", "commit"],
+      task_types: [
+        { id: "change-status", intent: "flip a status flag", authority_level: "explain" },
+      ],
+      agents: [{ id: "lara", name: "LARA", authority_level: "prepare" }],
+      grant_ceiling: {
+        sources: [
+          { id: "org-risk", authority_level: "prepare" },
+          { id: "task-ceiling", task_type_ref: "change-status" },
+          { id: "agent-ceiling", agent_ref: "lara" },
+        ],
+        mandatory_sources: ["org-risk"],
+      },
+      units: [{ id: "u", path: "f.md", intent: "i", scope: "global", audience: ["agent"] }],
+    });
+  }
+
+  it("includes authority_level_scale at manifest root", () => {
+    const json = JSON.parse(manifestToJson(authorityManifest(), "example"));
+    expect(json.authority_level_scale).toEqual([
+      "observe",
+      "explain",
+      "suggest",
+      "prepare",
+      "commit",
+    ]);
+  });
+
+  it("includes task_types at manifest root", () => {
+    const json = JSON.parse(manifestToJson(authorityManifest(), "example"));
+    expect(json.task_types).toHaveLength(1);
+    expect(json.task_types[0].id).toBe("change-status");
+    expect(json.task_types[0].authority_level).toBe("explain");
+  });
+
+  it("includes agents at manifest root", () => {
+    const json = JSON.parse(manifestToJson(authorityManifest(), "example"));
+    expect(json.agents).toHaveLength(1);
+    expect(json.agents[0].id).toBe("lara");
+    expect(json.agents[0].authority_level).toBe("prepare");
+  });
+
+  it("includes grant_ceiling (sources + mandatory_sources) at manifest root", () => {
+    const json = JSON.parse(manifestToJson(authorityManifest(), "example"));
+    expect(json.grant_ceiling).toBeDefined();
+    expect(json.grant_ceiling.sources).toHaveLength(3);
+    expect(json.grant_ceiling.sources.map((s: { id: string }) => s.id)).toEqual([
+      "org-risk",
+      "task-ceiling",
+      "agent-ceiling",
+    ]);
+    expect(json.grant_ceiling.mandatory_sources).toEqual(["org-risk"]);
+  });
+
+  it("omits root authority fields when the manifest declares none", () => {
+    const manifest = parseDict({
+      project: "example",
+      version: "1.0.0",
+      units: [{ id: "u", path: "f.md", intent: "i", scope: "global", audience: ["agent"] }],
+    });
+    const json = JSON.parse(manifestToJson(manifest, "example"));
+    expect(json.authority_level_scale).toBeUndefined();
+    expect(json.task_types).toBeUndefined();
+    expect(json.agents).toBeUndefined();
+    expect(json.grant_ceiling).toBeUndefined();
+  });
+});
+
 describe("manifestToJson — action_scope (§4.3a)", () => {
   // The bridge parsed action_scope but never surfaced it: mapper's entry builder
   // copied `kind` and skipped the envelope that gives `kind: skill` its meaning.

--- a/bridge/typescript/tests/tools.test.ts
+++ b/bridge/typescript/tests/tools.test.ts
@@ -11,6 +11,7 @@ const FULL_DIR = join(import.meta.dirname, "fixtures/full");
 const MINIMAL_DIR = join(import.meta.dirname, "fixtures/minimal");
 const COMMANDS_DIR = join(import.meta.dirname, "fixtures/commands");
 const FEDERATION_DIR = join(import.meta.dirname, "fixtures/federation");
+const AUTHORITY_DIR = join(import.meta.dirname, "fixtures/authority");
 
 async function connectClient(
   manifestPath: string,
@@ -39,16 +40,17 @@ async function connectClient(
 }
 
 describe("tools/list", () => {
-  it("lists all four tools", async () => {
+  it("lists all five tools", async () => {
     const client = await connectClient(join(FULL_DIR, "knowledge.yaml"));
     const { tools } = await client.listTools();
 
-    expect(tools).toHaveLength(4);
+    expect(tools).toHaveLength(5);
     const names = tools.map((t) => t.name);
     expect(names).toContain("search_knowledge");
     expect(names).toContain("get_unit");
     expect(names).toContain("get_command_syntax");
     expect(names).toContain("list_manifests");
+    expect(names).toContain("resolve_grant_ceiling");
     await client.close();
   });
 
@@ -836,5 +838,58 @@ describe("attestation gating (C20)", () => {
     const rowB = (JSON.parse(txt(withAttest)) as Array<{ id: string; requires_attestation?: boolean }>).find((x) => x.id === "secret")!;
     expect(rowA.requires_attestation).toBe(true);
     expect(rowB.requires_attestation).toBeUndefined();
+  });
+});
+
+describe("resolve_grant_ceiling tool (§3.13, RFC-0025)", () => {
+  const txt = (r: unknown) => ((r as { content: Array<{ text: string }> }).content[0].text);
+
+  it("returns the effective authority MIN across grant_ceiling sources and names the binding source", async () => {
+    const client = await connectClient(join(AUTHORITY_DIR, "knowledge.yaml"));
+    const result = await client.callTool({
+      name: "resolve_grant_ceiling",
+      arguments: {},
+    });
+    const out = JSON.parse(txt(result));
+    // Sources resolve to: org-risk=prepare, org-data=suggest,
+    // task-ceiling->change-status=explain, agent-ceiling->lara=prepare.
+    // The minimum on the declared scale is `explain`, bound by `task-ceiling`.
+    expect(out.effective_level).toBe("explain");
+    expect(out.binding_source_ids).toEqual(["task-ceiling"]);
+    expect(out.authority_level_scale).toEqual([
+      "observe",
+      "explain",
+      "suggest",
+      "prepare",
+      "commit",
+    ]);
+    await client.close();
+  });
+
+  it("caps a unit's declared action permission by the effective level when an action is given", async () => {
+    const client = await connectClient(join(AUTHORITY_DIR, "knowledge.yaml"));
+    const result = await client.callTool({
+      name: "resolve_grant_ceiling",
+      arguments: { unit_id: "status-writer", action: "modify" },
+    });
+    const out = JSON.parse(txt(result));
+    // status-writer declares modify: initiative, but the effective level `explain`
+    // caps modify to `denied` — the tool must return the stricter value.
+    expect(out.effective_level).toBe("explain");
+    expect(out.declared).toBe("initiative");
+    expect(out.capped).toBe("denied");
+    await client.close();
+  });
+
+  it("reports no ceiling when the manifest declares no grant_ceiling", async () => {
+    const client = await connectClient(join(FULL_DIR, "knowledge.yaml"));
+    const result = await client.callTool({
+      name: "resolve_grant_ceiling",
+      arguments: {},
+    });
+    const out = JSON.parse(txt(result));
+    expect(out.effective_level).toBeNull();
+    expect(out.binding_source_ids).toEqual([]);
+    await client.close();
   });
 });


### PR DESCRIPTION
> Autonomous TDD fix (KCP-native hardening) — please review before merge.

## Gap (verified)

The TypeScript MCP bridge is **authority-blind**. `parser.ts` (§765) and `model.ts` (§386–389) already **parse** the RFC-0025 / §3.13 (v0.27) root authority model — `authority_level_scale`, `task_types`, `agents`, `grant_ceiling` — but `mapper.ts`'s `manifestToJson` root projection (the `...(manifest.X ? {} : {})` block) **omitted all four**. The whole root authority model was therefore invisible to any MCP consumer. Without the ordinal scale a consumer cannot even order two authority levels; without `grant_ceiling` it cannot see the multi-source minimum that governs whether a procedure may act, and would have to fall back to the more permissive reading.

## Red test (before)

- `mapper.test.ts` → *"root authority model"*: a manifest with an authority model round-trips through `manifestToJson`, asserting the four root fields are present. **Failed** against the current tree (`Target cannot be null or undefined` / `expected undefined not to be undefined`) — the fields were absent.
- `tools.test.ts` → *"resolve_grant_ceiling tool"*: **Failed** with `Unknown tool: "resolve_grant_ceiling"` — the tool did not exist.

## Fix (minimal)

1. **`mapper.ts`** — emit `authority_level_scale` / `task_types` / `agents` / `grant_ceiling` in the root JSON projection. Declared-only; `task_types` and `agents` default to `[]` and are omitted when empty to preserve the "declared none" signal. No existing gate weakened.
2. **`server.ts`** — add the `resolve_grant_ceiling` MCP tool, wiring the **existing pure** `computeGrantCeiling` + `applyAuthorityCap` exports (`shared/src/validator.ts` §1165+). It returns the effective authority **MIN** across `grant_ceiling` sources on the declared scale plus the binding source id(s); with an optional `action` (+ optional `unit_id`) it also returns that unit's declared permission **capped** by the effective level (stricter of the two, never widened). Fail-closed: non-binding sources (outside the scale, or referencing an entity with no declared ceiling) are ignored inside `computeGrantCeiling`.

New fixture `tests/fixtures/authority/` exercises the parse → map → tool path end to end. The cap test demonstrates the ceiling biting: `status-writer` declares `modify: initiative`, effective level `explain` caps it to `denied`.

## Deferred (noted, out of scope)

- A step-graph surface via `get_playbook`.
- `load_eligible` enforcement.

## Full-suite result

- `vitest run` (bridge/typescript): **266 passed** (8 files).
- `tsc --noEmit`: **clean**.
