### PR TITLE
fix: deny.paths matches structurally (glob) + §4.3a deny-finality errata (v0.32.1)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1853,9 +1853,20 @@ region and carve a prohibited hole inside it — allow `schema/**` while forbidd
 `schema/secrets/**` — without having to enumerate the complement. The override is the safe
 direction by construction: a denylist can only *narrow* what the allowlist already bounded, so it
 can never widen a skill's reach, and a checker that cannot resolve a match denies rather than
-permits. Where an implementation supports escalation (§3.14), an action a `deny` holds SHOULD
-raise a grant request rather than fail silently, exactly as an over-threshold `spend` does
-(§4.3a.1). Two validator lints surface authoring slips without weakening the gate: a `deny`
+permits. An action a `deny` holds is refused **finally**: what an implementation SHOULD raise
+is a notify-only *prohibited-attempt* event (§4.3b, RFC-0030) — never a grant request. No
+grant, approval, or escalation outcome may enact the action; unlike an over-threshold `spend`
+(§4.3a.1), which a granted request proceeds past, a `deny` is a boundary rather than a
+threshold, and is changed only by a superseding, reviewed, signed manifest version.
+
+**Path entries in `deny.paths` are patterns, and matching MUST be structural, not literal.**
+A requested path is denied when any `deny.paths` entry matches it under the allowlist's glob
+semantics: `**` matches across segment boundaries, `*` within a single segment, every other
+character literally. An implementation that compares path tokens for string equality only
+does not enforce this subsection — the `schema/secrets/**` carve-out above would never fire,
+because no requested path is ever the literal string `schema/secrets/**`.
+
+Two validator lints surface authoring slips without weakening the gate: a `deny`
 that lists nothing prohibits nothing, and a token that is **both** allowlisted and forbidden
 leaves an allow entry the `deny` neutralizes — the declaration reads wider than it enforces.
 

--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.32.0</version>
+    <version>0.32.1</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>no.cantara.kcp</groupId>
             <artifactId>kcp-parser</artifactId>
