### PR TITLE
RFC-0029: skill authority_level + action_scope.deny (negative scope)

### DIFF
--- a/RFC-0029-Skill-Authority-and-Prohibitions.md
+++ b/RFC-0029-Skill-Authority-and-Prohibitions.md
@@ -1,0 +1,76 @@
+# RFC-0029: Skill-Level Authority and Prohibitions
+
+**Status:** Draft
+**Version target:** 0.31 (§4.3a addition)
+**Related:** RFC-0025 (Authority Level and Grant Ceiling) — this RFC makes a `kind: skill` unit a *source* in the lowest-of, and gives the scale a per-skill attachment point. RFC-0027 (Playbooks) — a step's `uses` skill now contributes its own ceiling and prohibitions to the step's effective authority. SPEC.md §4.3a (`kind`, `action_scope`), §3.13 (`authority_level`, `grant_ceiling`), §4.17 (permission values).
+
+## What This RFC Proposes
+
+Two additions to `kind: skill`, both fail-closed and backward-compatible (absent = today's behaviour):
+
+1. **`authority_level` on a `kind: skill` unit** — the skill's *own* capability ceiling, on the RFC-0025 scale (`observe < explain < suggest < prepare < commit`). It becomes an additional **source in the `grant_ceiling` minimum** (§3.13). An agent whose skill is declared at `suggest` can never be driven to `commit`, no matter what a playbook step, task-type, or tenant grant permits — the lowest still wins.
+
+2. **`action_scope.deny`** — an explicit **negative scope** with the same `{tools, paths, capabilities}` shape as the existing allowlist, expressing "**never**, regardless of any allow". A match in `deny` **denies**, overriding any allow (including a wider grant), fail-closed.
+
+```yaml
+- id: dokument-og-bevisagent
+  kind: skill
+  authority_level: prepare            # this agent's own ceiling — a source in the lowest-of
+  load_eligible: true
+  action_scope:
+    tools: [finn_gjeldende_kilde, read]
+    paths: ["evidence/**"]
+    deny:                           # explicit prohibitions — override any allow
+      tools: [publish, set_status]    # "aldri sette formell status" — structural, not prose
+      capabilities: [llm_quality_grade]
+```
+
+## The Problem
+
+### An agent's own ceiling is unrepresentable; the lowest-of is missing a source
+
+RFC-0025's `grant_ceiling` resolves the effective authority as the **minimum** across *policy / customer / playbook / task-type*. But a real agent library also has **per-agent** ceilings — "the Regelverksagent may only *suggest*, never *commit*". Today that limit can only be enforced by never *granting* the agent more elsewhere — an implicit, un-declared, un-auditable constraint. The agent's own ceiling should be a first-class **source** in the minimum, so the constraint is declared once, on the agent, and holds everywhere the agent is used.
+
+### `action_scope` is allowlist-only; "never X" cannot be said
+
+`action_scope` (§4.3a) is a positive allowlist (`tools`, `paths`, `capabilities`). There is no way to declare a **prohibition** that survives a wider grant. Real agent definitions carry hard "absolutte forbud" — *"never give a holistic LLM quality grade"*, *"never set a formal status"*, *"never delete"*. Encoded as prose they are unenforceable; encoded as *absence* from an allowlist they are fragile (a later, broader allow silently re-permits them). A negative scope that **overrides** allow makes the prohibition structural.
+
+### Provenance of the claims in this section
+
+The two gaps were surfaced by a downstream KCP consumer modelling a governed agent library as `kind: skill` units: each agent had (a) a distinct maximum authority and (b) an explicit list of prohibitions, and neither could be expressed against the current §4.3a schema — the authority had to live outside the manifest and the prohibitions became comments.
+
+## Design
+
+### `authority_level` on `kind: skill`
+
+| Field | Requiredness | Type | Semantics |
+|---|---|---|---|
+| `authority_level` | OPTIONAL | string | An RFC-0025 scale token. The skill's own ceiling. When present, it is **source (5)** in the `grant_ceiling` minimum for any step or invocation that `uses` this skill. Absent → the skill contributes no ceiling (today's behaviour). A token off the manifest's `authority_level_scale` is **fail-closed**: it ranks below everything (blocks every action). |
+
+The effective authority for a step that `uses` a skill is the minimum over: (1) step `authority_level`, (2) playbook `authority_level`, (3) task-type `grant_ceiling`, (4) tenant/agent grant, **(5) the skill's own `authority_level`** — this RFC adds (5). A skill can only ever *lower* the effective ceiling; it can never raise it. That monotonicity is what keeps it safe to select automatically.
+
+### `action_scope.deny`
+
+| Field | Requiredness | Type | Semantics |
+|---|---|---|---|
+| `action_scope.deny` | OPTIONAL | object | Same shape as `action_scope` itself: `{tools?, paths?, capabilities?}`. A requested tool/path/capability that matches `deny` is **denied**, and this denial **overrides any allow** — including a wider `grant_ceiling` or an allowlist match. Evaluation is deny-first: *deny* is checked before *allow*; a `deny` match short-circuits to refused. |
+
+Naming follows the access-control convention (XACML `deny-overrides`, AWS IAM explicit-deny, Kubernetes/OPA/Cisco) and KCP's own "deny-by-default" (§4.3c) — `deny` in this domain already implies override-of-allow. Path matching reuses the existing `action_scope` path-glob semantics. An empty `deny` object is a no-op. `deny` is **not** a substitute for omitting an allow — it is an assertion that a capability is prohibited *even if otherwise granted*, which is the property prose and allowlist-absence cannot provide.
+
+### Interaction with existing rules
+
+- **§4.3c `load_eligible`** unaffected — eligibility gates *loading*; `authority_level`/`deny` gate *what a loaded skill may do*.
+- **RFC-0027 steps** — a step's effective authority now folds in the used skill's ceiling (source 5); a step's conformance check now also applies the used skill's `deny`.
+- **§4.17 permission caps** — `deny` composes *after* the §4.17 authority→permission cap: an action must pass the authority cap **and** not be forbidden.
+- **Validator** — `authority_level` must be on the scale; `deny` must be a valid scope shape; a unit whose `deny` fully contains its own `allow` for a dimension SHOULD emit a §7 warning (self-nullifying scope).
+
+### Migration / backward compatibility
+
+Both fields are OPTIONAL and absent-means-today. No existing manifest changes meaning. Parsers that predate this RFC ignore unknown fields and load the skill ungoverned on the new dimensions — so the fields **MUST** be treated as fail-open by old parsers but fail-closed by conformant ones; publishers targeting mixed fleets should not rely on `deny` for a hard security boundary until the consuming runtime is known to be conformant (same caveat as every §4.3a governance field).
+
+## Acceptance
+
+1. A `kind: skill` with `authority_level: suggest` used by a step granted `commit` resolves to effective `suggest` (the skill is the binding source, named in the trace).
+2. An `action_scope.deny.tools: [publish]` denies a `publish` request even when `tools: [publish]` would otherwise allow it, fail-closed, with the deny cited.
+3. Validator: off-scale `authority_level` → error; malformed `deny` → error; self-nullifying `deny` ⊇ `allow` → warning.
+4. Round-trips through the manifest JSON projection (MCP bridge) with both fields present.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1833,31 +1833,31 @@ skill's declared `authority_level` to the MIN, and the effective level can never
 elsewhere in §3.13, a skill with no declared `authority_level` makes such a source non-binding
 (absence is not a grant), and the minimum can never be raised by any single input.
 
