### PR TITLE
release: KCP v0.32 — RFC-0030 playbook prohibitions + deny finality across all languages

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Knowledge Context Protocol (KCP) Specification
 
-**Version:** 0.31
+**Version:** 0.32
 **Status:** Draft
 **Date:** 2026-07-24
 **Repository:** github.com/cantara/knowledge-context-protocol
@@ -2070,9 +2070,9 @@ This requirement binds an actor rather than a field, so no validator can check i
 - A validator SHOULD warn when a step omits `authority_level` while its `uses` unit declares
   a mutating `action_scope`.
 
-#### 4.3b — playbook-level prohibitions and deny finality (PROPOSED, v0.32)
+#### 4.3b — playbook-level prohibitions and deny finality (v0.32)
 
-> **PROPOSED (RFC-0030), for design review.** This subsection makes one sub-object of the
+> **Added in v0.32 (RFC-0030).** This subsection makes one sub-object of the
 > playbook `action_scope` envelope normative and clarifies one §4.3a sentence. No existing
 > gate is weakened; fail-closed by construction.
 

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.31.0</version>
+    <version>0.32.0</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>no.cantara.kcp</groupId>
             <artifactId>kcp-parser</artifactId>
-            <version>0.31.0</version>
+            <version>0.32.0</version>
         </dependency>
 
         <!-- MCP Java SDK: core + Jackson 3 bundle -->

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.31.0"
+version = "0.32.0"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 keywords = ["kcp", "mcp", "knowledge", "ai-agents"]
 dependencies = [
-    "kcp>=0.31.0",
+    "kcp>=0.32.0",
     # Bounded below 2.0: mcp 2.0.0 replaced the Server handler-registration API
     # (Server.list_resources and friends), which fails 103 of this bridge's 170 tests.
     # The unbounded ">=1.0.0" let that major in silently and broke CI. Lifting the bound

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^13.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.31.0
+    `\nKCP Developer CLI — v0.32.0
 
 Usage: kcp <command> [options]
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -224,7 +224,7 @@ function yamlQuote(s: string): string {
 
 // Scaffolded manifests declare the spec version this CLI release implements.
 // Guarded against the validator's known-version list in consistency.test.ts.
-export const SCAFFOLD_KCP_VERSION = "0.31";
+export const SCAFFOLD_KCP_VERSION = "0.32";
 
 function writeManifest(
   outputPath: string,

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.31.0";
+export const RENDERER_VERSION = "kcp-cli 0.32.0";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -32,7 +32,7 @@ signing:
   signature: https://cantara.github.io/knowledge-context-protocol/knowledge.yaml.sig
 
 # Legacy header fields (preserved for consumers that read them directly)
-kcp_version: "0.31"
+kcp_version: "0.32"
 
 # §3.13 (v0.27): the fixed ordinal authority scale. Declaring it makes every
 # authority_level below a ceiling on this total order — and leaves the planner
@@ -69,7 +69,7 @@ units:
     triggers: [ spec, specification, fields, validation, conformance, yaml, format ]
     content_hash:
       algorithm: sha256
-      value: 7804c22147bdf31f05db156d0e166e9eaae3d9e9d9c8d041a28d82033206f175
+      value: a7364fbde57b73995d71f1dd2f1b612a239511d350ad36bb17a4121cbfaab814
 
   - id: proposal
     path: PROPOSAL.md

--- a/parsers/java/pom.xml
+++ b/parsers/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-parser</artifactId>
-    <version>0.31.0</version>
+    <version>0.32.0</version>
     <packaging>jar</packaging>
 
     <name>KCP Reference Parser</name>

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -69,7 +69,7 @@ public class KcpValidator {
     private static final Set<String> VALID_ACCESS_VALUES = Set.of("public", "authenticated", "restricted");
     private static final Set<String> VALID_SENSITIVITY_VALUES = Set.of("public", "internal", "confidential", "restricted");
     private static final Set<String> VALID_HITL_MECHANISMS = Set.of("oauth_consent", "uma", "custom");
-    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31");
+    private static final Set<String> KNOWN_KCP_VERSIONS = Set.of("0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31", "0.32");
     // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
     private static final Set<String> VALID_CONTENT_MODALITIES = Set.of("prose", "table", "code", "list", "diagram", "reference", "mixed");
     private static final Set<String> VALID_DENSITY = Set.of("sparse", "normal", "dense");
@@ -446,6 +446,32 @@ public class KcpValidator {
                         && !declaredLevels.contains(step.authorityLevel())) {
                     warnings.add(sctx + ": 'authority_level' value '" + step.authorityLevel()
                             + "' is not in the declared 'authority_level_scale' (§3.13)");
+                }
+
+                // §4.3b (v0.32, RFC-0030): a step whose used unit's allowlist is entirely
+                // contained in the effective deny (playbook deny ∪ skill deny) for a
+                // dimension is self-nullified on that dimension — it reads enactable but
+                // cannot act. A warning: denying never widens anything, so the slip fails
+                // safe, but a dead step is worth naming.
+                if (step.uses() != null) {
+                    KnowledgeUnit denyTarget = unitsById.get(step.uses());
+                    ActionScope targetScope = denyTarget != null ? denyTarget.actionScope() : null;
+                    if (targetScope != null) {
+                        for (String dim : List.of("tools", "paths", "capabilities")) {
+                            List<String> allowed = switch (dim) {
+                                case "tools" -> targetScope.tools();
+                                case "paths" -> targetScope.paths();
+                                default -> targetScope.capabilities();
+                            };
+                            if (allowed != null && !allowed.isEmpty()
+                                    && allowed.stream().allMatch(token -> effectiveDeniesToken(
+                                            java.util.Arrays.asList(unit.actionScope(), targetScope), dim, token))) {
+                                warnings.add(sctx + ": every '" + dim + "' entry '" + step.uses()
+                                        + "' allows is denied by the effective deny (playbook ∪ skill)"
+                                        + " — the step is self-nullified on '" + dim + "' (§4.3b, RFC-0030)");
+                            }
+                        }
+                    }
                 }
 
                 // A step whose unit can mutate but which declares no ceiling is bounded
@@ -937,6 +963,21 @@ public class KcpValidator {
             default -> null;
         };
         return values != null && values.contains(token);
+    }
+
+    /**
+     * §4.3b (v0.32, RFC-0030): does the UNION of deny lists deny {@code token} on
+     * {@code dimension}? The effective denylist for a playbook step is the union of the
+     * playbook's own {@code action_scope.deny} and the used skill's — a match in either
+     * denies, overriding any allow. Union is the only sound composition: adding a source
+     * can only refuse more, never less (the scope-axis mirror of the §3.13 lowest-of rule).
+     * Mirrors {@code effectiveDeniesToken} in the TypeScript validator.
+     */
+    public static boolean effectiveDeniesToken(List<ActionScope> scopes, String dimension, String token) {
+        for (ActionScope scope : scopes) {
+            if (deniesToken(scope, dimension, token)) return true;
+        }
+        return false;
     }
 
     /**

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpPlaybookNegativeScopeTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpPlaybookNegativeScopeTest.java
@@ -1,0 +1,175 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.ActionScope;
+import no.cantara.kcp.model.KnowledgeManifest;
+import no.cantara.kcp.model.KnowledgeUnit;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * §4.3b playbook-level prohibitions (v0.32, RFC-0030).
+ *
+ * <p>Mirrors cli/src/playbook-negative-scope.test.ts and
+ * parsers/python/tests/test_playbook_negative_scope.py, so the three stay in
+ * cross-language parity. A {@code kind: playbook} unit's {@code action_scope.deny} is a
+ * blanket prohibition over EVERY step — the one normative sub-object of the otherwise
+ * declarative playbook {@code action_scope} envelope. The effective denylist for a step
+ * is the UNION of the playbook's deny and the used skill's deny: a match in either
+ * denies, overriding any allow, fail-closed. Union is the only sound composition —
+ * adding a source can only refuse more (the scope-axis mirror of the §3.13 lowest-of).
+ */
+class KcpPlaybookNegativeScopeTest {
+
+    private static Map<String, Object> sletteagent() {
+        Map<String, Object> u = new HashMap<>();
+        u.put("id", "sletteagent");
+        u.put("kind", "skill");
+        u.put("path", "skills/sletteagent.md");
+        u.put("intent", "How do I delete customer data compliantly?");
+        u.put("scope", "project");
+        u.put("audience", List.of("agent"));
+        u.put("load_eligible", true);
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("tools", List.of("delete", "read"));
+        scope.put("paths", List.of("customers/**", "legal/hold/2025/**"));
+        scope.put("deny", Map.of("tools", List.of("transfer_ownership")));
+        u.put("action_scope", scope);
+        return u;
+    }
+
+    private static Map<String, Object> basePlaybook() {
+        Map<String, Object> u = new HashMap<>();
+        u.put("id", "pb-002-gdpr-sletting");
+        u.put("kind", "playbook");
+        u.put("path", "playbooks/gdpr-sletting.md");
+        u.put("intent", "How is a GDPR Art.17 deletion request executed?");
+        u.put("scope", "project");
+        u.put("audience", List.of("agent"));
+        u.put("load_eligible", true);
+        u.put("authority_level", "commit");
+        u.put("steps", List.of(Map.of("id", "slett", "uses", "sletteagent", "authority_level", "commit")));
+        return u;
+    }
+
+    private static KnowledgeManifest manifest(List<Map<String, Object>> units) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("project", "example");
+        m.put("version", "1.0.0");
+        m.put("kcp_version", "0.32");
+        m.put("authority_level_scale", List.of("observe", "explain", "suggest", "prepare", "commit"));
+        m.put("units", units);
+        return KcpParser.fromMap(m);
+    }
+
+    private static KnowledgeUnit unit(KnowledgeManifest m, String id) {
+        return m.units().stream().filter(u -> id.equals(u.id())).findFirst().orElseThrow();
+    }
+
+    @Test
+    void roundTripsDenyOnAPlaybook() {
+        Map<String, Object> pb = basePlaybook();
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("deny", Map.of(
+                "paths", List.of("legal/hold/**"),
+                "tools", List.of("transfer_ownership")));
+        pb.put("action_scope", scope);
+
+        KnowledgeManifest m = manifest(List.of(sletteagent(), pb));
+        ActionScope pbScope = unit(m, "pb-002-gdpr-sletting").actionScope();
+        assertNotNull(pbScope.deny());
+        assertEquals(List.of("legal/hold/**"), pbScope.deny().paths());
+        assertEquals(List.of("transfer_ownership"), pbScope.deny().tools());
+    }
+
+    @Test
+    void effectiveDenyIsTheUnion() {
+        Map<String, Object> pb = basePlaybook();
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("deny", Map.of(
+                "paths", List.of("legal/hold/**"),
+                "tools", List.of("set_billing")));
+        pb.put("action_scope", scope);
+
+        KnowledgeManifest m = manifest(List.of(sletteagent(), pb));
+        ActionScope pbScope = unit(m, "pb-002-gdpr-sletting").actionScope();
+        ActionScope skillScope = unit(m, "sletteagent").actionScope();
+        List<ActionScope> scopes = Arrays.asList(pbScope, skillScope);
+
+        // playbook-only match
+        assertTrue(KcpValidator.effectiveDeniesToken(scopes, "paths", "legal/hold/**"));
+        assertFalse(KcpValidator.deniesToken(skillScope, "paths", "legal/hold/**"));
+
+        // skill-only match
+        assertTrue(KcpValidator.effectiveDeniesToken(scopes, "tools", "transfer_ownership"));
+        assertFalse(KcpValidator.deniesToken(pbScope, "tools", "transfer_ownership"));
+
+        // neither — allowed tokens pass through
+        assertFalse(KcpValidator.effectiveDeniesToken(scopes, "tools", "read"));
+    }
+
+    @Test
+    void addingADenySourceNeverUnDenies() {
+        KnowledgeManifest m = manifest(List.of(sletteagent(), basePlaybook()));
+        ActionScope skillScope = unit(m, "sletteagent").actionScope();
+        assertTrue(KcpValidator.deniesToken(skillScope, "tools", "transfer_ownership"));
+        // a playbook that denies nothing cannot relax the skill's deny
+        assertTrue(KcpValidator.effectiveDeniesToken(
+                Arrays.asList(null, skillScope), "tools", "transfer_ownership"));
+    }
+
+    @Test
+    void warnsWhenAStepIsSelfNullified() {
+        Map<String, Object> pb = basePlaybook();
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("deny", Map.of("tools", List.of("delete", "read"))); // everything the skill allows
+        pb.put("action_scope", scope);
+
+        var result = KcpValidator.validate(manifest(List.of(sletteagent(), pb)), null);
+        assertTrue(result.warnings().stream()
+                .anyMatch(w -> w.contains("self-nullified") && w.contains("'tools'")));
+        // paths dimension is not fully denied — no warning there
+        assertFalse(result.warnings().stream()
+                .anyMatch(w -> w.contains("self-nullified") && w.contains("'paths'")));
+    }
+
+    @Test
+    void doesNotWarnWhenTheDenyOnlyCarvesAHole() {
+        Map<String, Object> pb = basePlaybook();
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("deny", Map.of("paths", List.of("legal/hold/**")));
+        pb.put("action_scope", scope);
+
+        var result = KcpValidator.validate(manifest(List.of(sletteagent(), pb)), null);
+        assertFalse(result.warnings().stream().anyMatch(w -> w.contains("self-nullified")));
+    }
+
+    @Test
+    void skillDenyAloneCanSelfNullifyAStep() {
+        Map<String, Object> skill = sletteagent();
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("tools", List.of("transfer_ownership"));
+        scope.put("deny", Map.of("tools", List.of("transfer_ownership")));
+        skill.put("action_scope", scope);
+
+        var result = KcpValidator.validate(manifest(List.of(skill, basePlaybook())), null);
+        assertTrue(result.warnings().stream()
+                .anyMatch(w -> w.contains("self-nullified") && w.contains("'tools'")));
+    }
+
+    @Test
+    void emptyDenyOnAPlaybookDrawsTheProhibitsNothingLint() {
+        Map<String, Object> pb = basePlaybook();
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("deny", Map.of());
+        pb.put("action_scope", scope);
+
+        var result = KcpValidator.validate(manifest(List.of(sletteagent(), pb)), null);
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("prohibits nothing")));
+    }
+}

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -95,7 +95,7 @@ VALID_INDEXING_SHORTHANDS = {"open", "read-only", "no-train", "none"}
 VALID_ACCESS_VALUES = {"public", "authenticated", "restricted"}
 VALID_SENSITIVITY_VALUES = {"public", "internal", "confidential", "restricted"}
 # human_in_the_loop is an object per spec §3.4 — no HITL enum, validation done inline
-KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31"}
+KNOWN_KCP_VERSIONS = {"0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31", "0.32"}
 # content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 VALID_CONTENT_MODALITIES = {"prose", "table", "code", "list", "diagram", "reference", "mixed"}
 VALID_DENSITY = {"sparse", "normal", "dense"}
@@ -213,6 +213,17 @@ def denies_token(scope, dimension: str, token: str) -> bool:
         return False
     values = getattr(scope.deny, dimension, None)
     return bool(values) and token in values
+
+
+def effective_denies_token(scopes, dimension: str, token: str) -> bool:
+    """§4.3b (v0.32, RFC-0030): does the UNION of deny lists deny ``token`` on
+    ``dimension``? The effective denylist for a playbook step is the union of the
+    playbook's own ``action_scope.deny`` and the used skill's — a match in either
+    denies, overriding any allow. Union is the only sound composition: adding a
+    source can only refuse more, never less (the scope-axis mirror of the §3.13
+    lowest-of rule). Mirrors ``effectiveDeniesToken`` in the TypeScript validator.
+    """
+    return any(denies_token(scope, dimension, token) for scope in scopes)
 
 
 def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) -> ValidationResult:
@@ -611,6 +622,28 @@ def validate(manifest: KnowledgeManifest, manifest_dir: Optional[str] = None) ->
                     f"{sctx}: 'authority_level' value '{step.authority_level}' is "
                     f"not in the declared 'authority_level_scale' (§3.13)"
                 )
+
+            # §4.3b (v0.32, RFC-0030): a step whose used unit's allowlist is entirely
+            # contained in the effective deny (playbook deny ∪ skill deny) for a
+            # dimension is self-nullified on that dimension — it reads enactable but
+            # cannot act. A warning: denying never widens anything, so the slip fails
+            # safe, but a dead step is worth naming.
+            if step.uses is not None:
+                target_scope = getattr(units_by_id.get(step.uses), "action_scope", None)
+                if target_scope is not None:
+                    for dim in ("tools", "paths", "capabilities"):
+                        allowed = getattr(target_scope, dim, None) or []
+                        if allowed and all(
+                            effective_denies_token(
+                                [unit.action_scope, target_scope], dim, token
+                            )
+                            for token in allowed
+                        ):
+                            warnings.append(
+                                f"{sctx}: every '{dim}' entry '{step.uses}' allows is "
+                                f"denied by the effective deny (playbook ∪ skill) — the "
+                                f"step is self-nullified on '{dim}' (§4.3b, RFC-0030)"
+                            )
 
             # A step whose unit can mutate but which declares no ceiling is bounded
             # only by the enacting agent's own grant — looser than intended (§4.3b).

--- a/parsers/python/pyproject.toml
+++ b/parsers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp"
-version = "0.31.0"
+version = "0.32.0"
 description = "Knowledge Context Protocol — reference parser and validator"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/parsers/python/tests/test_playbook_negative_scope.py
+++ b/parsers/python/tests/test_playbook_negative_scope.py
@@ -1,0 +1,160 @@
+"""§4.3b playbook-level prohibitions (v0.32, RFC-0030).
+
+Mirrors cli/src/playbook-negative-scope.test.ts. A ``kind: playbook`` unit's
+``action_scope.deny`` is a blanket prohibition over EVERY step — the one normative
+sub-object of the otherwise declarative playbook ``action_scope`` envelope. The
+effective denylist for a step is the UNION of the playbook's deny and the used
+skill's deny: a match in either denies, overriding any allow, fail-closed. Union is
+the only sound composition — adding a source can only refuse more (the scope-axis
+mirror of the §3.13 lowest-of).
+"""
+
+from kcp.parser import parse_dict
+from kcp.validator import validate, denies_token, effective_denies_token
+
+
+def _manifest(units, **extra):
+    raw = {
+        "project": "example",
+        "version": "1.0.0",
+        "kcp_version": "0.32",
+        "authority_level_scale": ["observe", "explain", "suggest", "prepare", "commit"],
+        "units": units,
+    }
+    raw.update(extra)
+    return parse_dict(raw)
+
+
+SLETTEAGENT = {
+    "id": "sletteagent",
+    "kind": "skill",
+    "path": "skills/sletteagent.md",
+    "intent": "How do I delete customer data compliantly?",
+    "scope": "project",
+    "audience": ["agent"],
+    "load_eligible": True,
+    "action_scope": {
+        "tools": ["delete", "read"],
+        "paths": ["customers/**", "legal/hold/2025/**"],
+        "deny": {"tools": ["transfer_ownership"]},
+    },
+}
+
+BASE_PLAYBOOK = {
+    "id": "pb-002-gdpr-sletting",
+    "kind": "playbook",
+    "path": "playbooks/gdpr-sletting.md",
+    "intent": "How is a GDPR Art.17 deletion request executed?",
+    "scope": "project",
+    "audience": ["agent"],
+    "load_eligible": True,
+    "authority_level": "commit",
+}
+
+
+def test_round_trips_deny_on_a_playbook():
+    m = _manifest([
+        SLETTEAGENT,
+        {
+            **BASE_PLAYBOOK,
+            "action_scope": {
+                "deny": {"paths": ["legal/hold/**"], "tools": ["transfer_ownership"]},
+            },
+            "steps": [{"id": "slett", "uses": "sletteagent", "authority_level": "commit"}],
+        },
+    ])
+    pb = next(u for u in m.units if u.id == "pb-002-gdpr-sletting")
+    assert pb.action_scope.deny.paths == ["legal/hold/**"]
+    assert pb.action_scope.deny.tools == ["transfer_ownership"]
+
+
+def test_effective_deny_is_the_union():
+    m = _manifest([
+        SLETTEAGENT,
+        {
+            **BASE_PLAYBOOK,
+            "action_scope": {"deny": {"paths": ["legal/hold/**"], "tools": ["set_billing"]}},
+            "steps": [{"id": "slett", "uses": "sletteagent", "authority_level": "commit"}],
+        },
+    ])
+    pb = next(u for u in m.units if u.id == "pb-002-gdpr-sletting")
+    skill = next(u for u in m.units if u.id == "sletteagent")
+    scopes = [pb.action_scope, skill.action_scope]
+
+    # playbook-only match
+    assert effective_denies_token(scopes, "paths", "legal/hold/**")
+    assert not denies_token(skill.action_scope, "paths", "legal/hold/**")
+
+    # skill-only match
+    assert effective_denies_token(scopes, "tools", "transfer_ownership")
+    assert not denies_token(pb.action_scope, "tools", "transfer_ownership")
+
+    # neither — allowed tokens pass through
+    assert not effective_denies_token(scopes, "tools", "read")
+
+
+def test_adding_a_deny_source_never_un_denies():
+    m = _manifest([SLETTEAGENT])
+    skill = m.units[0]
+    assert denies_token(skill.action_scope, "tools", "transfer_ownership")
+    # a playbook that denies nothing on this dimension cannot relax the skill's deny
+    assert effective_denies_token([None, skill.action_scope], "tools", "transfer_ownership")
+
+
+def test_warns_when_a_step_is_self_nullified():
+    m = _manifest([
+        SLETTEAGENT,
+        {
+            **BASE_PLAYBOOK,
+            "action_scope": {"deny": {"tools": ["delete", "read"]}},
+            "steps": [{"id": "slett", "uses": "sletteagent", "authority_level": "commit"}],
+        },
+    ])
+    result = validate(m)
+    assert any("self-nullified" in w and "'tools'" in w for w in result.warnings)
+    # paths dimension is not fully denied — no warning there
+    assert not any("self-nullified" in w and "'paths'" in w for w in result.warnings)
+
+
+def test_does_not_warn_when_the_deny_only_carves_a_hole():
+    m = _manifest([
+        SLETTEAGENT,
+        {
+            **BASE_PLAYBOOK,
+            "action_scope": {"deny": {"paths": ["legal/hold/**"]}},
+            "steps": [{"id": "slett", "uses": "sletteagent", "authority_level": "commit"}],
+        },
+    ])
+    result = validate(m)
+    assert not any("self-nullified" in w for w in result.warnings)
+
+
+def test_skill_deny_alone_can_self_nullify_a_step():
+    m = _manifest([
+        {
+            **SLETTEAGENT,
+            "action_scope": {
+                "tools": ["transfer_ownership"],
+                "deny": {"tools": ["transfer_ownership"]},
+            },
+        },
+        {
+            **BASE_PLAYBOOK,
+            "steps": [{"id": "slett", "uses": "sletteagent", "authority_level": "commit"}],
+        },
+    ])
+    result = validate(m)
+    assert any("self-nullified" in w and "'tools'" in w for w in result.warnings)
+
+
+def test_empty_deny_on_a_playbook_draws_the_prohibits_nothing_lint():
+    m = _manifest([
+        SLETTEAGENT,
+        {
+            **BASE_PLAYBOOK,
+            "action_scope": {"deny": {}},
+            "steps": [{"id": "slett", "uses": "sletteagent", "authority_level": "commit"}],
+        },
+    ])
+    result = validate(m)
+    assert any("prohibits nothing" in w for w in result.warnings)

--- a/schema/knowledge-schema.json
+++ b/schema/knowledge-schema.json
@@ -10,7 +10,7 @@
     "kcp_version": {
       "type": "string",
       "description": "Version of the KCP specification this manifest conforms to. RECOMMENDED. Current value: \"0.31\". Prior drafts \"0.1\" through \"0.14\", \"0.16\" through \"0.30\" are also accepted for backward compatibility (\"0.15\" was never a spec version).",
-      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31"]
+      "enum": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.16", "0.17", "0.18", "0.19", "0.20", "0.21", "0.22", "0.23", "0.24", "0.25", "0.26", "0.27", "0.28", "0.29", "0.30", "0.31", "0.32"]
     },
     "project": {
       "type": "string",
@@ -258,7 +258,7 @@
             },
             "deny": {
               "type": "object",
-              "description": "v0.31: explicit negative scope. Same {tools, paths, capabilities} shape as the allowlist, but every entry is a PROHIBITION — a token listed here is denied even when the allowlist grants it. Checked in addition to and overriding the allowlist, fail-closed. A deny that is a narrower glob of an allow is the intended carve-out; an exact-token collision with the allowlist neutralizes that allow. See SPEC.md §4.3a. PROPOSED (v0.32, RFC-0030): on a kind:playbook unit this sub-object is NORMATIVE (unlike the rest of the playbook envelope, which is declarative) — the effective denylist for a step is the union of the playbook's deny and the used skill's. See SPEC.md §4.3b.",
+              "description": "v0.31: explicit negative scope. Same {tools, paths, capabilities} shape as the allowlist, but every entry is a PROHIBITION — a token listed here is denied even when the allowlist grants it. Checked in addition to and overriding the allowlist, fail-closed. A deny that is a narrower glob of an allow is the intended carve-out; an exact-token collision with the allowlist neutralizes that allow. See SPEC.md §4.3a. v0.32 (RFC-0030): on a kind:playbook unit this sub-object is NORMATIVE (unlike the rest of the playbook envelope, which is declarative) — the effective denylist for a step is the union of the playbook's deny and the used skill's. See SPEC.md §4.3b.",
               "properties": {
                 "tools": {
                   "type": "array",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kcp/shared",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kcp/shared",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kcp/shared",
   "private": true,
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -163,6 +163,7 @@ const KNOWN_KCP_VERSIONS = new Set([
   "0.29",
   "0.30",
   "0.31",
+  "0.32",
 ]);
 // content_structure vocabularies (RFC-0016, v0.17). Unknown values warn but pass through.
 const VALID_CONTENT_MODALITIES = new Set([


### PR DESCRIPTION
Promotes RFC-0030 (#187) from PROPOSED to **v0.32** and bumps the current spec version across all four language implementations, mirroring the #186 release mechanics.

## Promote
- SPEC.md header 0.31 → 0.32; §4.3b subsection PROPOSED → v0.32
- knowledge.yaml `kcp_version: 0.32`, SPEC content_hash refreshed
- schema: version enum + deny description promoted to v0.32 wording

## Parser mirror (Python + Java ⇄ TS parity)
- `effective_denies_token` / `effectiveDeniesToken` — union adjudicator over `[playbook.action_scope, skill.action_scope]`
- self-nullified-step warning (used unit's allowlist fully contained in the effective deny on a dimension)
- bridge mappers unchanged — `deny` already round-trips

## Versions
0.32.0 across shared, cli, bridge {ts,py,java}, parsers {py,java}; RENDERER_VERSION, CLI banner, SCAFFOLD_KCP_VERSION.

## Tests
TS **204/204** · Python **236/236** · Java **221/221** — including 7 new playbook-negative-scope tests per language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)