-            <version>0.32.0</version>
+            <version>0.32.1</version>
         </dependency>
 
         <!-- MCP Java SDK: core + Jackson 3 bundle -->

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.32.0"
+version = "0.32.1"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^13.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.32.0
+    `\nKCP Developer CLI — v0.32.1
 
 Usage: kcp <command> [options]
 

--- a/cli/src/deny-path-glob.test.ts
+++ b/cli/src/deny-path-glob.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { parseDict } from "../../shared/src/parser.js";
+import { validate, deniesToken, effectiveDeniesToken, pathGlobMatches } from "../../shared/src/validator.js";
+
+/**
+ * §4.3a (v0.32.1) — deny.paths entries are PATTERNS, matched structurally.
+ *
+ * Exact-string comparison never fires the `schema/secrets/**` carve-out the spec
+ * promises: no requested path is ever the literal string `schema/secrets/**`. These
+ * tests pin the glob semantics (`**` crosses segments, `*` stays within one) for
+ * deniesToken, for the union (effectiveDeniesToken), and for the §4.3b
+ * self-nullified-step lint — and pin that tools/capabilities stay exact-match.
+ */
+
+describe("pathGlobMatches", () => {
+  it("** crosses segment boundaries", () => {
+    expect(pathGlobMatches("legal/hold/**", "legal/hold/2025/case.pdf")).toBe(true);
+    expect(pathGlobMatches("legal/hold/**", "legal/hold/x")).toBe(true);
+    expect(pathGlobMatches("legal/hold/**", "legal/holdings/x")).toBe(false);
+  });
+  it("* stays within a single segment", () => {
+    expect(pathGlobMatches("customers/*/pii", "customers/acme/pii")).toBe(true);
+    expect(pathGlobMatches("customers/*/pii", "customers/a/b/pii")).toBe(false);
+  });
+  it("literal characters are escaped, not regex", () => {
+    expect(pathGlobMatches("a.b/c", "a.b/c")).toBe(true);
+    expect(pathGlobMatches("a.b/c", "axb/c")).toBe(false);
+  });
+});
+
+describe("§4.3a — deny.paths matches structurally", () => {
+  const scope = {
+    paths: ["schema/**"],
+    deny: { paths: ["schema/secrets/**", "legal/hold/**"], tools: ["delete"] },
+  };
+
+  it("a deny glob denies every path beneath it", () => {
+    expect(deniesToken(scope, "paths", "legal/hold/2025/case.pdf")).toBe(true);
+    expect(deniesToken(scope, "paths", "schema/secrets/key.pem")).toBe(true);
+  });
+
+  it("the carve-out fires: allowed region, prohibited hole", () => {
+    expect(deniesToken(scope, "paths", "schema/api.json")).toBe(false);
+    expect(deniesToken(scope, "paths", "schema/secrets/nested/key.pem")).toBe(true);
+  });
+
+  it("tools and capabilities remain exact tokens", () => {
+    expect(deniesToken(scope, "tools", "delete")).toBe(true);
+    expect(deniesToken(scope, "tools", "delete_all")).toBe(false);
+  });
+
+  it("the union (§4.3b) inherits glob matching from either source", () => {
+    const pbScope = { deny: { paths: ["legal/hold/**"] } };
+    const skillScope = { paths: ["customers/**"], deny: {} };
+    expect(effectiveDeniesToken([pbScope, skillScope], "paths", "legal/hold/2025/x")).toBe(true);
+    expect(effectiveDeniesToken([pbScope, skillScope], "paths", "customers/acme/x")).toBe(false);
+  });
+});
+
+describe("§4.3b — self-nullified lint sees glob containment", () => {
+  function manifest(skillPaths: string[], pbDenyPaths: string[]) {
+    return parseDict({
+      project: "example",
+      version: "1.0.0",
+      kcp_version: "0.32",
+      authority_level_scale: ["observe", "explain", "suggest", "prepare", "commit"],
+      units: [
+        {
+          id: "sletteagent", kind: "skill", path: "skills/s.md",
+          intent: "How do I delete compliantly?", scope: "project", audience: ["agent"],
+          load_eligible: true,
+          action_scope: { tools: ["read"], paths: skillPaths },
+        },
+        {
+          id: "pb", kind: "playbook", path: "playbooks/p.md",
+          intent: "How is deletion executed?", scope: "project", audience: ["agent"],
+          load_eligible: true, authority_level: "commit",
+          action_scope: { deny: { paths: pbDenyPaths } },
+          steps: [{ id: "slett", uses: "sletteagent", authority_level: "commit" }],
+        },
+      ],
+    });
+  }
+
+  it("warns when a broader deny glob covers every allowed path", () => {
+    const result = validate(manifest(["legal/hold/2025/**"], ["legal/hold/**"]));
+    expect(result.warnings.some((w) => w.includes("self-nullified") && w.includes("'paths'"))).toBe(true);
+  });
+
+  it("does not warn when the deny only carves a hole", () => {
+    const result = validate(manifest(["customers/**"], ["customers/pii/**"]));
+    expect(result.warnings.some((w) => w.includes("self-nullified"))).toBe(false);
+  });
+});

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.32.0";
+export const RENDERER_VERSION = "kcp-cli 0.32.1";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -69,7 +69,7 @@ units:
     triggers: [ spec, specification, fields, validation, conformance, yaml, format ]
     content_hash:
       algorithm: sha256
-      value: a7364fbde57b73995d71f1dd2f1b612a239511d350ad36bb17a4121cbfaab814
+      value: f9d6e4fb01c694ce433e5925c91c4a65dace0cbb762f45041d0ab1d048d96964
 
   - id: proposal
     path: PROPOSAL.md

--- a/parsers/java/pom.xml
+++ b/parsers/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-parser</artifactId>
-    <version>0.32.0</version>
+    <version>0.32.1</version>
     <packaging>jar</packaging>
 
     <name>KCP Reference Parser</name>

--- a/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
+++ b/parsers/java/src/main/java/no/cantara/kcp/KcpValidator.java
@@ -962,7 +962,39 @@ public class KcpValidator {
             case "capabilities" -> scope.deny().capabilities();
             default -> null;
         };