-**`action_scope.forbid` — an explicit negative scope.** `tools`/`paths`/`capabilities` are an
-*allowlist*: what the skill may touch. `forbid` is the complementary *denylist*, carrying the
+**`action_scope.deny` — an explicit negative scope.** `tools`/`paths`/`capabilities` are an
+*allowlist*: what the skill may touch. `deny` is the complementary *denylist*, carrying the
 same `{tools, paths, capabilities}` shape, and every entry is a prohibition:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `forbid.tools` | array of string | Tool names the skill MUST NOT invoke, even if allowlisted. |
-| `forbid.paths` | array of string | Paths (globs permitted) the skill MUST NOT read or write, even if allowlisted. |
-| `forbid.capabilities` | array of string | Capabilities the skill MUST NOT exercise, even if allowlisted. |
+| `deny.tools` | array of string | Tool names the skill MUST NOT invoke, even if allowlisted. |
+| `deny.paths` | array of string | Paths (globs permitted) the skill MUST NOT read or write, even if allowlisted. |
+| `deny.capabilities` | array of string | Capabilities the skill MUST NOT exercise, even if allowlisted. |
 
 All sub-fields are OPTIONAL and `action_scope` remains an opaque passthrough for parsers that do
 not implement conformance checking.
 
-**`forbid` overrides the allowlist, fail-closed.** A conformance checker adjudicates each
-tool/path/capability against **both** lists, and `forbid` wins: a token present in the relevant
-`forbid` list is **denied** even when the allowlist grants it. This lets an author allow a broad
+**`deny` overrides the allowlist, fail-closed.** A conformance checker adjudicates each
+tool/path/capability against **both** lists, and `deny` wins: a token present in the relevant
+`deny` list is **denied** even when the allowlist grants it. This lets an author allow a broad
 region and carve a prohibited hole inside it — allow `schema/**` while forbidding
 `schema/secrets/**` — without having to enumerate the complement. The override is the safe
 direction by construction: a denylist can only *narrow* what the allowlist already bounded, so it
 can never widen a skill's reach, and a checker that cannot resolve a match denies rather than
-permits. Where an implementation supports escalation (§3.14), an action a `forbid` holds SHOULD
+permits. Where an implementation supports escalation (§3.14), an action a `deny` holds SHOULD
 raise a grant request rather than fail silently, exactly as an over-threshold `spend` does
-(§4.3a.1). Two validator lints surface authoring slips without weakening the gate: a `forbid`
+(§4.3a.1). Two validator lints surface authoring slips without weakening the gate: a `deny`
 that lists nothing prohibits nothing, and a token that is **both** allowlisted and forbidden
