### PR TITLE
release: KCP v0.31 — RFC-0029 skill authority + action_scope.deny across all languages

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knowledge Context Protocol (KCP) Specification
 
-**Version:** 0.30
+**Version:** 0.31
 **Status:** Draft
 **Date:** 2026-07-24
 **Repository:** github.com/cantara/knowledge-context-protocol
@@ -1816,9 +1816,9 @@ by default like `executable`/`service`: absent an explicit eligibility grant it 
 pointer with `invocation: explicit` (§16.3, C4). Skills are the manifest-declared counterpart of
 the runtime-depth lifecycle recorded in §17 (`skill_selected` … `verdict_emitted`).
 
-#### 4.3a — skill authority ceiling and negative scope (PROPOSED, v0.31)
+#### 4.3a — skill authority ceiling and negative scope (v0.31)
 
-> **Status: PROPOSED for design review.** This subsection extends the `kind: skill`
+> **Added in v0.31 (RFC-0029).** This subsection extends the `kind: skill`
 > envelope with two capabilities a downstream KCP consumer needs to enforce a skill's
 > own limits at run time. It reuses the existing `authority_level` field and the existing
 > `action_scope` shape; no existing gate is weakened. It is fail-closed by construction.

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.30.3</version>
+    <version>0.31.0</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>no.cantara.kcp</groupId>
             <artifactId>kcp-parser</artifactId>
-            <version>0.30.0</version>
+            <version>0.31.0</version>
         </dependency>
 
         <!-- MCP Java SDK: core + Jackson 3 bundle -->

--- a/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpMapper.java
+++ b/bridge/java/src/main/java/no/cantara/kcp/mcp/KcpMapper.java
@@ -278,6 +278,20 @@ public final class KcpMapper {
                         scope.append("\"spend\":{").append(spend).append("}");
                     }
                 }
+                // §4.3a (v0.31, RFC-0029): the explicit negative scope. Surfaced so a
+                // consumer sees the prohibitions, not just the allowlist — a deny dropped
+                // at the bridge boundary reads as "no prohibition", the more permissive lie.
+                if (u.actionScope().deny() != null) {
+                    var dn = u.actionScope().deny();
+                    StringBuilder deny = new StringBuilder();
+                    appendArrayIfPresent(deny, "tools", dn.tools());
+                    appendArrayIfPresent(deny, "paths", dn.paths());
+                    appendArrayIfPresent(deny, "capabilities", dn.capabilities());
+                    if (deny.length() > 0) {
+                        if (scope.length() > 0) scope.append(",");
+                        scope.append("\"deny\":{").append(deny).append("}");
+                    }
+                }
                 if (scope.length() > 0) {
                     sb.append(",\"action_scope\":{").append(scope).append("}");
                 }

--- a/bridge/python/kcp_mcp/mapper.py
+++ b/bridge/python/kcp_mcp/mapper.py
@@ -202,6 +202,21 @@ def build_manifest_json(manifest: KnowledgeManifest, slug: str) -> str:
                         ("allowed_vendors", getattr(sp, "allowed_vendors", None)),
                     ) if v is not None
                 }