-        return values != null && values.contains(token);
+        if (values == null) return false;
+        // §4.3a (v0.32.1): paths are PATTERNS matched structurally — exact comparison
+        // would never fire the schema/secrets/** carve-out. tools/capabilities exact.
+        if ("paths".equals(dimension)) {
+            for (String p : values) {
+                if (p.equals(token) || pathGlobMatches(p, token)) return true;
+            }
+            return false;
+        }
+        return values.contains(token);
+    }
+
+    /**
+     * §4.3a (v0.32.1): glob matching for path patterns. {@code **} matches across
+     * segment boundaries, {@code *} within a single segment, every other character
+     * literally. Mirrors {@code pathGlobMatches} in the TypeScript validator.
+     */
+    public static boolean pathGlobMatches(String pattern, String path) {
+        StringBuilder re = new StringBuilder();
+        int i = 0;
+        while (i < pattern.length()) {
+            if (pattern.startsWith("**", i)) {
+                re.append(".*");
+                i += 2;
+            } else if (pattern.charAt(i) == '*') {
+                re.append("[^/]*");
+                i += 1;
+            } else {
+                re.append(java.util.regex.Pattern.quote(String.valueOf(pattern.charAt(i))));
+                i += 1;
+            }
+        }
+        return path.matches(re.toString());
     }
 
     /**

--- a/parsers/java/src/test/java/no/cantara/kcp/KcpDenyPathGlobTest.java
+++ b/parsers/java/src/test/java/no/cantara/kcp/KcpDenyPathGlobTest.java
@@ -1,0 +1,142 @@
+package no.cantara.kcp;
+
+import no.cantara.kcp.model.ActionScope;
+import no.cantara.kcp.model.KnowledgeManifest;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * §4.3a (v0.32.1) — deny.paths entries are PATTERNS, matched structurally.
+ *
+ * <p>Mirrors cli/src/deny-path-glob.test.ts and parsers/python/tests/test_deny_path_glob.py.
+ * Exact-string comparison never fires the {@code schema/secrets/**} carve-out the spec
+ * promises: no requested path is ever the literal string {@code schema/secrets/**}. Pins
+ * glob semantics for deniesToken, the union (effectiveDeniesToken), and the §4.3b
+ * self-nullified lint — and pins that tools/capabilities stay exact-match.
+ */
+class KcpDenyPathGlobTest {
+
+    @Test
+    void doubleStarCrossesSegments() {
+        assertTrue(KcpValidator.pathGlobMatches("legal/hold/**", "legal/hold/2025/case.pdf"));
+        assertTrue(KcpValidator.pathGlobMatches("legal/hold/**", "legal/hold/x"));
+        assertFalse(KcpValidator.pathGlobMatches("legal/hold/**", "legal/holdings/x"));
+    }
+
+    @Test
+    void singleStarStaysWithinSegment() {
+        assertTrue(KcpValidator.pathGlobMatches("customers/*/pii", "customers/acme/pii"));
+        assertFalse(KcpValidator.pathGlobMatches("customers/*/pii", "customers/a/b/pii"));
+    }
+
+    @Test
+    void literalsAreEscaped() {
+        assertTrue(KcpValidator.pathGlobMatches("a.b/c", "a.b/c"));
+        assertFalse(KcpValidator.pathGlobMatches("a.b/c", "axb/c"));
+    }
+
+    private static KnowledgeManifest scopedManifest() {
+        Map<String, Object> scope = new HashMap<>();
+        scope.put("paths", List.of("schema/**"));
+        scope.put("deny", Map.of(
+                "paths", List.of("schema/secrets/**", "legal/hold/**"),
+                "tools", List.of("delete")));
+        Map<String, Object> u = new HashMap<>();
+        u.put("id", "s");
+        u.put("kind", "skill");
+        u.put("path", "skills/s.md");
+        u.put("intent", "How do I rotate safely?");
+        u.put("scope", "project");
+        u.put("audience", List.of("agent"));
+        u.put("load_eligible", true);
+        u.put("action_scope", scope);
+        Map<String, Object> m = new HashMap<>();
+        m.put("project", "example");
+        m.put("version", "1.0.0");
+        m.put("kcp_version", "0.32");
+        m.put("units", List.of(u));
+        return KcpParser.fromMap(m);
+    }
+
+    @Test
+    void denyGlobDeniesPathsBeneathIt() {
+        ActionScope scope = scopedManifest().units().get(0).actionScope();
+        assertTrue(KcpValidator.deniesToken(scope, "paths", "legal/hold/2025/case.pdf"));
+        assertTrue(KcpValidator.deniesToken(scope, "paths", "schema/secrets/key.pem"));
+    }
+
+    @Test
+    void carveOutFires() {
+        ActionScope scope = scopedManifest().units().get(0).actionScope();
+        assertFalse(KcpValidator.deniesToken(scope, "paths", "schema/api.json"));
+        assertTrue(KcpValidator.deniesToken(scope, "paths", "schema/secrets/nested/key.pem"));
+    }
+
+    @Test
+    void toolsRemainExact() {
+        ActionScope scope = scopedManifest().units().get(0).actionScope();
+        assertTrue(KcpValidator.deniesToken(scope, "tools", "delete"));
+        assertFalse(KcpValidator.deniesToken(scope, "tools", "delete_all"));
+    }
+
+    private static KnowledgeManifest playbookManifest(List<String> skillPaths, List<String> pbDenyPaths) {
+        Map<String, Object> skill = new HashMap<>();
+        skill.put("id", "sletteagent");
+        skill.put("kind", "skill");
+        skill.put("path", "skills/s.md");
+        skill.put("intent", "How do I delete compliantly?");
+        skill.put("scope", "project");
+        skill.put("audience", List.of("agent"));
+        skill.put("load_eligible", true);
+        skill.put("action_scope", Map.of("tools", List.of("read"), "paths", skillPaths));
+        Map<String, Object> pb = new HashMap<>();
+        pb.put("id", "pb");
+        pb.put("kind", "playbook");
+        pb.put("path", "playbooks/p.md");
+        pb.put("intent", "How is deletion executed?");
+        pb.put("scope", "project");
+        pb.put("audience", List.of("agent"));
+        pb.put("load_eligible", true);
+        pb.put("authority_level", "commit");
+        pb.put("action_scope", Map.of("deny", Map.of("paths", pbDenyPaths)));
+        pb.put("steps", List.of(Map.of("id", "slett", "uses", "sletteagent", "authority_level", "commit")));
+        Map<String, Object> m = new HashMap<>();
+        m.put("project", "example");
+        m.put("version", "1.0.0");
+        m.put("kcp_version", "0.32");
+        m.put("authority_level_scale", List.of("observe", "explain", "suggest", "prepare", "commit"));
+        m.put("units", List.of(skill, pb));
+        return KcpParser.fromMap(m);
+    }
+
+    @Test
+    void unionInheritsGlob() {
+        KnowledgeManifest m = playbookManifest(List.of("customers/**"), List.of("legal/hold/**"));
+        ActionScope pbScope = m.units().get(1).actionScope();
+        ActionScope skillScope = m.units().get(0).actionScope();
+        assertTrue(KcpValidator.effectiveDeniesToken(
+                java.util.Arrays.asList(pbScope, skillScope), "paths", "legal/hold/2025/x"));
+        assertFalse(KcpValidator.effectiveDeniesToken(
+                java.util.Arrays.asList(pbScope, skillScope), "paths", "customers/acme/x"));
+    }
+
+    @Test
+    void selfNullifiedLintSeesGlobContainment() {
+        var result = KcpValidator.validate(
+                playbookManifest(List.of("legal/hold/2025/**"), List.of("legal/hold/**")), null);
+        assertTrue(result.warnings().stream()
+                .anyMatch(w -> w.contains("self-nullified") && w.contains("'paths'")));
+    }
+
+    @Test
+    void carveOutDoesNotSelfNullify() {
+        var result = KcpValidator.validate(
+                playbookManifest(List.of("customers/**"), List.of("customers/pii/**")), null);
+        assertFalse(result.warnings().stream().anyMatch(w -> w.contains("self-nullified")));
+    }
+}