-leaves an allow entry the `forbid` neutralizes — the declaration reads wider than it enforces.
+leaves an allow entry the `deny` neutralizes — the declaration reads wider than it enforces.
 
 ```yaml
 - id: rotate-signing-key
@@ -1871,7 +1871,7 @@ leaves an allow entry the `forbid` neutralizes — the declaration reads wider t
     tools: [kcp-sign, git]
     paths: ["schema/**", ".well-known/kcp-signing-key"]
     capabilities: [key-management]
-    forbid:
+    deny:
       paths: ["schema/secrets/**"]   # carve a prohibited hole inside an allowed region
       tools: [shell]                 # denied even if a broader grant would allow it
       capabilities: [network]

--- a/SPEC.md
+++ b/SPEC.md
@@ -1816,6 +1816,67 @@ by default like `executable`/`service`: absent an explicit eligibility grant it 
 pointer with `invocation: explicit` (§16.3, C4). Skills are the manifest-declared counterpart of
 the runtime-depth lifecycle recorded in §17 (`skill_selected` … `verdict_emitted`).
 
+#### 4.3a — skill authority ceiling and negative scope (PROPOSED, v0.31)
+
+> **Status: PROPOSED for design review.** This subsection extends the `kind: skill`
+> envelope with two capabilities a downstream KCP consumer needs to enforce a skill's
+> own limits at run time. It reuses the existing `authority_level` field and the existing
+> `action_scope` shape; no existing gate is weakened. It is fail-closed by construction.
+
+**A skill's own `authority_level` is a `grant_ceiling` source.** A `kind: skill` unit MAY
+declare `authority_level` (the §3.13 scale, ceiling semantics — "at most this level"), just as
+any unit may (§4.23). On a skill it names the skill's *own capability ceiling*: the most
+discretion the procedure was written to hold, independent of who invokes it. Because a
+`grant_ceiling` source (§3.13) may resolve a level via `unit_ref`, that ceiling **participates
+directly in the multi-source minimum** — a source citing the skill by `unit_ref` contributes the
+skill's declared `authority_level` to the MIN, and the effective level can never exceed it. As
+elsewhere in §3.13, a skill with no declared `authority_level` makes such a source non-binding
+(absence is not a grant), and the minimum can never be raised by any single input.
+
+**`action_scope.forbid` — an explicit negative scope.** `tools`/`paths`/`capabilities` are an
+*allowlist*: what the skill may touch. `forbid` is the complementary *denylist*, carrying the
+same `{tools, paths, capabilities}` shape, and every entry is a prohibition:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `forbid.tools` | array of string | Tool names the skill MUST NOT invoke, even if allowlisted. |
+| `forbid.paths` | array of string | Paths (globs permitted) the skill MUST NOT read or write, even if allowlisted. |
+| `forbid.capabilities` | array of string | Capabilities the skill MUST NOT exercise, even if allowlisted. |
+
+All sub-fields are OPTIONAL and `action_scope` remains an opaque passthrough for parsers that do
+not implement conformance checking.
+
+**`forbid` overrides the allowlist, fail-closed.** A conformance checker adjudicates each
+tool/path/capability against **both** lists, and `forbid` wins: a token present in the relevant
+`forbid` list is **denied** even when the allowlist grants it. This lets an author allow a broad
+region and carve a prohibited hole inside it — allow `schema/**` while forbidding
+`schema/secrets/**` — without having to enumerate the complement. The override is the safe
+direction by construction: a denylist can only *narrow* what the allowlist already bounded, so it
+can never widen a skill's reach, and a checker that cannot resolve a match denies rather than
+permits. Where an implementation supports escalation (§3.14), an action a `forbid` holds SHOULD
+raise a grant request rather than fail silently, exactly as an over-threshold `spend` does
+(§4.3a.1). Two validator lints surface authoring slips without weakening the gate: a `forbid`
+that lists nothing prohibits nothing, and a token that is **both** allowlisted and forbidden
+leaves an allow entry the `forbid` neutralizes — the declaration reads wider than it enforces.
+
+```yaml
+- id: rotate-signing-key
+  path: skills/rotate-signing-key.md
+  kind: skill
+  intent: "How do I rotate the manifest signing key safely?"
+  scope: project
+  audience: [agent, operator]
+  authority_level: prepare        # the skill's own ceiling; a grant_ceiling unit_ref caps to it
+  action_scope:
+    tools: [kcp-sign, git]
+    paths: ["schema/**", ".well-known/kcp-signing-key"]
+    capabilities: [key-management]
+    forbid:
+      paths: ["schema/secrets/**"]   # carve a prohibited hole inside an allowed region
+      tools: [shell]                 # denied even if a broader grant would allow it
+      capabilities: [network]
+```
+
 
 #### 4.3a.1 `action_scope.spend` — what a procedure may buy
 

--- a/bridge/typescript/node_modules
+++ b/bridge/typescript/node_modules
@@ -1,0 +1,1 @@
+/src/cantara/knowledge-context-protocol/bridge/typescript/node_modules

--- a/cli/node_modules
+++ b/cli/node_modules
@@ -1,0 +1,1 @@
+/src/cantara/knowledge-context-protocol/cli/node_modules

--- a/cli/src/skill-negative-scope.test.ts
+++ b/cli/src/skill-negative-scope.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseDict } from "../../shared/src/parser.js";
-import { validate, forbidsToken } from "../../shared/src/validator.js";
+import { validate, deniesToken } from "../../shared/src/validator.js";
 
 /**
  * §4.3a skill negative scope + own authority ceiling (SPEC PROPOSAL, design review).
@@ -12,9 +12,9 @@ import { validate, forbidsToken } from "../../shared/src/validator.js";
  *     (`authority_level` on a unit already parses and is scale-checked; these tests
  *     pin that it holds for a skill and feeds a grant_ceiling `unit_ref`.)
  *
- *  2. `action_scope.forbid` — an explicit negative scope with the same
- *     {tools, paths, capabilities} shape as the allowlist. A forbid entry is DENIED
- *     even when the allowlist would grant it: forbid overrides allow, fail-closed.
+ *  2. `action_scope.deny` — an explicit negative scope with the same
+ *     {tools, paths, capabilities} shape as the allowlist. A deny entry is DENIED
+ *     even when the allowlist would grant it: deny overrides allow, fail-closed.
  */
 
 function manifest(units: unknown[], extra: Record<string, unknown> = {}) {
@@ -38,8 +38,8 @@ const BASE_SKILL = {
   load_eligible: true,
 };
 
-describe("§4.3a — action_scope.forbid negative scope", () => {
-  it("round-trips forbid alongside the allowlist", () => {
+describe("§4.3a — action_scope.deny negative scope", () => {
+  it("round-trips deny alongside the allowlist", () => {
     const m = manifest([
       {
         ...BASE_SKILL,
@@ -47,7 +47,7 @@ describe("§4.3a — action_scope.forbid negative scope", () => {
           tools: ["kcp-sign", "git"],
           paths: ["schema/**"],
           capabilities: ["key-management"],
-          forbid: {
+          deny: {
             tools: ["shell"],
             paths: ["schema/secrets/**"],
             capabilities: ["network"],
@@ -57,52 +57,52 @@ describe("§4.3a — action_scope.forbid negative scope", () => {
     ]);
     const scope = m.units[0]!.action_scope!;
     expect(scope.tools).toEqual(["kcp-sign", "git"]);
-    expect(scope.forbid).toBeDefined();
-    expect(scope.forbid!.tools).toEqual(["shell"]);
-    expect(scope.forbid!.paths).toEqual(["schema/secrets/**"]);
-    expect(scope.forbid!.capabilities).toEqual(["network"]);
-    // a well-formed forbid + allow validates clean
+    expect(scope.deny).toBeDefined();
+    expect(scope.deny!.tools).toEqual(["shell"]);
+    expect(scope.deny!.paths).toEqual(["schema/secrets/**"]);
+    expect(scope.deny!.capabilities).toEqual(["network"]);
+    // a well-formed deny + allow validates clean
     const r = validate(m);
     expect(r.isValid).toBe(true);
   });
 
-  it("forbidsToken adjudicates fail-closed: forbid denies even when allow grants", () => {
+  it("deniesToken adjudicates fail-closed: deny denies even when allow grants", () => {
     const m = manifest([
       {
         ...BASE_SKILL,
-        action_scope: { tools: ["git", "shell"], forbid: { tools: ["shell"] } },
+        action_scope: { tools: ["git", "shell"], deny: { tools: ["shell"] } },
       },
     ]);
     const scope = m.units[0]!.action_scope;
-    expect(forbidsToken(scope, "tools", "shell")).toBe(true);
-    expect(forbidsToken(scope, "tools", "git")).toBe(false);
+    expect(deniesToken(scope, "tools", "shell")).toBe(true);
+    expect(deniesToken(scope, "tools", "git")).toBe(false);
   });
 
-  it("catches an over-broad allow entry that a forbid denies (forbid overrides allow)", () => {
+  it("catches an over-broad allow entry that a deny denies (deny overrides allow)", () => {
     const m = manifest([
       {
         ...BASE_SKILL,
-        // 'shell' is both granted and forbidden — the allow is dead, forbid wins.
-        action_scope: { tools: ["git", "shell"], forbid: { tools: ["shell"] } },
+        // 'shell' is both granted and forbidden — the allow is dead, deny wins.
+        action_scope: { tools: ["git", "shell"], deny: { tools: ["shell"] } },
       },
     ]);
     const r = validate(m);
     const hit = r.warnings.find(
-      (w) => /forbid/.test(w) && /shell/.test(w) && /§4\.3a/.test(w)
+      (w) => /deny/.test(w) && /shell/.test(w) && /§4\.3a/.test(w)
     );
-    expect(hit, `expected a forbid-overrides-allow warning, got: ${r.warnings.join(" | ")}`).toBeDefined();
+    expect(hit, `expected a deny-overrides-allow warning, got: ${r.warnings.join(" | ")}`).toBeDefined();
   });
 
-  it("warns on an empty forbid — it prohibits nothing (shape lint)", () => {
+  it("warns on an empty deny — it prohibits nothing (shape lint)", () => {
     const m = manifest([
       {
         ...BASE_SKILL,
-        action_scope: { tools: ["git"], forbid: {} },
+        action_scope: { tools: ["git"], deny: {} },
       },
     ]);
     const r = validate(m);
-    const hit = r.warnings.find((w) => /forbid/.test(w) && /prohibits nothing/.test(w));
-    expect(hit, `expected an empty-forbid warning, got: ${r.warnings.join(" | ")}`).toBeDefined();
+    const hit = r.warnings.find((w) => /deny/.test(w) && /prohibits nothing/.test(w));
+    expect(hit, `expected an empty-deny warning, got: ${r.warnings.join(" | ")}`).toBeDefined();
   });
 });
 

--- a/cli/src/skill-negative-scope.test.ts
+++ b/cli/src/skill-negative-scope.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { parseDict } from "../../shared/src/parser.js";
+import { validate, forbidsToken } from "../../shared/src/validator.js";
+
+/**
+ * §4.3a skill negative scope + own authority ceiling (SPEC PROPOSAL, design review).
+ *
+ * Two capabilities a downstream KCP consumer needs from a `kind: skill` unit:
+ *
+ *  1. The skill carries its OWN `authority_level` — its capability ceiling — so it
+ *     participates as a `grant_ceiling` source (§3.13) in the multi-source MIN.
+ *     (`authority_level` on a unit already parses and is scale-checked; these tests
+ *     pin that it holds for a skill and feeds a grant_ceiling `unit_ref`.)
+ *
+ *  2. `action_scope.forbid` — an explicit negative scope with the same
+ *     {tools, paths, capabilities} shape as the allowlist. A forbid entry is DENIED
+ *     even when the allowlist would grant it: forbid overrides allow, fail-closed.
+ */
+
+function manifest(units: unknown[], extra: Record<string, unknown> = {}) {
+  return parseDict({
+    project: "example",
+    version: "1.0.0",
+    kcp_version: "0.30",
+    authority_level_scale: ["observe", "explain", "suggest", "prepare", "commit"],
+    units,
+    ...extra,
+  });
+}
+
+const BASE_SKILL = {
+  id: "rotate-signing-key",
+  kind: "skill",
+  path: "skills/rotate.md",
+  intent: "How do I rotate the signing key safely?",
+  scope: "project",
+  audience: ["agent"],
+  load_eligible: true,
+};
+
+describe("§4.3a — action_scope.forbid negative scope", () => {
+  it("round-trips forbid alongside the allowlist", () => {
+    const m = manifest([
+      {
+        ...BASE_SKILL,
+        action_scope: {
+          tools: ["kcp-sign", "git"],
+          paths: ["schema/**"],
+          capabilities: ["key-management"],
+          forbid: {
+            tools: ["shell"],
+            paths: ["schema/secrets/**"],
+            capabilities: ["network"],
+          },
+        },
+      },
+    ]);
+    const scope = m.units[0]!.action_scope!;
+    expect(scope.tools).toEqual(["kcp-sign", "git"]);
+    expect(scope.forbid).toBeDefined();
+    expect(scope.forbid!.tools).toEqual(["shell"]);
+    expect(scope.forbid!.paths).toEqual(["schema/secrets/**"]);
+    expect(scope.forbid!.capabilities).toEqual(["network"]);
+    // a well-formed forbid + allow validates clean
+    const r = validate(m);
+    expect(r.isValid).toBe(true);
+  });
+
+  it("forbidsToken adjudicates fail-closed: forbid denies even when allow grants", () => {
+    const m = manifest([
+      {
+        ...BASE_SKILL,
+        action_scope: { tools: ["git", "shell"], forbid: { tools: ["shell"] } },
+      },
+    ]);
+    const scope = m.units[0]!.action_scope;
+    expect(forbidsToken(scope, "tools", "shell")).toBe(true);
+    expect(forbidsToken(scope, "tools", "git")).toBe(false);
+  });
+
+  it("catches an over-broad allow entry that a forbid denies (forbid overrides allow)", () => {
+    const m = manifest([
+      {
+        ...BASE_SKILL,
+        // 'shell' is both granted and forbidden — the allow is dead, forbid wins.
+        action_scope: { tools: ["git", "shell"], forbid: { tools: ["shell"] } },
+      },
+    ]);
+    const r = validate(m);
+    const hit = r.warnings.find(
+      (w) => /forbid/.test(w) && /shell/.test(w) && /§4\.3a/.test(w)
+    );
+    expect(hit, `expected a forbid-overrides-allow warning, got: ${r.warnings.join(" | ")}`).toBeDefined();
+  });
+
+  it("warns on an empty forbid — it prohibits nothing (shape lint)", () => {
+    const m = manifest([
+      {
+        ...BASE_SKILL,
+        action_scope: { tools: ["git"], forbid: {} },
+      },
+    ]);
+    const r = validate(m);
+    const hit = r.warnings.find((w) => /forbid/.test(w) && /prohibits nothing/.test(w));
+    expect(hit, `expected an empty-forbid warning, got: ${r.warnings.join(" | ")}`).toBeDefined();
+  });
+});
+
+describe("§3.13/§4.3a — a skill's own authority_level is a grant_ceiling source", () => {
+  it("round-trips authority_level on a skill and scale-checks it", () => {
+    const m = manifest([
+      {
+        ...BASE_SKILL,
+        authority_level: "prepare",
+        action_scope: { tools: ["kcp-sign"] },
+      },
+    ]);
+    expect(m.units[0]!.authority_level).toBe("prepare");
+    const r = validate(m);
+    expect(r.isValid).toBe(true);
+    // a value off the declared scale warns
+    const m2 = manifest([
+      { ...BASE_SKILL, authority_level: "yolo", action_scope: { tools: ["kcp-sign"] } },
+    ]);
+    const r2 = validate(m2);
+    expect(
+      r2.warnings.some((w) => /authority_level/.test(w) && /yolo/.test(w))
+    ).toBe(true);
+  });
+
+  it("resolves the skill's authority_level through a grant_ceiling unit_ref", () => {
+    const m = manifest(
+      [{ ...BASE_SKILL, authority_level: "suggest", action_scope: { tools: ["kcp-sign"] } }],
+      {
+        grant_ceiling: {
+          sources: [
+            { id: "org-policy", authority_level: "prepare" },
+            { id: "skill-ceiling", unit_ref: "rotate-signing-key" },
+          ],
+        },
+      }
+    );
+    const r = validate(m);
+    // unit_ref resolves to a declared, in-scale level — no unknown-ref error
+    expect(r.errors.find((e) => /unit_ref/.test(e))).toBeUndefined();
+    expect(r.isValid).toBe(true);
+  });
+});

--- a/examples/skill-negative-scope/knowledge.yaml
+++ b/examples/skill-negative-scope/knowledge.yaml
@@ -3,11 +3,11 @@
 # Demonstrates the two §4.3a additions under design review:
 #   1. a kind: skill unit carries its OWN authority_level (its capability ceiling),
 #      which a grant_ceiling source pulls into the multi-source MIN via unit_ref;
-#   2. action_scope.forbid — an explicit denylist that overrides the allowlist,
+#   2. action_scope.deny — an explicit denylist that overrides the allowlist,
 #      fail-closed. Here the skill is allowed all of schema/**, but forbidden the
 #      schema/secrets/** subtree and the `shell` tool.
 #
-# kcp_version stays "0.30" (the current spec minor); `forbid` is an additive field a
+# kcp_version stays "0.30" (the current spec minor); `deny` is an additive field a
 # pre-proposal parser silently ignores per §2, so the manifest stays backward compatible.
 
 kcp_version: "0.30"
@@ -40,7 +40,7 @@ units:
       tools: [kcp-sign, git]
       paths: ["schema/**", ".well-known/kcp-signing-key"]
       capabilities: [key-management]
-      forbid:                          # PROPOSED v0.31 — overrides the allowlist, fail-closed
+      deny:                          # PROPOSED v0.31 — overrides the allowlist, fail-closed
         paths: ["schema/secrets/**"]   # a prohibited hole inside the allowed schema/** region
         tools: [shell]                 # denied even though a broader grant might allow it
         capabilities: [network]

--- a/examples/skill-negative-scope/knowledge.yaml
+++ b/examples/skill-negative-scope/knowledge.yaml
@@ -1,0 +1,46 @@
+# Skill authority ceiling + negative scope — worked example (PROPOSED, v0.31).
+#
+# Demonstrates the two §4.3a additions under design review:
+#   1. a kind: skill unit carries its OWN authority_level (its capability ceiling),
+#      which a grant_ceiling source pulls into the multi-source MIN via unit_ref;
+#   2. action_scope.forbid — an explicit denylist that overrides the allowlist,
+#      fail-closed. Here the skill is allowed all of schema/**, but forbidden the
+#      schema/secrets/** subtree and the `shell` tool.
+#
+# kcp_version stays "0.30" (the current spec minor); `forbid` is an additive field a
+# pre-proposal parser silently ignores per §2, so the manifest stays backward compatible.
+
+kcp_version: "0.30"
+project: skill-negative-scope-demo
+version: 1.0.0
+
+authority_level_scale: [observe, explain, suggest, prepare, commit]
+
+grant_ceiling:
+  sources:
+    # An org-wide ceiling and the skill's own ceiling both apply; the effective
+    # level is their MINIMUM. The skill declares `prepare`, so it can never lift
+    # the effective level above what it was written to hold.
+    - id: org-risk-policy
+      authority_level: prepare
+    - id: skill-capability-ceiling
+      unit_ref: rotate-signing-key
+  mandatory_sources: [org-risk-policy]
+
+units:
+  - id: rotate-signing-key
+    path: skills/rotate-signing-key.md
+    kind: skill
+    intent: "How do I rotate the manifest signing key safely?"
+    scope: project
+    audience: [agent, operator]
+    load_eligible: true
+    authority_level: prepare          # the skill's own capability ceiling (§3.13 / §4.23)
+    action_scope:
+      tools: [kcp-sign, git]
+      paths: ["schema/**", ".well-known/kcp-signing-key"]
+      capabilities: [key-management]
+      forbid:                          # PROPOSED v0.31 — overrides the allowlist, fail-closed
+        paths: ["schema/secrets/**"]   # a prohibited hole inside the allowed schema/** region
+        tools: [shell]                 # denied even though a broader grant might allow it
+        capabilities: [network]

--- a/examples/skill-negative-scope/skills/rotate-signing-key.md
+++ b/examples/skill-negative-scope/skills/rotate-signing-key.md
@@ -1,0 +1,14 @@
+# Rotate the manifest signing key
+
+A governed `kind: skill` procedure. Its enaction is bounded by the `action_scope`
+declared for it in [`../knowledge.yaml`](../knowledge.yaml):
+
+- **Allowed** tools `kcp-sign`, `git`; paths `schema/**` and `.well-known/kcp-signing-key`;
+  capability `key-management`.
+- **Forbidden** (overrides the allowlist, fail-closed): the `schema/secrets/**` subtree,
+  the `shell` tool, and the `network` capability — denied even though `schema/**` and a
+  broader tool grant would otherwise reach them.
+
+Its own `authority_level: prepare` is the ceiling it was written to hold; the manifest's
+`grant_ceiling` folds that ceiling into the multi-source minimum via `unit_ref`, so the
+effective authority for enacting this skill can never exceed `prepare`.

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -69,7 +69,7 @@ units:
     triggers: [ spec, specification, fields, validation, conformance, yaml, format ]
     content_hash:
       algorithm: sha256
-      value: cbfd5dc93c5b7f27d32ac89bd8630eea698155f5dd318703f7663b3f6fda3227
+      value: 4a75536a45d9d56b54714f7605c297f6edcb44f4a4b7fd97eed794b247b15f52
 
   - id: proposal
     path: PROPOSAL.md

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -69,7 +69,7 @@ units:
     triggers: [ spec, specification, fields, validation, conformance, yaml, format ]
     content_hash:
       algorithm: sha256
-      value: c85b51b6daa37918ab074c14cda74e3f5b053e274650189e059c486a9a78e2ea
+      value: cbfd5dc93c5b7f27d32ac89bd8630eea698155f5dd318703f7663b3f6fda3227
 
   - id: proposal
     path: PROPOSAL.md

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/src/cantara/knowledge-context-protocol/node_modules

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -256,9 +256,9 @@
                 }
               }
             },
-            "forbid": {
+            "deny": {
               "type": "object",
-              "description": "PROPOSED (v0.31): explicit negative scope. Same {tools, paths, capabilities} shape as the allowlist, but every entry is a PROHIBITION — a token listed here is denied even when the allowlist grants it. Checked in addition to and overriding the allowlist, fail-closed. A forbid that is a narrower glob of an allow is the intended carve-out; an exact-token collision with the allowlist neutralizes that allow. See SPEC.md §4.3a.",
+              "description": "PROPOSED (v0.31): explicit negative scope. Same {tools, paths, capabilities} shape as the allowlist, but every entry is a PROHIBITION — a token listed here is denied even when the allowlist grants it. Checked in addition to and overriding the allowlist, fail-closed. A deny that is a narrower glob of an allow is the intended carve-out; an exact-token collision with the allowlist neutralizes that allow. See SPEC.md §4.3a.",
               "properties": {
                 "tools": {
                   "type": "array",

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -255,6 +255,27 @@
                   "description": "ISO 4217 code (USD, EUR) or crypto ticker (USDC, ETH) that 'max_spend' is denominated in."
                 }
               }
+            },
+            "forbid": {
+              "type": "object",
+              "description": "PROPOSED (v0.31): explicit negative scope. Same {tools, paths, capabilities} shape as the allowlist, but every entry is a PROHIBITION — a token listed here is denied even when the allowlist grants it. Checked in addition to and overriding the allowlist, fail-closed. A forbid that is a narrower glob of an allow is the intended carve-out; an exact-token collision with the allowlist neutralizes that allow. See SPEC.md §4.3a.",
+              "properties": {
+                "tools": {
+                  "type": "array",
+                  "description": "Tool names the procedure MUST NOT invoke, even if allowlisted.",
+                  "items": { "type": "string" }
+                },
+                "paths": {
+                  "type": "array",
+                  "description": "File-system paths (globs permitted) the procedure MUST NOT read or write, even if allowlisted.",
+                  "items": { "type": "string" }
+                },
+                "capabilities": {
+                  "type": "array",
+                  "description": "Named capabilities the procedure MUST NOT exercise, even if allowlisted.",
+                  "items": { "type": "string" }
+                }
+              }
             }
           }
         },

--- a/shared/node_modules
+++ b/shared/node_modules
@@ -1,0 +1,1 @@
+/src/cantara/knowledge-context-protocol/cli/node_modules

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -137,9 +137,9 @@ export interface Spend {
  *
  * Same {tools, paths, capabilities} shape as the allowlist, but every entry is a
  * PROHIBITION: a token listed here is denied even when the allowlist grants it.
- * `forbid` is checked in addition to — and overrides — the allowlist, fail-closed.
+ * `deny` is checked in addition to — and overrides — the allowlist, fail-closed.
  */
-export interface ForbidScope {
+export interface DenyScope {
   tools?: string[];         // tool names the procedure MUST NOT invoke, even if allowlisted
   paths?: string[];         // file-system paths (globs permitted) the procedure MUST NOT touch
   capabilities?: string[];  // named capabilities the procedure MUST NOT exercise
@@ -151,7 +151,7 @@ export interface ActionScope {
   paths?: string[];         // file-system paths (globs permitted) the procedure may read/write
   capabilities?: string[];  // named capabilities the procedure requires or exercises
   spend?: Spend;            // purchases the procedure may make (per-purchase cap + vendor allowlist)
-  forbid?: ForbidScope;     // §4.3a (PROPOSED, v0.31) — explicit prohibitions; override the allowlist, fail-closed
+  deny?: DenyScope;     // §4.3a (PROPOSED, v0.31) — explicit prohibitions; override the allowlist, fail-closed
 }
 
 /**

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -132,12 +132,26 @@ export interface Spend {
   currency?: string;          // ISO 4217 code or crypto ticker `max_spend` is denominated in
 }
 
+/**
+ * Explicit negative scope on a `kind: skill` action_scope. See SPEC.md §4.3a (PROPOSED, v0.31).
+ *
+ * Same {tools, paths, capabilities} shape as the allowlist, but every entry is a
+ * PROHIBITION: a token listed here is denied even when the allowlist grants it.
+ * `forbid` is checked in addition to — and overrides — the allowlist, fail-closed.
+ */
+export interface ForbidScope {
+  tools?: string[];         // tool names the procedure MUST NOT invoke, even if allowlisted
+  paths?: string[];         // file-system paths (globs permitted) the procedure MUST NOT touch
+  capabilities?: string[];  // named capabilities the procedure MUST NOT exercise
+}
+
 /** Envelope of tools/paths/capabilities/spend a `kind: skill` procedure may touch. See SPEC.md §4.3a (v0.26). */
 export interface ActionScope {
   tools?: string[];         // tool names the procedure may invoke
   paths?: string[];         // file-system paths (globs permitted) the procedure may read/write
   capabilities?: string[];  // named capabilities the procedure requires or exercises
   spend?: Spend;            // purchases the procedure may make (per-purchase cap + vendor allowlist)
+  forbid?: ForbidScope;     // §4.3a (PROPOSED, v0.31) — explicit prohibitions; override the allowlist, fail-closed
 }
 
 /**

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import yaml from "js-yaml";
 import type {
   ActionScope,
+  ForbidScope,
   PlaybookStep,
   Spend,
   Auth,
@@ -539,6 +540,24 @@ function parseActionScope(raw: unknown): ActionScope | undefined {
     paths: stringListOrUndefined(d["paths"]),
     capabilities: stringListOrUndefined(d["capabilities"]),
     spend: parseSpend(d["spend"]),
+    forbid: parseForbidScope(d["forbid"]),
+  };
+}
+
+/**
+ * §4.3a (PROPOSED, v0.31): the explicit negative scope a `kind: skill` declares.
+ *
+ * Same {tools, paths, capabilities} shape as the allowlist; every entry is a
+ * prohibition. Mirrors parseActionScope's leniency — anything that is not an object
+ * yields undefined ("declares no prohibition") rather than failing the whole parse.
+ */
+function parseForbidScope(raw: unknown): ForbidScope | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const d = raw as RawMap;
+  return {
+    tools: stringListOrUndefined(d["tools"]),
+    paths: stringListOrUndefined(d["paths"]),
+    capabilities: stringListOrUndefined(d["capabilities"]),
   };
 }
 

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import yaml from "js-yaml";
 import type {
   ActionScope,
-  ForbidScope,
+  DenyScope,
   PlaybookStep,
   Spend,
   Auth,
@@ -540,7 +540,7 @@ function parseActionScope(raw: unknown): ActionScope | undefined {
     paths: stringListOrUndefined(d["paths"]),
     capabilities: stringListOrUndefined(d["capabilities"]),
     spend: parseSpend(d["spend"]),
-    forbid: parseForbidScope(d["forbid"]),
+    deny: parseDenyScope(d["deny"]),
   };
 }
 
@@ -551,7 +551,7 @@ function parseActionScope(raw: unknown): ActionScope | undefined {
  * prohibition. Mirrors parseActionScope's leniency — anything that is not an object
  * yields undefined ("declares no prohibition") rather than failing the whole parse.
  */
-function parseForbidScope(raw: unknown): ForbidScope | undefined {
+function parseDenyScope(raw: unknown): DenyScope | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
   const d = raw as RawMap;
   return {

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -4,7 +4,7 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve, join } from "node:path";
-import type { KnowledgeManifest, Payment, RateLimits, Temporal, ValidationResult } from "./model.js";
+import type { ActionScope, KnowledgeManifest, Payment, RateLimits, Temporal, ValidationResult } from "./model.js";
 
 // --- Per-unit content digest (RFC-0019 §3.2, draft) ---
 // Lives here (not in a render module) so the CLI and bridge validator
@@ -219,6 +219,21 @@ function supersededCycleIds(successor: Map<string, string>): string[] {
     for (const id of path) if (state.get(id) === 1) state.set(id, 2);
   }
   return [...cycle].sort();
+}
+
+/**
+ * §4.3a (PROPOSED, v0.31): does a skill's `action_scope.forbid` deny `token` on
+ * `dimension`? Fail-closed override — a forbid entry denies the token even when the
+ * allowlist grants it. Exact-string match. Exported so a runtime enforcer and the
+ * validator's overlap lint share one adjudication rule, the way §4.3a.1 `spend` and
+ * the allowlist share one fail-closed default.
+ */
+export function forbidsToken(
+  scope: ActionScope | undefined,
+  dimension: "tools" | "paths" | "capabilities",
+  token: string
+): boolean {
+  return scope?.forbid?.[dimension]?.includes(token) ?? false;
 }
 
 export function validate(
@@ -518,6 +533,39 @@ export function validate(
       errors.push(
         `${ctx}: kind 'skill' with 'load_eligible: true' MUST declare an 'action_scope' — it is authorised to act and bounded in nothing (§4.3c)`
       );
+    }
+
+    // §4.3a (PROPOSED, v0.31): the explicit negative scope. Two lints, both warnings —
+    // a forbid never widens anything, so a slip here fails safe, but a slip is still
+    // worth naming:
+    //  - an empty `forbid` prohibits nothing (an authoring slip: the author reached for
+    //    a prohibition and declared none);
+    //  - a token that is BOTH allowed and forbidden. Forbid overrides allow, fail-closed,
+    //    so the allow entry is dead — the scope reads wider than it enforces. Naming the
+    //    exact contradiction lets the author drop the allow (or the forbid). A forbid that
+    //    is a narrower glob of an allow (schema/** allowed, schema/secrets/** forbidden)
+    //    is the intended carve-out and is NOT flagged; only an exact-token collision is.
+    const forbid = unit.action_scope?.forbid;
+    if (forbid !== undefined) {
+      const forbidsAnything =
+        (forbid.tools?.length ?? 0) > 0 ||
+        (forbid.paths?.length ?? 0) > 0 ||
+        (forbid.capabilities?.length ?? 0) > 0;
+      if (!forbidsAnything) {
+        warnings.push(
+          `${ctx}: 'action_scope.forbid' is declared but empty — it prohibits nothing (§4.3a)`
+        );
+      }
+      for (const dim of ["tools", "paths", "capabilities"] as const) {
+        const allowed = new Set(unit.action_scope?.[dim] ?? []);
+        for (const token of forbid[dim] ?? []) {
+          if (allowed.has(token)) {
+            warnings.push(
+              `${ctx}: 'action_scope.${dim}' allows '${token}' while 'forbid.${dim}' denies it — the allow entry is neutralized; forbid overrides allow, fail-closed (§4.3a)`
+            );
+          }
+        }
+      }
     }
 
     if (unit.kind !== "playbook") {

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -222,18 +222,18 @@ function supersededCycleIds(successor: Map<string, string>): string[] {
 }
 
 /**
- * §4.3a (PROPOSED, v0.31): does a skill's `action_scope.forbid` deny `token` on
- * `dimension`? Fail-closed override — a forbid entry denies the token even when the
+ * §4.3a (PROPOSED, v0.31): does a skill's `action_scope.deny` deny `token` on
+ * `dimension`? Fail-closed override — a deny entry denies the token even when the
  * allowlist grants it. Exact-string match. Exported so a runtime enforcer and the
  * validator's overlap lint share one adjudication rule, the way §4.3a.1 `spend` and
  * the allowlist share one fail-closed default.
  */
-export function forbidsToken(
+export function deniesToken(
   scope: ActionScope | undefined,
   dimension: "tools" | "paths" | "capabilities",
   token: string
 ): boolean {
-  return scope?.forbid?.[dimension]?.includes(token) ?? false;
+  return scope?.deny?.[dimension]?.includes(token) ?? false;
 }
 
 export function validate(
@@ -536,32 +536,32 @@ export function validate(
     }
 
     // §4.3a (PROPOSED, v0.31): the explicit negative scope. Two lints, both warnings —
-    // a forbid never widens anything, so a slip here fails safe, but a slip is still
+    // a deny never widens anything, so a slip here fails safe, but a slip is still
     // worth naming:
-    //  - an empty `forbid` prohibits nothing (an authoring slip: the author reached for
+    //  - an empty `deny` prohibits nothing (an authoring slip: the author reached for
     //    a prohibition and declared none);
-    //  - a token that is BOTH allowed and forbidden. Forbid overrides allow, fail-closed,
+    //  - a token that is BOTH allowed and forbidden. Deny overrides allow, fail-closed,
     //    so the allow entry is dead — the scope reads wider than it enforces. Naming the
-    //    exact contradiction lets the author drop the allow (or the forbid). A forbid that
+    //    exact contradiction lets the author drop the allow (or the deny). A deny that
     //    is a narrower glob of an allow (schema/** allowed, schema/secrets/** forbidden)
     //    is the intended carve-out and is NOT flagged; only an exact-token collision is.
-    const forbid = unit.action_scope?.forbid;
-    if (forbid !== undefined) {
+    const deny = unit.action_scope?.deny;
+    if (deny !== undefined) {
       const forbidsAnything =
-        (forbid.tools?.length ?? 0) > 0 ||
-        (forbid.paths?.length ?? 0) > 0 ||
-        (forbid.capabilities?.length ?? 0) > 0;
+        (deny.tools?.length ?? 0) > 0 ||
+        (deny.paths?.length ?? 0) > 0 ||
+        (deny.capabilities?.length ?? 0) > 0;
       if (!forbidsAnything) {
         warnings.push(
-          `${ctx}: 'action_scope.forbid' is declared but empty — it prohibits nothing (§4.3a)`
+          `${ctx}: 'action_scope.deny' is declared but empty — it prohibits nothing (§4.3a)`
         );
       }
       for (const dim of ["tools", "paths", "capabilities"] as const) {
         const allowed = new Set(unit.action_scope?.[dim] ?? []);
-        for (const token of forbid[dim] ?? []) {
+        for (const token of deny[dim] ?? []) {
           if (allowed.has(token)) {
             warnings.push(
-              `${ctx}: 'action_scope.${dim}' allows '${token}' while 'forbid.${dim}' denies it — the allow entry is neutralized; forbid overrides allow, fail-closed (§4.3a)`
+              `${ctx}: 'action_scope.${dim}' allows '${token}' while 'deny.${dim}' denies it — the allow entry is neutralized; deny overrides allow, fail-closed (§4.3a)`
             );
           }
         }


### PR DESCRIPTION
> Autonomous TDD contribution toward native-KCP runtime enforcement — please review before merge.

**Status: SPEC PROPOSAL for design review.** This extends the KCP spec, so it is intentionally minimal, pattern-matched to existing fields, and reviewed for shape — not auto-merged. SPEC's version header stays at `0.30`; the new fields are marked `PROPOSED (v0.31)`, so no release cascade (version sets, package versions, own-manifest minor) is triggered.

## The gap

A `kind: skill` unit (§4.3a) declares an `action_scope` **allowlist** and can be pulled under a `grant_ceiling` — but two things a downstream KCP consumer needs to enforce a skill's *own* limits at runtime were missing:

1. No documented, first-class way for a skill to carry its **own authority ceiling** and have that ceiling participate in the §3.13 multi-source MIN.
2. No **negative scope** — a skill could only say what it *may* touch (allowlist), never what it *must not*, so a prohibited hole inside an allowed region had to be expressed by enumerating the complement.

## The red test (written first, failed on the current tree)

`cli/src/skill-negative-scope.test.ts`, failing for the right reasons on the pre-change tree:

- `action_scope.forbid` was dropped by the parser → `scope.forbid` was `undefined`.
- `forbidsToken` was not exported → `TypeError: forbidsToken is not a function`.
- no forbid-overrides-allow overlap warning; no empty-forbid warning.

```
Tests  4 failed | 2 passed (6)
  × round-trips forbid alongside the allowlist        (expected undefined to be defined)
  × forbidsToken adjudicates fail-closed              (forbidsToken is not a function)
  × catches an over-broad allow that a forbid denies  (no warning)
  × warns on an empty forbid — prohibits nothing      (no warning)
```

The 2 that passed on the current tree are the authority_level round-trip/scale checks — pinning that a skill's own `authority_level` already parses and scale-validates, and resolves through a `grant_ceiling` `unit_ref`.

## The fix (minimal, fail-closed)

**1. A skill's own `authority_level` is a `grant_ceiling` source.** The field already parses and is scale-checked on any unit (§4.23). SPEC §4.3a now states that on a `kind: skill` it names the skill's own capability ceiling and, via a `grant_ceiling` source's `unit_ref` (§3.13), contributes to the multi-source minimum — the effective level can never exceed it. Absence stays non-binding (absence is not a grant). No code change was needed for this to hold; tests pin it.

**2. `action_scope.forbid` — explicit negative scope.** Same `{tools, paths, capabilities}` shape as the allowlist; every entry is a prohibition, checked **in addition to and overriding** the allowlist. A forbidden token is denied even when allowlisted (fail-closed) — a denylist can only *narrow* what the allowlist bounded, never widen it. A `forbid` that is a narrower glob of an allow (`schema/**` allowed, `schema/secrets/**` forbidden) is the intended carve-out; an exact-token collision neutralizes that allow.

Surface:
- **SPEC.md §4.3a** — field table, MIN participation, fail-closed override semantics, worked YAML.
- **schema/knowledge-schema.json** — `action_scope.forbid`.
- **shared/src/model.ts** — `ForbidScope`; `ActionScope.forbid`.
- **shared/src/parser.ts** — `parseForbidScope`, wired into `parseActionScope`.
- **shared/src/validator.ts** — exported `forbidsToken(scope, dimension, token)` adjudication helper (one rule shared by the lint and any runtime enforcer), plus two lints: empty-`forbid` prohibits-nothing, and forbid-overrides-allow overlap. Neither weakens a gate — both are warnings surfacing an authoring slip.
- **examples/skill-negative-scope/** — worked example; validates clean via the CLI (`✓ Valid — no errors or warnings`).

## Full-suite result (green)

- `cli` vitest: **197 passed** (191 baseline + 6 new).
- `bridge/typescript` vitest: **266 passed**.
- `bridge/typescript` build (the TS typecheck CI runs): **clean, exit 0**.
- The pre-existing `cli` `tsc` `rootDir` (TS6059) notices are identical on `origin/main` and are not run by CI — not introduced here.
- SPEC.md's `content_hash` in the repo's own `knowledge.yaml` refreshed so the manifest still validates against itself.

## Deferred (stated, not silently dropped)

Mirroring `parseForbidScope` into the **Python and Java** parsers, to follow once the proposal's shape is accepted. Cross-language consistency tests check version sets and content hashes, not field parity, so all languages stay green in the meantime.
