### PR TITLE
spec(§17): prohibited_attempt_events — normative shape + canonical wire fixture

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4604,7 +4604,7 @@ Promoted from [RFC-0017](./RFC-0017-Observability-Hooks.md). A local-first obser
 convention: bridges and renderers MAY record events to a well-known SQLite database at
 `~/.kcp/usage.db` (WAL mode required; writes MUST never block serving). `kcp stats` reads it.
 
-Four tables:
+Five tables:
 
 - **`usage_events`** — bridge query traffic and the runtime-depth procedural lifecycle. Columns:
   `timestamp`, `event_type` (`search` | `get_unit` | `inject` | `skill_selected` |
@@ -4629,6 +4629,25 @@ Four tables:
   `resolved_by` (populated on `granted`/`denied` rows only), `correlation_id`. Same local-only,
   consent-gated transmission rule as `usage_events` — grant requests can contain sensitive
   internal-escalation context.
+- **`prohibited_attempt_events`** (v0.32.1, RFC-0030) — the notify-only audit trail for
+  deny-hits (§4.3a negative scope, §4.3b playbook prohibitions). **One row per refused
+  attempt** — unlike `grant_request_events` there is no state machine to transition, because a
+  deny-hit is final by definition: no row in this table may ever correlate with an enactment
+  of the refused action. Columns: `timestamp`, `unit_id` (the `kind: skill` whose enactment
+  was refused), `playbook_id` (NULL unless refused inside a `kind: playbook` context),
+  `step_id` (NULL likewise), `dimension` (`tools` | `paths` | `capabilities`), `token` (the
+  requested tool, path, or capability), `matched_pattern` (the `deny` entry that matched —
+  differs from `token` when a path glob fires), `binding_source` (`skill` | `playbook` |
+  `both`), `acknowledged_by` (NULL until a human acknowledges the notification; a populated
+  value records **acknowledgement only** and MUST NOT enact — see §4.3b *deny finality*),
+  `correlation_id`. Rows sharing (`unit_id`, `dimension`, `token`) are the governance signal
+  this table exists for: a climbing repeat count means misconfiguration, compromise, or
+  probing. Same local-only, consent-gated transmission rule as `usage_events`.
+
+  Where transmission **is** consented (e.g. a dashboard `/trace` sink), the wire format is a
+  JSON object with `kind: "prohibited_attempt"` and the same field names — the canonical
+  example lives at `conformance/fixtures/observability/prohibited-attempt.json`, and an
+  emitter and an ingester are conformant when that fixture round-trips between them.
 
 Wall-clock timestamps live here, not in rendered artifacts — observability wants time;
 render determinism (§16.1) forbids it. A repository whose quarantine count moves from 0 to 3

--- a/cli/src/prohibited-attempt-fixture.test.ts
+++ b/cli/src/prohibited-attempt-fixture.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * §17 `prohibited_attempt_events` (v0.32.1, RFC-0030) — pins the canonical wire-format
+ * fixture that emitters (e.g. a governance adjudicator) and ingesters (e.g. a dashboard
+ * /trace sink) test against. An emitter and an ingester are conformant when this fixture
+ * round-trips between them; this test keeps the fixture from drifting away from §17.
+ */
+
+const FIXTURE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../conformance/fixtures/observability/prohibited-attempt.json"
+);
+
+describe("§17 prohibited_attempt wire-format fixture", () => {
+  const ev = JSON.parse(readFileSync(FIXTURE, "utf8"));
+
+  it("declares the kind discriminator", () => {
+    expect(ev.kind).toBe("prohibited_attempt");
+  });
+
+  it("carries every §17 column, with the nullable ones present-but-null when unset", () => {
+    for (const key of [
+      "timestamp", "unit_id", "playbook_id", "step_id", "dimension",
+      "token", "matched_pattern", "binding_source", "acknowledged_by", "correlation_id",
+    ]) {
+      expect(Object.hasOwn(ev, key), `missing §17 field '${key}'`).toBe(true);
+    }
+  });
+
+  it("constrains the enumerated fields", () => {
+    expect(["tools", "paths", "capabilities"]).toContain(ev.dimension);
+    expect(["skill", "playbook", "both"]).toContain(ev.binding_source);
+  });
+
+  it("shows the glob case the table exists to record: token ≠ matched_pattern", () => {
+    expect(ev.dimension).toBe("paths");
+    expect(ev.token).not.toBe(ev.matched_pattern);
+  });
+
+  it("is notify-only in its example: nothing acknowledged, nothing enacted", () => {
+    expect(ev.acknowledged_by).toBeNull();
+  });
+});

--- a/conformance/fixtures/observability/prohibited-attempt.json
+++ b/conformance/fixtures/observability/prohibited-attempt.json
@@ -1,0 +1,13 @@
+{
+  "kind": "prohibited_attempt",
+  "timestamp": "2026-07-31T06:15:04Z",
+  "unit_id": "sletteagent",
+  "playbook_id": "pb-002-gdpr-sletting",
+  "step_id": "slett",
+  "dimension": "paths",
+  "token": "legal/hold/2025/case-4711/evidence.pdf",
+  "matched_pattern": "legal/hold/**",
+  "binding_source": "playbook",
+  "acknowledged_by": null,
+  "correlation_id": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+}

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -69,7 +69,7 @@ units:
     triggers: [ spec, specification, fields, validation, conformance, yaml, format ]
     content_hash:
       algorithm: sha256
-      value: f9d6e4fb01c694ce433e5925c91c4a65dace0cbb762f45041d0ab1d048d96964
+      value: fb6d90240e0446f4064a11159a033cd534f618b71bf702f53c5e0351c29028d5
 
   - id: proposal
     path: PROPOSAL.md


### PR DESCRIPTION
RFC-0030 made the prohibited-attempt event normative behaviour but gave it no schema — five consumers independently invented five shapes, name-aligned but schema-unaligned, with nothing proving an emitter's event ingests into a sink.

- **SPEC.md §17**: fifth table, `prohibited_attempt_events` — one row per refused attempt (no state machine; a deny-hit is final by definition, and no row may ever correlate with an enactment). `matched_pattern` ≠ `token` captures the v0.32.1 path-glob case; `binding_source` (`skill|playbook|both`); `acknowledged_by` records acknowledgement only and MUST NOT enact. Repeats on (`unit_id`,`dimension`,`token`) are the probing signal.
- **`conformance/fixtures/observability/prohibited-attempt.json`**: canonical wire object (`kind: "prohibited_attempt"`). An emitter and an ingester are conformant when it round-trips between them — kcp-harness (emit) and kcp-dashboard (ingest) align next.
- Fixture pinned by `cli/src/prohibited-attempt-fixture.test.ts`.

TS 218 green. No version bump — ships with the v0.32.1 tag alongside #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)