--- a/parsers/python/kcp/validator.py
+++ b/parsers/python/kcp/validator.py
@@ -203,16 +203,43 @@ def _find_step_cycle(steps) -> Optional[list]:
     return None
 
 
+def path_glob_matches(pattern: str, path: str) -> bool:
+    """§4.3a (v0.32.1): glob matching for path patterns. ``**`` matches across
+    segment boundaries, ``*`` within a single segment, every other character
+    literally. Mirrors ``pathGlobMatches`` in the TypeScript validator.
+    """
+    out = []
+    i = 0
+    while i < len(pattern):
+        if pattern.startswith("**", i):
+            out.append(".*")
+            i += 2
+        elif pattern[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        else:
+            out.append(re.escape(pattern[i]))
+            i += 1
+    return re.fullmatch("".join(out), path) is not None
+
+
 def denies_token(scope, dimension: str, token: str) -> bool:
     """§4.3a (v0.31, RFC-0029): does a skill's ``action_scope.deny`` deny ``token`` on
     ``dimension``? Fail-closed override — a deny entry denies the token even when the
-    allowlist grants it. Exact-string match. Mirrors ``deniesToken`` in the TypeScript
-    validator, so a runtime enforcer and the validator's overlap lint share one rule.
+    allowlist grants it. Mirrors ``deniesToken`` in the TypeScript validator, so a
+    runtime enforcer and the validator's overlap lint share one rule. Since v0.32.1,
+    ``paths`` entries are PATTERNS matched structurally (§4.3a) — exact comparison
+    would never fire the ``schema/secrets/**`` carve-out; tools/capabilities remain
+    exact tokens.
     """
     if scope is None or getattr(scope, "deny", None) is None:
         return False
     values = getattr(scope.deny, dimension, None)
-    return bool(values) and token in values
+    if not values:
+        return False
+    if dimension == "paths":
+        return any(p == token or path_glob_matches(p, token) for p in values)
+    return token in values
 
 
 def effective_denies_token(scopes, dimension: str, token: str) -> bool:

--- a/parsers/python/pyproject.toml
+++ b/parsers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp"
-version = "0.32.0"
+version = "0.32.1"
 description = "Knowledge Context Protocol — reference parser and validator"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/parsers/python/tests/test_deny_path_glob.py
+++ b/parsers/python/tests/test_deny_path_glob.py
@@ -1,0 +1,105 @@
+"""§4.3a (v0.32.1) — deny.paths entries are PATTERNS, matched structurally.
+
+Mirrors cli/src/deny-path-glob.test.ts. Exact-string comparison never fires the
+``schema/secrets/**`` carve-out the spec promises: no requested path is ever the
+literal string ``schema/secrets/**``. Pins glob semantics for ``denies_token``,
+the union (``effective_denies_token``), and the §4.3b self-nullified lint — and
+pins that tools/capabilities stay exact-match.
+"""
+
+from kcp.parser import parse_dict
+from kcp.validator import (
+    validate,
+    denies_token,
+    effective_denies_token,
+    path_glob_matches,
+)
+
+
+def test_double_star_crosses_segments():
+    assert path_glob_matches("legal/hold/**", "legal/hold/2025/case.pdf")
+    assert path_glob_matches("legal/hold/**", "legal/hold/x")
+    assert not path_glob_matches("legal/hold/**", "legal/holdings/x")
+
+
+def test_single_star_stays_within_segment():
+    assert path_glob_matches("customers/*/pii", "customers/acme/pii")
+    assert not path_glob_matches("customers/*/pii", "customers/a/b/pii")
+
+
+def test_literals_are_escaped():
+    assert path_glob_matches("a.b/c", "a.b/c")
+    assert not path_glob_matches("a.b/c", "axb/c")
+
+
+class _Scope:
+    def __init__(self, **kw):
+        self.tools = kw.get("tools")
+        self.paths = kw.get("paths")
+        self.capabilities = kw.get("capabilities")
+        self.deny = kw.get("deny")
+        self.spend = None
+
+
+def _scope():
+    return _Scope(
+        paths=["schema/**"],
+        deny=_Scope(paths=["schema/secrets/**", "legal/hold/**"], tools=["delete"]),
+    )
+
+
+def test_deny_glob_denies_paths_beneath_it():
+    assert denies_token(_scope(), "paths", "legal/hold/2025/case.pdf")
+    assert denies_token(_scope(), "paths", "schema/secrets/key.pem")
+
+
+def test_carve_out_fires():
+    assert not denies_token(_scope(), "paths", "schema/api.json")
+    assert denies_token(_scope(), "paths", "schema/secrets/nested/key.pem")
+
+
+def test_tools_remain_exact():
+    assert denies_token(_scope(), "tools", "delete")
+    assert not denies_token(_scope(), "tools", "delete_all")
+
+
+def test_union_inherits_glob():
+    pb = _Scope(deny=_Scope(paths=["legal/hold/**"]))
+    skill = _Scope(paths=["customers/**"])
+    assert effective_denies_token([pb, skill], "paths", "legal/hold/2025/x")
+    assert not effective_denies_token([pb, skill], "paths", "customers/acme/x")
+
+
+def _manifest(skill_paths, pb_deny_paths):
+    return parse_dict({
+        "project": "example",
+        "version": "1.0.0",
+        "kcp_version": "0.32",
+        "authority_level_scale": ["observe", "explain", "suggest", "prepare", "commit"],
+        "units": [
+            {
+                "id": "sletteagent", "kind": "skill", "path": "skills/s.md",
+                "intent": "How do I delete compliantly?", "scope": "project",
+                "audience": ["agent"], "load_eligible": True,
+                "action_scope": {"tools": ["read"], "paths": skill_paths},
+            },
+            {
+                "id": "pb", "kind": "playbook", "path": "playbooks/p.md",
+                "intent": "How is deletion executed?", "scope": "project",
+                "audience": ["agent"], "load_eligible": True,
+                "authority_level": "commit",
+                "action_scope": {"deny": {"paths": pb_deny_paths}},
+                "steps": [{"id": "slett", "uses": "sletteagent", "authority_level": "commit"}],
+            },
+        ],
+    })
+
+
+def test_self_nullified_lint_sees_glob_containment():
+    result = validate(_manifest(["legal/hold/2025/**"], ["legal/hold/**"]))
+    assert any("self-nullified" in w and "'paths'" in w for w in result.warnings)
+
+
+def test_carve_out_does_not_self_nullify():
+    result = validate(_manifest(["customers/**"], ["customers/pii/**"]))
+    assert not any("self-nullified" in w for w in result.warnings)

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kcp/shared",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kcp/shared",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kcp/shared",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.32.1",
   "type": "module",
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/shared/src/validator.ts
+++ b/shared/src/validator.ts
@@ -230,12 +230,43 @@ function supersededCycleIds(successor: Map<string, string>): string[] {
  * validator's overlap lint share one adjudication rule, the way §4.3a.1 `spend` and
  * the allowlist share one fail-closed default.
  */
+/**
+ * §4.3a (v0.32.1): glob matching for path patterns. `**` matches across segment
+ * boundaries, `*` within a single segment, every other character literally.
+ * Path entries in `deny.paths` (and the allowlist) are patterns, not literals —
+ * exact-string comparison would never fire the `schema/secrets/**` carve-out the
+ * spec promises, leaving the paths dimension of a deny unenforced.
+ */
+export function pathGlobMatches(pattern: string, path: string): boolean {
+  let re = "";
+  for (let i = 0; i < pattern.length; ) {
+    if (pattern.startsWith("**", i)) {
+      re += ".*";
+      i += 2;
+    } else if (pattern[i] === "*") {
+      re += "[^/]*";
+      i += 1;
+    } else {
+      re += pattern[i]!.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+      i += 1;
+    }
+  }
+  return new RegExp("^" + re + "$").test(path);
+}
+
 export function deniesToken(
   scope: ActionScope | undefined,
   dimension: "tools" | "paths" | "capabilities",
   token: string
 ): boolean {
-  return scope?.deny?.[dimension]?.includes(token) ?? false;
+  const entries = scope?.deny?.[dimension];
+  if (!entries) return false;
+  // paths are patterns (§4.3a): a requested path is denied when any deny entry
+  // glob-matches it. tools/capabilities remain exact tokens.
+  if (dimension === "paths") {
+    return entries.some((p) => p === token || pathGlobMatches(p, token));
+  }
+  return entries.includes(token);
 }
 
 /**


### PR DESCRIPTION
Two §4.3a corrections surfaced by post-release review of RFC-0029/0030:

## 1. deny.paths was unenforced (exact-string match)
All three validators adjudicated `deny.paths` with `includes(token)` — the `schema/secrets/**` carve-out the spec promises could never fire (no requested path is ever the literal string `schema/secrets/**`). **The paths dimension of every deny was unenforced.**

Fix: `pathGlobMatches` (`**` crosses segments, `*` within one, literals escaped), applied deny-first in `deniesToken` for the paths dimension only; tools/capabilities remain exact tokens. The §4.3b union and self-nullified lint inherit glob behaviour. SPEC.md §4.3a now states matching MUST be structural, with the failure mode named.

## 2. §4.3a still said deny-hits raise grant requests
The v0.31 sentence ("SHOULD raise a grant request … exactly as an over-threshold `spend` does") survived in §4.3a while RFC-0030's finality rule landed in §4.3b — a skill-deny reader got the forbidden reading. Replaced in place with the finality rule: notify-only prohibited-attempt event, never a grant request; boundary, not threshold.

## Tests
TS **213** · Python **245** · Java **230** — 9 new glob cases per language (`**` crossing, `*` segment-bound, literal escaping, carve-out fires / does not self-nullify, union inherits glob, tools stay exact). Versions → 0.32.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)