+            # §4.3a (v0.31, RFC-0029): the explicit negative scope. Surfaced so a
+            # consumer sees the prohibitions, not just the allowlist — a deny that is
+            # dropped at the bridge boundary reads as "no prohibition", the more
+            # permissive falsehood.
+            dn = getattr(u.action_scope, "deny", None)
+            if dn is not None:
+                deny_obj = {
+                    k: v for k, v in (
+                        ("tools", getattr(dn, "tools", None)),
+                        ("paths", getattr(dn, "paths", None)),
+                        ("capabilities", getattr(dn, "capabilities", None)),
+                    ) if v
+                }
+                if deny_obj:
+                    scope["deny"] = deny_obj
             if scope:
                 entry["action_scope"] = scope
         # §4.3c (v0.30): the grant deciding whether a governed procedure may act.

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.30.3"
+version = "0.31.0"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 keywords = ["kcp", "mcp", "knowledge", "ai-agents"]
 dependencies = [
-    "kcp>=0.30.0",
+    "kcp>=0.31.0",
     # Bounded below 2.0: mcp 2.0.0 replaced the Server handler-registration API
     # (Server.list_resources and friends), which fails 103 of this bridge's 170 tests.
     # The unbounded ">=1.0.0" let that major in silently and broke CI. Lifting the bound

--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.25.3",

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.30.3",
+  "version": "0.31.0",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.3",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.30.3",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^13.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.30.3",
+  "version": "0.31.0",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.30.3
+    `\nKCP Developer CLI — v0.31.0
 
 Usage: kcp <command> [options]
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -224,7 +224,7 @@ function yamlQuote(s: string): string {
 
 // Scaffolded manifests declare the spec version this CLI release implements.
 // Guarded against the validator's known-version list in consistency.test.ts.
-export const SCAFFOLD_KCP_VERSION = "0.30";
+export const SCAFFOLD_KCP_VERSION = "0.31";
 
 function writeManifest(
   outputPath: string,

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.30.3";
+export const RENDERER_VERSION = "kcp-cli 0.31.0";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -32,7 +32,7 @@ signing:
   signature: https://cantara.github.io/knowledge-context-protocol/knowledge.yaml.sig
 
 # Legacy header fields (preserved for consumers that read them directly)
-kcp_version: "0.30"
+kcp_version: "0.31"
 
 # §3.13 (v0.27): the fixed ordinal authority scale. Declaring it makes every
 # authority_level below a ceiling on this total order — and leaves the planner
@@ -69,7 +69,7 @@ units:
     triggers: [ spec, specification, fields, validation, conformance, yaml, format ]
     content_hash:
       algorithm: sha256
-      value: 4a75536a45d9d56b54714f7605c297f6edcb44f4a4b7fd97eed794b247b15f52
+      value: 57435b1a4bf49705f1ef3f2cc0870c5a1d393a29903088e32f225a06ad2b9e0b
 
   - id: proposal
     path: PROPOSAL.md

--- a/parsers/java/pom.xml
+++ b/parsers/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-parser</artifactId>
-    <version>0.30.0</version>
+    <version>0.31.0</version>
     <packaging>jar</packaging>
 
     <name>KCP Reference Parser</name>

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpParser.java
@@ -8,6 +8,7 @@ import no.cantara.kcp.model.Compliance;
 import no.cantara.kcp.model.ContentHash;
 import no.cantara.kcp.model.ContentStructure;
 import no.cantara.kcp.model.ActionScope;
+import no.cantara.kcp.model.DenyScope;
 import no.cantara.kcp.model.PlaybookStep;
 import no.cantara.kcp.model.Spend;
 import no.cantara.kcp.model.Delegation;
@@ -499,7 +500,25 @@ public class KcpParser {
                 asStringList(d.get("tools")),
                 asStringList(d.get("paths")),
                 asStringList(d.get("capabilities")),
-                parseSpend(d.get("spend")));
+                parseSpend(d.get("spend")),
+                parseDenyScope(d.get("deny")));
+    }
+
+    /**
+     * §4.3a (v0.31, RFC-0029): the explicit negative scope a {@code kind: skill} declares.
+     *
+     * <p>Same {@code {tools, paths, capabilities}} shape as the allowlist; every entry is a
+     * prohibition. Mirrors {@link #parseActionScope}'s leniency — anything that is not a map
+     * yields null ("declares no prohibition") rather than failing the whole parse.
+     */
+    @SuppressWarnings("unchecked")
+    private static DenyScope parseDenyScope(Object raw) {
+        if (!(raw instanceof Map<?, ?> m)) return null;
+        Map<String, Object> d = (Map<String, Object>) m;
+        return new DenyScope(
+                asStringList(d.get("tools")),
+                asStringList(d.get("paths")),
+                asStringList(d.get("capabilities")));
     }
 
     @SuppressWarnings("unchecked")

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -13,6 +13,7 @@ import no.cantara.kcp.model.GrantCeilingSource;
 import no.cantara.kcp.model.HumanInTheLoop;
 import no.cantara.kcp.model.KnowledgeManifest;
 import no.cantara.kcp.model.ActionScope;
+import no.cantara.kcp.model.DenyScope;
 import no.cantara.kcp.model.KnowledgeUnit;
 import no.cantara.kcp.model.PlaybookStep;
 import no.cantara.kcp.model.AgentIdentity;
@@ -68,7 +69,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");
@@ -338,6 +339,27 @@ public class KcpValidator {
                 errors.add(ctx + ": kind 'skill' with 'load_eligible: true' MUST declare"
                         + " an 'action_scope' — it is authorised to act and bounded in"
                         + " nothing (§4.3c)");
+            }
+
+            // §4.3a (v0.31, RFC-0029): the explicit negative scope. Two lints, both
+            // warnings — a deny never widens anything, so a slip here fails safe, but a
+            // slip is still worth naming: an empty deny prohibits nothing; a token BOTH
+            // allowed and forbidden leaves a dead allow (deny overrides allow,
+            // fail-closed). A deny that is a narrower glob of an allow is the intended
+            // carve-out and is NOT flagged; only an exact-token collision is.
+            ActionScope ownScope = unit.actionScope();
+            DenyScope ownDeny = ownScope != null ? ownScope.deny() : null;
+            if (ownDeny != null) {
+                boolean forbidsAnything =
+                        (ownDeny.tools() != null && !ownDeny.tools().isEmpty())
+                        || (ownDeny.paths() != null && !ownDeny.paths().isEmpty())
+                        || (ownDeny.capabilities() != null && !ownDeny.capabilities().isEmpty());
+                if (!forbidsAnything) {
+                    warnings.add(ctx + ": 'action_scope.deny' is declared but empty — it prohibits nothing (§4.3a)");
+                }
+                checkDenyOverlap(ctx, "tools", ownScope.tools(), ownDeny.tools(), warnings);
+                checkDenyOverlap(ctx, "paths", ownScope.paths(), ownDeny.paths(), warnings);
+                checkDenyOverlap(ctx, "capabilities", ownScope.capabilities(), ownDeny.capabilities(), warnings);
             }
 
             if (!"playbook".equals(kind)) {
@@ -881,6 +903,40 @@ public class KcpValidator {
         if (level != null && !knownAuthorityLevels.isEmpty() && !knownAuthorityLevels.contains(level)) {
             warnings.add(ctx + ": 'authority_level' value '" + level + "' is not in the declared 'authority_level_scale'");
         }
+    }
+
+    /**
+     * §4.3a (v0.31, RFC-0029): warn when a token is both allowlisted and forbidden on the same
+     * dimension. Deny overrides allow, fail-closed, so the allow entry is dead — the scope reads
+     * wider than it enforces. Only exact-token collisions are flagged; a narrower deny glob of a
+     * broader allow (schema/** allowed, schema/secrets/** forbidden) is the intended carve-out.
+     */
+    private static void checkDenyOverlap(String ctx, String dim, List<String> allow, List<String> deny, List<String> warnings) {
+        if (deny == null || deny.isEmpty()) return;
+        Set<String> allowed = allow != null ? new HashSet<>(allow) : Set.of();
+        for (String token : deny) {
+            if (allowed.contains(token)) {
+                warnings.add(ctx + ": 'action_scope." + dim + "' allows '" + token + "' while 'deny." + dim
+                        + "' denies it — the allow entry is neutralized; deny overrides allow, fail-closed (§4.3a)");
+            }
+        }
+    }
+
+    /**
+     * §4.3a (v0.31, RFC-0029): does a skill's {@code action_scope.deny} deny {@code token} on
+     * {@code dimension}? Fail-closed override — a deny entry denies the token even when the
+     * allowlist grants it. Exact-string match. Mirrors {@code deniesToken} in the TypeScript
+     * validator, so a runtime enforcer and the validator's overlap lint share one rule.
+     */
+    public static boolean deniesToken(ActionScope scope, String dimension, String token) {
+        if (scope == null || scope.deny() == null) return false;
+        List<String> values = switch (dimension) {
+            case "tools" -> scope.deny().tools();
+            case "paths" -> scope.deny().paths();
+            case "capabilities" -> scope.deny().capabilities();
+            default -> null;
+        };
+        return values != null && values.contains(token);
     }
 
     /**

--- a/parsers/java/src/main/java/no/cantara/kcp/model/ActionScope.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/ActionScope.java
@@ -16,7 +16,8 @@ public record ActionScope(
         List<String> tools,        // tool names the procedure may invoke
         List<String> paths,        // paths (globs permitted) it may read or write
         List<String> capabilities, // named capabilities it requires or exercises
-        Spend spend                // purchases it may make (§4.3a.1)
+        Spend spend,               // purchases it may make (§4.3a.1)
+        DenyScope deny             // §4.3a (v0.31, RFC-0029) — explicit prohibitions; override the allowlist, fail-closed
 ) {
     public ActionScope {
         tools = tools != null ? List.copyOf(tools) : null;

--- a/parsers/java/src/main/java/no/cantara/kcp/model/DenyScope.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/model/DenyScope.java
@@ -1,0 +1,23 @@
+package no.cantara.kcp.model;
+
+import java.util.List;
+
+/**
+ * Explicit negative scope on a {@code kind: skill} action_scope. See SPEC.md §4.3a (v0.31, RFC-0029).
+ *
+ * <p>Same {@code {tools, paths, capabilities}} shape as the allowlist, but every entry is a
+ * PROHIBITION: a token listed here is denied even when the allowlist grants it. {@code deny}
+ * is checked in addition to — and overrides — the allowlist, fail-closed. Mirrors
+ * {@code shared/src/parser.ts} {@code parseDenyScope}.
+ */
+public record DenyScope(
+        List<String> tools,        // tool names the procedure MUST NOT invoke, even if allowlisted
+        List<String> paths,        // paths (globs permitted) it MUST NOT touch, even if allowlisted
+        List<String> capabilities  // named capabilities it MUST NOT exercise, even if allowlisted
+) {
+    public DenyScope {
+        tools = tools != null ? List.copyOf(tools) : null;
+        paths = paths != null ? List.copyOf(paths) : null;
+        capabilities = capabilities != null ? List.copyOf(capabilities) : null;
+    }
+}

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpSkillNegativeScopeTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpSkillNegativeScopeTest.java
@@ -1,0 +1,154 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.ActionScope;
+import no.cantara.kcp.model.KnowledgeManifest;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * §4.3a skill negative scope + own authority ceiling (v0.31, RFC-0029).
+ *
+ * <p>Mirrors cli/src/skill-negative-scope.test.ts and
+ * parsers/python/tests/test_skill_negative_scope.py, so the three stay in cross-language
+ * parity. Two capabilities a downstream KCP consumer needs from a {@code kind: skill} unit:
+ *
+ * <ol>
+ *   <li>The skill carries its OWN {@code authority_level} — its capability ceiling — so it
+ *       participates as a {@code grant_ceiling} source (§3.13) in the multi-source MIN.</li>
+ *   <li>{@code action_scope.deny} — an explicit negative scope with the same
+ *       {tools, paths, capabilities} shape as the allowlist. A deny entry is DENIED even
+ *       when the allowlist would grant it: deny overrides allow, fail-closed.</li>
+ * </ol>
+ */
+class KcpSkillNegativeScopeTest {
+
+    private static Map<String, Object> baseSkill() {
+        Map<String, Object> u = new HashMap<>();
+        u.put("id", "rotate-signing-key");
+        u.put("kind", "skill");
+        u.put("path", "skills/rotate.md");
+        u.put("intent", "How do I rotate the signing key safely?");
+        u.put("scope", "project");
+        u.put("audience", List.of("agent"));
+        u.put("load_eligible", true);
+        return u;
+    }
+
+    private static KnowledgeManifest manifest(List<Map<String, Object>> units, Map<String, Object> extra) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("project", "example");
+        m.put("version", "1.0.0");
+        m.put("kcp_version", "0.31");
+        m.put("authority_level_scale", List.of("observe", "explain", "suggest", "prepare", "commit"));
+        m.put("units", units);
+        if (extra != null) m.putAll(extra);
+        return KcpParser.fromMap(m);
+    }
+
+    @Test
+    void roundTripsDenyAlongsideAllowlist() {
+        Map<String, Object> skill = baseSkill();
+        Map<String, Object> deny = new HashMap<>();
+        deny.put("tools", List.of("shell"));
+        deny.put("paths", List.of("schema/secrets/**"));
+        deny.put("capabilities", List.of("network"));
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("tools", List.of("kcp-sign", "git"));
+        scope.put("paths", List.of("schema/**"));
+        scope.put("capabilities", List.of("key-management"));
+        scope.put("deny", deny);
+        skill.put("action_scope", scope);
+
+        KnowledgeManifest m = manifest(List.of(skill), null);
+        ActionScope as = m.units().get(0).actionScope();
+        assertEquals(List.of("kcp-sign", "git"), as.tools());
+        assertNotNull(as.deny());
+        assertEquals(List.of("shell"), as.deny().tools());
+        assertEquals(List.of("schema/secrets/**"), as.deny().paths());
+        assertEquals(List.of("network"), as.deny().capabilities());
+        // a well-formed deny + allow validates clean
+        assertTrue(KcpValidator.validate(m).isValid());
+    }
+
+    @Test
+    void deniesTokenAdjudicatesFailClosed() {
+        Map<String, Object> skill = baseSkill();
+        skill.put("action_scope", Map.of(
+                "tools", List.of("git", "shell"),
+                "deny", Map.of("tools", List.of("shell"))));
+        KnowledgeManifest m = manifest(List.of(skill), null);
+        ActionScope as = m.units().get(0).actionScope();
+        assertTrue(KcpValidator.deniesToken(as, "tools", "shell"));
+        assertFalse(KcpValidator.deniesToken(as, "tools", "git"));
+    }
+
+    @Test
+    void catchesOverBroadAllowThatDenyDenies() {
+        // 'shell' is both granted and forbidden — the allow is dead, deny wins.
+        Map<String, Object> skill = baseSkill();
+        skill.put("action_scope", Map.of(
+                "tools", List.of("git", "shell"),
+                "deny", Map.of("tools", List.of("shell"))));
+        KcpValidator.ValidationResult r = KcpValidator.validate(manifest(List.of(skill), null));
+        boolean hit = r.warnings().stream()
+                .anyMatch(w -> w.contains("deny") && w.contains("shell") && w.contains("§4.3a"));
+        assertTrue(hit, "expected a deny-overrides-allow warning, got: " + r.warnings());
+    }
+
+    @Test
+    void warnsOnEmptyDeny() {
+        Map<String, Object> skill = baseSkill();
+        skill.put("action_scope", Map.of(
+                "tools", List.of("git"),
+                "deny", new HashMap<String, Object>()));
+        KcpValidator.ValidationResult r = KcpValidator.validate(manifest(List.of(skill), null));
+        boolean hit = r.warnings().stream()
+                .anyMatch(w -> w.contains("deny") && w.contains("prohibits nothing"));
+        assertTrue(hit, "expected an empty-deny warning, got: " + r.warnings());
+    }
+
+    @Test
+    void roundTripsAuthorityLevelOnSkillAndScaleChecksIt() {
+        Map<String, Object> skill = baseSkill();
+        skill.put("authority_level", "prepare");
+        skill.put("action_scope", Map.of("tools", List.of("kcp-sign")));
+        KnowledgeManifest m = manifest(List.of(skill), null);
+        assertEquals("prepare", m.units().get(0).authorityLevel());
+        assertTrue(KcpValidator.validate(m).isValid());
+
+        // a value off the declared scale warns
+        Map<String, Object> skill2 = baseSkill();
+        skill2.put("authority_level", "yolo");
+        skill2.put("action_scope", Map.of("tools", List.of("kcp-sign")));
+        KcpValidator.ValidationResult r2 = KcpValidator.validate(manifest(List.of(skill2), null));
+        assertTrue(r2.warnings().stream().anyMatch(w -> w.contains("authority_level") && w.contains("yolo")));
+    }
+
+    @Test
+    void skillAuthorityLevelResolvesThroughGrantCeilingUnitRef() {
+        Map<String, Object> skill = baseSkill();
+        skill.put("authority_level", "suggest");
+        skill.put("action_scope", Map.of("tools", List.of("kcp-sign")));
+
+        Map<String, Object> src1 = new HashMap<>();
+        src1.put("id", "org-policy");
+        src1.put("authority_level", "prepare");
+        Map<String, Object> src2 = new HashMap<>();
+        src2.put("id", "skill-ceiling");
+        src2.put("unit_ref", "rotate-signing-key");
+        List<Object> sources = new ArrayList<>(List.of(src1, src2));
+
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("grant_ceiling", Map.of("sources", sources));
+
+        KcpValidator.ValidationResult r = KcpValidator.validate(manifest(List.of(skill), extra));
+        assertTrue(r.errors().stream().noneMatch(e -> e.contains("unit_ref")));
+        assertTrue(r.isValid());
+    }
+}

--- a/parsers/python/kcp/model.py
+++ b/parsers/python/kcp/model.py
@@ -140,6 +140,20 @@ class Spend:
 
 
 @dataclass
+class DenyScope:
+    """Explicit negative scope on a ``kind: skill`` action_scope. See SPEC.md §4.3a (v0.31, RFC-0029).
+
+    Same ``{tools, paths, capabilities}`` shape as the allowlist, but every entry is a
+    PROHIBITION: a token listed here is denied even when the allowlist grants it. ``deny``
+    is checked in addition to — and overrides — the allowlist, fail-closed. Mirrors
+    ``shared/src/parser.ts`` ``parseDenyScope``.
+    """
+    tools: Optional[List[str]] = None  # tool names the procedure MUST NOT invoke, even if allowlisted
+    paths: Optional[List[str]] = None  # paths (globs permitted) it MUST NOT touch, even if allowlisted
+    capabilities: Optional[List[str]] = None  # named capabilities it MUST NOT exercise, even if allowlisted
+
+
+@dataclass
 class ActionScope:
     """The envelope bounding a ``kind: skill`` unit. See SPEC.md §4.3a.
 
@@ -151,6 +165,7 @@ class ActionScope:
     paths: Optional[List[str]] = None  # paths (globs permitted) it may read or write
     capabilities: Optional[List[str]] = None  # named capabilities it requires or exercises
     spend: Optional[Spend] = None  # purchases it may make (§4.3a.1)
+    deny: Optional[DenyScope] = None  # §4.3a (v0.31, RFC-0029) — explicit prohibitions; override the allowlist, fail-closed
 
 
 @dataclass

--- a/parsers/python/kcp/parser.py
+++ b/parsers/python/kcp/parser.py
@@ -7,7 +7,7 @@ import re
 import yaml
 
 from .model import (
-    ActionScope,
+    ActionScope, DenyScope,
     Agent, AgentIdentity, Auth, AuthMethod, Authority, Compliance, ContentHash, ContentStructure,
     Delegation, Discovery, ExternalDependency, ExternalRelationship, FreshnessPolicy,
     GrantCeiling, GrantCeilingSource, KnowledgeManifest, KnowledgeUnit, ManifestRef, Payment,
@@ -265,6 +265,20 @@ def _parse_escalation(raw) -> Optional[List[str]]:
     return None
 
 
+def _parse_deny_scope(data: Optional[dict]) -> Optional["DenyScope"]:
+    # §4.3a (v0.31, RFC-0029): the explicit negative scope a kind: skill declares.
+    # Same {tools, paths, capabilities} shape as the allowlist; every entry is a
+    # prohibition. Mirrors _parse_action_scope's leniency — anything that is not an
+    # object yields None ("declares no prohibition") rather than failing the whole parse.
+    if not isinstance(data, dict):
+        return None
+    return DenyScope(
+        tools=data.get("tools"),
+        paths=data.get("paths"),
+        capabilities=data.get("capabilities"),
+    )
+
+
 def _parse_action_scope(data: Optional[dict]) -> Optional["ActionScope"]:
     # A scalar or list where an object belongs yields None rather than raising: a
     # malformed envelope must not take down the whole parse, and None correctly reads
@@ -276,6 +290,7 @@ def _parse_action_scope(data: Optional[dict]) -> Optional["ActionScope"]:
         paths=data.get("paths"),
         capabilities=data.get("capabilities"),
         spend=_parse_spend(data.get("spend")),
+        deny=_parse_deny_scope(data.get("deny")),
     )
 
 

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -95,7 +95,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}
@@ -201,6 +201,18 @@ def _find_step_cycle(steps) -> Optional[list]:
                 colour[dep] = GREY
                 stack.append([dep, 0])
     return None
+
+
+def denies_token(scope, dimension: str, token: str) -> bool:
+    """§4.3a (v0.31, RFC-0029): does a skill's ``action_scope.deny`` deny ``token`` on
+    ``dimension``? Fail-closed override — a deny entry denies the token even when the
+    allowlist grants it. Exact-string match. Mirrors ``deniesToken`` in the TypeScript
+    validator, so a runtime enforcer and the validator's overlap lint share one rule.
+    """
+    if scope is None or getattr(scope, "deny", None) is None:
+        return False
+    values = getattr(scope.deny, dimension, None)
+    return bool(values) and token in values
 
 
 def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) -> ValidationResult:
@@ -472,6 +484,32 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
                 f"{ctx}: kind 'skill' with 'load_eligible: true' MUST declare an "
                 f"'action_scope' — it is authorised to act and bounded in nothing (§4.3c)"
             )
+
+        # §4.3a (v0.31, RFC-0029): the explicit negative scope. Two lints, both warnings —
+        # a deny never widens anything, so a slip here fails safe, but a slip is still
+        # worth naming:
+        #  - an empty ``deny`` prohibits nothing (an authoring slip: the author reached
+        #    for a prohibition and declared none);
+        #  - a token that is BOTH allowed and forbidden. Deny overrides allow, fail-closed,
+        #    so the allow entry is dead — the scope reads wider than it enforces. A deny
+        #    that is a narrower glob of an allow (schema/** allowed, schema/secrets/**
+        #    forbidden) is the intended carve-out and is NOT flagged; only an exact-token
+        #    collision is.
+        deny = unit.action_scope.deny if unit.action_scope is not None else None
+        if deny is not None:
+            forbids_anything = bool(deny.tools or deny.paths or deny.capabilities)
+            if not forbids_anything:
+                warnings.append(
+                    f"{ctx}: 'action_scope.deny' is declared but empty — it prohibits nothing (§4.3a)"
+                )
+            for dim in ("tools", "paths", "capabilities"):
+                allowed = set(getattr(unit.action_scope, dim) or [])
+                for token in getattr(deny, dim) or []:
+                    if token in allowed:
+                        warnings.append(
+                            f"{ctx}: 'action_scope.{dim}' allows '{token}' while 'deny.{dim}' denies it "
+                            f"— the allow entry is neutralized; deny overrides allow, fail-closed (§4.3a)"
+                        )
 
         if (unit.kind or "knowledge") != "playbook":
             # steps on a non-playbook is a category error, not a silent no-op: the

--- a/parsers/python/pyproject.toml
+++ b/parsers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp"
-version = "0.30.0"
+version = "0.31.0"
 description = "Knowledge Context Protocol — reference parser and validator"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/parsers/python/tests/test_skill_negative_scope.py
+++ b/parsers/python/tests/test_skill_negative_scope.py
@@ -1,0 +1,120 @@
+"""§4.3a skill negative scope + own authority ceiling (v0.31, RFC-0029).
+
+Mirrors cli/src/skill-negative-scope.test.ts. Two capabilities a downstream KCP
+consumer needs from a ``kind: skill`` unit:
+
+ 1. The skill carries its OWN ``authority_level`` — its capability ceiling — so it
+    participates as a ``grant_ceiling`` source (§3.13) in the multi-source MIN.
+ 2. ``action_scope.deny`` — an explicit negative scope with the same
+    {tools, paths, capabilities} shape as the allowlist. A deny entry is DENIED even
+    when the allowlist would grant it: deny overrides allow, fail-closed.
+"""
+
+from kcp.parser import parse_dict
+from kcp.validator import validate, denies_token
+
+
+def _manifest(units, **extra):
+    raw = {
+        "project": "example",
+        "version": "1.0.0",
+        "kcp_version": "0.31",
+        "authority_level_scale": ["observe", "explain", "suggest", "prepare", "commit"],
+        "units": units,
+    }
+    raw.update(extra)
+    return parse_dict(raw)
+
+
+BASE_SKILL = {
+    "id": "rotate-signing-key",
+    "kind": "skill",
+    "path": "skills/rotate.md",
+    "intent": "How do I rotate the signing key safely?",
+    "scope": "project",
+    "audience": ["agent"],
+    "load_eligible": True,
+}
+
+
+def test_round_trips_deny_alongside_allowlist():
+    m = _manifest([
+        {
+            **BASE_SKILL,
+            "action_scope": {
+                "tools": ["kcp-sign", "git"],
+                "paths": ["schema/**"],
+                "capabilities": ["key-management"],
+                "deny": {
+                    "tools": ["shell"],
+                    "paths": ["schema/secrets/**"],
+                    "capabilities": ["network"],
+                },
+            },
+        }
+    ])
+    scope = m.units[0].action_scope
+    assert scope.tools == ["kcp-sign", "git"]
+    assert scope.deny is not None
+    assert scope.deny.tools == ["shell"]
+    assert scope.deny.paths == ["schema/secrets/**"]
+    assert scope.deny.capabilities == ["network"]
+    # a well-formed deny + allow validates clean
+    assert validate(m).is_valid
+
+
+def test_denies_token_adjudicates_fail_closed():
+    m = _manifest([
+        {**BASE_SKILL, "action_scope": {"tools": ["git", "shell"], "deny": {"tools": ["shell"]}}}
+    ])
+    scope = m.units[0].action_scope
+    assert denies_token(scope, "tools", "shell") is True
+    assert denies_token(scope, "tools", "git") is False
+
+
+def test_catches_over_broad_allow_that_deny_denies():
+    # 'shell' is both granted and forbidden — the allow is dead, deny wins.
+    m = _manifest([
+        {**BASE_SKILL, "action_scope": {"tools": ["git", "shell"], "deny": {"tools": ["shell"]}}}
+    ])
+    r = validate(m)
+    hit = [w for w in r.warnings if "deny" in w and "shell" in w and "§4.3a" in w]
+    assert hit, f"expected a deny-overrides-allow warning, got: {r.warnings}"
+
+
+def test_warns_on_empty_deny():
+    m = _manifest([
+        {**BASE_SKILL, "action_scope": {"tools": ["git"], "deny": {}}}
+    ])
+    r = validate(m)
+    hit = [w for w in r.warnings if "deny" in w and "prohibits nothing" in w]
+    assert hit, f"expected an empty-deny warning, got: {r.warnings}"
+
+
+def test_round_trips_authority_level_on_skill_and_scale_checks_it():
+    m = _manifest([
+        {**BASE_SKILL, "authority_level": "prepare", "action_scope": {"tools": ["kcp-sign"]}}
+    ])
+    assert m.units[0].authority_level == "prepare"
+    assert validate(m).is_valid
+    # a value off the declared scale warns
+    m2 = _manifest([
+        {**BASE_SKILL, "authority_level": "yolo", "action_scope": {"tools": ["kcp-sign"]}}
+    ])
+    r2 = validate(m2)
+    assert any("authority_level" in w and "yolo" in w for w in r2.warnings)
+
+
+def test_skill_authority_level_resolves_through_grant_ceiling_unit_ref():
+    m = _manifest(
+        [{**BASE_SKILL, "authority_level": "suggest", "action_scope": {"tools": ["kcp-sign"]}}],
+        grant_ceiling={
+            "sources": [
+                {"id": "org-policy", "authority_level": "prepare"},
+                {"id": "skill-ceiling", "unit_ref": "rotate-signing-key"},
+            ],
+        },
+    )
+    r = validate(m)
+    assert not [e for e in r.errors if "unit_ref" in e]
+    assert r.is_valid

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "kcp_version": {
       "type": "string",
-      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.30\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.28\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
-      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30"]
+      "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.31\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.30\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
+      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31"]
     },
     "project": {
       "type": "string",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kcp/shared",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kcp/shared",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kcp/shared",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.31.0",
   "type": "module",
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/shared/src/model.ts
+++ b/shared/src/model.ts
@@ -133,7 +133,7 @@ export interface Spend {
 }
 
 /**
- * Explicit negative scope on a `kind: skill` action_scope. See SPEC.md §4.3a (PROPOSED, v0.31).
+ * Explicit negative scope on a `kind: skill` action_scope. See SPEC.md §4.3a (v0.31, RFC-0029).
  *
  * Same {tools, paths, capabilities} shape as the allowlist, but every entry is a
  * PROHIBITION: a token listed here is denied even when the allowlist grants it.
@@ -151,7 +151,7 @@ export interface ActionScope {
   paths?: string[];         // file-system paths (globs permitted) the procedure may read/write
   capabilities?: string[];  // named capabilities the procedure requires or exercises
   spend?: Spend;            // purchases the procedure may make (per-purchase cap + vendor allowlist)
-  deny?: DenyScope;     // §4.3a (PROPOSED, v0.31) — explicit prohibitions; override the allowlist, fail-closed
+  deny?: DenyScope;     // §4.3a (v0.31, RFC-0029) — explicit prohibitions; override the allowlist, fail-closed
 }
 
 /**

--- a/shared/src/parser.ts
+++ b/shared/src/parser.ts
@@ -545,7 +545,7 @@ function parseActionScope(raw: unknown): ActionScope | undefined {
 }
 
 /**
- * §4.3a (PROPOSED, v0.31): the explicit negative scope a `kind: skill` declares.
+ * §4.3a (v0.31, RFC-0029): the explicit negative scope a `kind: skill` declares.
  *
  * Same {tools, paths, capabilities} shape as the allowlist; every entry is a
  * prohibition. Mirrors parseActionScope's leniency — anything that is not an object

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -162,6 +162,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.28",
   "0.29",
   "0.30",
+  "0.31",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([
@@ -222,7 +223,7 @@ function supersededCycleIds(successor: Map<string, string>): string[] {
 }
 
 /**
- * §4.3a (PROPOSED, v0.31): does a skill's `action_scope.deny` deny `token` on
+ * §4.3a (v0.31, RFC-0029): does a skill's `action_scope.deny` deny `token` on
  * `dimension`? Fail-closed override — a deny entry denies the token even when the
  * allowlist grants it. Exact-string match. Exported so a runtime enforcer and the
  * validator's overlap lint share one adjudication rule, the way §4.3a.1 `spend` and
@@ -535,7 +536,7 @@ export function validate(
       );
     }
 
-    // §4.3a (PROPOSED, v0.31): the explicit negative scope. Two lints, both warnings —
+    // §4.3a (v0.31, RFC-0029): the explicit negative scope. Two lints, both warnings —
     // a deny never widens anything, so a slip here fails safe, but a slip is still
     // worth naming:
     //  - an empty `deny` prohibits nothing (an authoring slip: the author reached for


### PR DESCRIPTION
> Autonomous cascade — please review before merge.

Promotes RFC-0029 (merged to main in #185) from **PROPOSED** to **v0.31** and bumps the current spec version `0.30 → 0.31` across all four language implementations, with the field parsing mirrored everywhere the reference (TS) already had it.

## Version bump — what moved vs what was left

**Moved (current-version constants + supported-version sets):**
- `SPEC.md` header `**Version:** 0.30 → 0.31`; §4.3a heading + status blockquote `PROPOSED, v0.31 → v0.31 (RFC-0029)`
- `knowledge.yaml` `kcp_version: 0.31`; `spec` unit `content_hash` recomputed against the edited SPEC.md
- `KNOWN_KCP_VERSIONS` gains `0.31` in all three validators (`shared/src/validator.ts`, `parsers/python/kcp/validator.py`, `parsers/java/.../KcpValidator.java`) and the `schema/knowledge-schema.json` `kcp_version` enum + "Current value" description
- Package/artifact versions → `0.31.0`: `shared`, `cli`, `bridge/typescript`, `bridge/python`, `parsers/python`, `parsers/java`, `bridge/java` (+ the three package-lock top-level versions)
- Bridge dependency pins → `0.31`: `bridge/python` `kcp>=0.31.0`, `bridge/java` `kcp-parser 0.31.0`
- `RENDERER_VERSION` (`kcp-cli 0.31.0`), CLI help banner (`v0.31.0`), `SCAFFOLD_KCP_VERSION` (`0.31`)

**Left untouched (historical references):** CHANGELOG entries, the version-drift prose/comments in `consistency.test.ts`, the `0.30` fixture input in `skill-negative-scope.test.ts` (0.30 remains a valid known version), and `magic-string 0.30.21` transitive dep lines. Prior versions `0.16–0.30` stay in the accepted enum/sets for backward compatibility.

## Parser mirror (Python + Java, matching shared/src TS semantics)
- `action_scope.deny` with the `{tools, paths, capabilities}` shape — new `DenyScope` model in Python and Java; wired through `parseActionScope`/`_parse_action_scope`
- Two warning-level validator lints: empty-`deny` (prohibits nothing) and deny-overrides-allow exact-token overlap (the allow entry is neutralized, fail-closed)
- `deniesToken`/`denies_token` fail-closed adjudicator exported to match TS
- A skill's own `authority_level` already parsed + scale-checked in all languages (verified; it feeds `grant_ceiling` via `unit_ref`)
- Bridge mappers (`bridge/python/kcp_mcp/mapper.py`, `bridge/java/.../KcpMapper.java`) now surface `deny` in the `action_scope` projection, matching the TS mapper's opaque passthrough

## TDD
Added `parsers/python/tests/test_skill_negative_scope.py` and `parsers/java/.../KcpSkillNegativeScopeTest.java`, mirroring `cli/src/skill-negative-scope.test.ts`: deny round-trip, deny-overrides-allow lint fires, empty-deny lint, `authority_level` scale-check + resolution through a `grant_ceiling` `unit_ref`.

## Per-suite results (all green)
| Suite | Result |
|---|---|
| cli (`vitest`) — incl. **consistency.test.ts** (version parity + content hashes) | 197/197 ✓ |
| bridge/typescript (`vitest`) | 266/266 ✓ |
| shared (`vitest`) | no own test files (0/0) — shared/src covered via cli + bridge symlinks |
| parsers/python (`pytest`) | 229 ✓ (6 new) |
| bridge/python (`pytest`) | 170 ✓ |
| parsers/java (`mvn test`) | 214 ✓ (6 new) |
| bridge/java (`mvn test`) | 175 ✓ |

`kcp validate` on the repo's own `knowledge.yaml` reports **✓ Valid — no errors or warnings** (53 units, kcp_version 0.31), confirming the SPEC.md content hash matches disk.

## Deferred
None — all four languages mirrored and all suites run in-sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)