### PR TITLE
chore(release): v0.32.2 — dependency currency

### DIFF
--- a/bridge/java/pom.xml
+++ b/bridge/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.cantara.kcp</groupId>
     <artifactId>kcp-mcp</artifactId>
-    <version>0.32.1</version>
+    <version>0.32.2</version>
     <packaging>jar</packaging>
 
     <name>KCP MCP Bridge (Java)</name>

--- a/bridge/python/pyproject.toml
+++ b/bridge/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcp-mcp"
-version = "0.32.1"
+version = "0.32.2"
 description = "KCP MCP bridge — expose knowledge.yaml units as MCP resources"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bridge/typescript/package-lock.json
+++ b/bridge/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kcp-mcp",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kcp-mcp",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.25.3",

--- a/bridge/typescript/package.json
+++ b/bridge/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcp-mcp",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "MCP bridge for the Knowledge Context Protocol \u2014 exposes knowledge.yaml units as MCP resources",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cantara.no/kcp",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^13.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cantara.no/kcp",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Developer CLI for the Knowledge Context Protocol — init, validate, query, render, sign, and usage stats for knowledge.yaml manifests",
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 
 function printUsage(): void {
   process.stderr.write(
-    `\nKCP Developer CLI — v0.32.1
+    `\nKCP Developer CLI — v0.32.2
 
 Usage: kcp <command> [options]
 

--- a/cli/src/render.ts
+++ b/cli/src/render.ts
@@ -35,7 +35,7 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
-export const RENDERER_VERSION = "kcp-cli 0.32.1";
+export const RENDERER_VERSION = "kcp-cli 0.32.2";
 export const RENDER_SCHEMA = "kcp-render-schema-0.2";
 export const DEFAULT_KEYS_PATH = join(homedir(), ".kcp", "trusted-keys.yaml");
 

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kcp/shared",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kcp/shared",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kcp/shared",
   "private": true,
-  "version": "0.32.1",
+  "version": "0.32.2",
   "type": "module",
   "dependencies": {
     "js-yaml": "^4.1.0"


### PR DESCRIPTION
Patch. SPEC.md is unchanged since v0.32.1; nothing in the protocol moved.

  #191  js-yaml -> 4.3.1 (cli, bridge/typescript, shared)
  #192  @types/better-sqlite3 -> v9 (cli)

cli/package.json               0.32.1 -> 0.32.2
bridge/typescript/package.json 0.32.1 -> 0.32.2
bridge/python/pyproject.toml   0.32.1 -> 0.32.2
bridge/java/pom.xml            0.32.1 -> 0.32.2
shared/package.json            0.32.1 -> 0.32.2

## Test plan
- [x] cli: `npm run build && vitest run` — 218/218 passing (includes version-drift/consistency guards)
- [x] bridge/typescript: `tsc && vitest run` — 266/266 passing
- [x] bridge/java: `mvn test` (after `mvn install` on parsers/java) — 175/175 passing, BUILD SUCCESS
- [x] bridge/python: pyproject.toml parses clean; unaffected by either dependency bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)