### PR TITLE
kcp-mcp: add --transport streamable-http with bearer auth

### DIFF
--- a/bridge/python/kcp_mcp/__main__.py
+++ b/bridge/python/kcp_mcp/__main__.py
@@ -2,8 +2,9 @@
 KCP MCP Bridge CLI entry point.
 
 Usage:
-    kcp-mcp [path/to/knowledge.yaml] [--agent-only] [--transport stdio|http] [--port N]
-            [--sub-manifests path ...]
+    kcp-mcp [path/to/knowledge.yaml] [--agent-only]
+            [--transport stdio|http|streamable-http] [--port N]
+            [--bearer-token-env VAR] [--sub-manifests path ...]
 """
 import argparse
 import asyncio
@@ -31,15 +32,33 @@ def main() -> None:
     )
     parser.add_argument(
         "--transport",
-        choices=["stdio", "http"],
+        choices=["stdio", "http", "streamable-http"],
         default="stdio",
-        help="MCP transport (default: stdio)",
+        help=(
+            "MCP transport (default: stdio). 'http' is the legacy SSE transport "
+            "(/sse + /messages/, unauthenticated) kept for backward compatibility. "
+            "'streamable-http' is the current MCP HTTP transport (single /mcp "
+            "endpoint, stateless, supports --bearer-token-env) and is the one to "
+            "use for a real deployment."
+        ),
     )
     parser.add_argument(
         "--port",
         type=int,
         default=8000,
         help="Port for HTTP transport (default: 8000)",
+    )
+    parser.add_argument(
+        "--bearer-token-env",
+        default=None,
+        metavar="VAR",
+        help=(
+            "Name of an environment variable holding a static bearer token. "
+            "Only meaningful with --transport streamable-http (the legacy 'http' "
+            "SSE transport has no auth hook and ignores this). If unset, the "
+            "streamable-http endpoint is unauthenticated — a warning is printed, "
+            "it is not silently allowed."
+        ),
     )
     parser.add_argument(
         "--no-warnings",
@@ -92,7 +111,9 @@ def main() -> None:
         sys.stderr.write(f"Error: {e}\n")
         sys.exit(1)
 
-    if args.transport == "http":
+    if args.transport == "streamable-http":
+        _run_streamable_http(server, args.port, args.bearer_token_env)
+    elif args.transport == "http":
         _run_http(server, args.port)
     else:
         _run_stdio(server)
@@ -136,6 +157,74 @@ def _run_http(server, port: int) -> None:
     )
 
     sys.stderr.write(f"[kcp-mcp] HTTP/SSE transport on http://localhost:{port}/sse\n")
+    uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+
+
+def _run_streamable_http(server, port: int, bearer_token_env: str | None) -> None:
+    """Serve over the current MCP HTTP transport: one stateless POST endpoint at
+    /mcp, matching the transport every other MCP server in the Sunstone/Mynder
+    stack already speaks (e.g. Sunstone Atlas Canvas's own /mcp). Unlike --transport
+    http (legacy SSE, no auth hook at all), this transport supports a static bearer
+    token — the only auth model this bridge needs, matching Canvas's own
+    SUNSTONE_CANVAS_ACCESS_TOKEN convention rather than inventing OAuth machinery
+    this bridge has no use for.
+    """
+    import hmac
+    import os
+
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+    from starlette.types import Receive, Scope, Send
+    import uvicorn
+
+    bearer_token = os.environ.get(bearer_token_env) if bearer_token_env else None
+    if bearer_token_env and not bearer_token:
+        sys.stderr.write(
+            f"Error: --bearer-token-env {bearer_token_env} was given but that "
+            "environment variable is unset or empty\n"
+        )
+        sys.exit(1)
+
+    session_manager = StreamableHTTPSessionManager(app=server, stateless=True)
+
+    class _BearerGatedMcpApp:
+        """A real ASGI-callable class, not a plain function — Starlette's Route
+        wraps bare async functions as request/response endpoints (single Request
+        arg) rather than passing them the raw ASGI (scope, receive, send) triple,
+        which silently breaks a streaming protocol like this one. The official
+        mcp.server.fastmcp.server.StreamableHTTPASGIApp is the same three-line
+        shape for the same reason — mirrored here instead of imported so this
+        bridge doesn't pull in the whole fastmcp package for one wrapper class.
+        """
+
+        async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+            if bearer_token:
+                request = Request(scope, receive)
+                auth = request.headers.get("authorization", "")
+                presented = auth[7:] if auth.startswith("Bearer ") else ""
+                # hmac.compare_digest, not ==: constant-time, same discipline as
+                # Canvas's own crypto.timingSafeEqual bearer check (server.mjs).
+                if not presented or not hmac.compare_digest(presented, bearer_token):
+                    response = JSONResponse({"error": "unauthorized"}, status_code=401)
+                    await response(scope, receive, send)
+                    return
+            await session_manager.handle_request(scope, receive, send)
+
+    starlette_app = Starlette(
+        routes=[Route("/mcp", endpoint=_BearerGatedMcpApp(), methods=["POST", "GET"])],
+        lifespan=lambda app: session_manager.run(),
+    )
+
+    if not bearer_token:
+        sys.stderr.write(
+            "[kcp-mcp] WARNING: no --bearer-token-env set — this endpoint is "
+            "UNAUTHENTICATED. Fine for localhost testing, not for a real "
+            "deployment.\n"
+        )
+    sys.stderr.write(f"[kcp-mcp] Streamable HTTP transport on http://localhost:{port}/mcp\n")
     uvicorn.run(starlette_app, host="0.0.0.0", port=port)
 
 


### PR DESCRIPTION
## Summary
- Existing `--transport http` is the legacy SSE transport (`/sse` + `/messages/`) with **no auth hook at all**. Fine for local dev, not safe to expose.
- Adds `--transport streamable-http` as a third option (existing `stdio`/`http` untouched, full backward compat for existing adopters — see ADOPTERS.md) — the current MCP HTTP transport (single stateless POST endpoint at `/mcp`), matching what Sunstone Atlas Canvas and the rest of the Mynder/Sunstone stack already speak.
- Adds `--bearer-token-env NAME`: reads a static token from the named env var, gates `/mcp` with a constant-time comparison (`hmac.compare_digest`). Matches Canvas's own `SUNSTONE_CANVAS_ACCESS_TOKEN` static-bearer model rather than adding OAuth machinery this bridge doesn't need. Running without a token still works (useful for local testing) but prints an explicit warning rather than silently allowing it.

## Test plan
- [x] `pytest tests/` — 170/170 pass, unchanged (only `__main__.py` touched, no server/mapper logic changed)
- [x] Live-verified with a real MCP Streamable HTTP client against the actual Mynder regulatory corpus (204 units, GDPR fragments): no token → 401, wrong token → 401, correct token → real `initialize` response
- [x] Full content round trip: `search_knowledge` → `get_unit` correctly resolved both a GDPR Art. 28 query and a breach-notification query to the right source over the new transport